### PR TITLE
Better CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,8 @@ jobs:
     steps:
       - name: Build-checkout
         uses: actions/checkout@v3
-      - name: Build-toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: armv7-unknown-linux-gnueabihf
-          override: true
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
       - name: Build-cargo-cross
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "html2md",
  "log",
  "ngrammatic",
+ "openssl",
  "redis",
  "reqwest",
  "serde",
@@ -969,6 +970,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +987,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.7"
 edition = "2021"
 
 [package.metadata.cross.target.armv7-unknown-linux-gnueabihf]
-image = "rustembedded/cross:armv7-unknown-linux-gnueabihf-0.1.16"
+image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:latest"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3.25"
 html2md = "0.2.13"
 log = "0.4"
 ngrammatic = "0.4.0"
+openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.11.12", features = ["blocking", "rustls-tls"] }
 redis = "0.22.1"
 serde = "1.0"


### PR DESCRIPTION
Changes to the CI:
- Using `rustup` instead of the GH action 
- Updating the image used by Cross
- Making Openssl a hard dependency to get Cross compilation working