### PR TITLE
[ANN-23]/Support for user accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ version = "1.2.5"
 dependencies = [
  "chrono",
  "diesel",
+ "diesel_migrations",
  "env_logger",
  "futures",
  "html2md",
@@ -334,6 +335,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ae22beef5e9d6fab9225ddb073c1c6c1a7a6ded5019d5da11d1e5c5adc34e2"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
 ]
 
 [[package]]
@@ -1009,6 +1021,27 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "migrations_internals"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8ff27a350511de30cdabb77147501c36ef02e0451d957abea2f30caffb2b58"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "mime"
@@ -2217,6 +2250,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mai"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "chrono",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "1.2.5"
 edition = "2021"
 
 [package.metadata.cross.target.armv7-unknown-linux-gnueabihf]
+pre-build = [
+  "dpkg --add-architecture armhf && apt-get update && apt-get install --assume-yes libpq-dev:armhf",
+]
 image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:latest"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mai"
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 
 [package.metadata.cross.target.armv7-unknown-linux-gnueabihf]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:latest"
 [dependencies]
 chrono = "0.4"
 diesel = { version = "2.0.0", features = ["postgres"] }
+diesel_migrations = "2.0.0"
 env_logger = "0.10"
 futures = "0.3.25"
 html2md = "0.2.14"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@
 
 ##### Commands
 
-###### \/help
+###### /help
 
 - Shows a list of commands that Annie-mai supports!
+
+###### /ping
+
+- Shows a list of commands that Annie-mai supports!
+
+###### /register
+
+- Register an association with your anilist account!
+  - `arg`: `anilist`: A string for your Anilist username
+- Annie-mai doesn't use this information for anything right now, but this will enable a more personalized experience in the future, which is in the works right now!
 
 ###### /anime
 

--- a/migrations/2023-01-22-200806_create_users/down.sql
+++ b/migrations/2023-01-22-200806_create_users/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE users

--- a/migrations/2023-01-22-200806_create_users/up.sql
+++ b/migrations/2023-01-22-200806_create_users/up.sql
@@ -1,7 +1,6 @@
 -- Your SQL goes here
 CREATE TABLE users (
-  discord_id BIGINT PRIMARY KEY,
-  anilist_id BIGINT NOT NULL,
-  anilist_username TEXT NOT NULL,
-  UNIQUE(discord_id, anilist_id)
-)
+    discord_id bigint PRIMARY KEY,
+    anilist_id bigint NOT NULL,
+    anilist_username text NOT NULL,
+    UNIQUE (discord_id, anilist_id))

--- a/migrations/2023-01-22-200806_create_users/up.sql
+++ b/migrations/2023-01-22-200806_create_users/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+CREATE TABLE users (
+  discord_id BIGINT PRIMARY KEY,
+  anilist_id BIGINT NOT NULL,
+  anilist_username TEXT NOT NULL,
+  UNIQUE(discord_id, anilist_id)
+)

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -41,8 +41,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
     let arg = interaction.data.options[0].resolved.to_owned().unwrap();
 
     info!(
-        "Got command 'anime' by user '{}' with args: {:#?}",
-        user.name, arg
+        "Got command 'anime' by user '{}' with args: {arg:#?}",
+        user.name,
     );
 
     let response = task::spawn_blocking(move || fetcher(Type::Anime, arg))

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -24,6 +24,7 @@ pub async fn run(ctx: &Context, interaction: &ApplicationCommandInteraction) {
                             .field("/anime", "Search for an anime", false)
                             .field("/manga", "Search for a manga", false)
                             .field("/songs", "Lookup an anime's songs", false)
+                            .field("/register", "Tell me your Anilist username", false)
                             .field("/help", "Show this message", false)
                             .field("/ping", "Check if I'm reachable", false)
                             .footer(|f| f.text("Annie Mai"))

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -41,8 +41,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
     let arg = interaction.data.options[0].resolved.to_owned().unwrap();
 
     info!(
-        "Got command 'manga' by user '{}' with args: {:#?}",
-        user.name, arg
+        "Got command 'manga' by user '{}' with args: {arg:#?}",
+        user.name
     );
 
     let response = task::spawn_blocking(move || fetcher(Type::Manga, arg))

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod anime;
 pub mod help;
 pub mod manga;
 pub mod ping;
+pub mod register;
 pub mod songs;

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -33,8 +33,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
     let arg = interaction.data.options[0].resolved.to_owned().unwrap();
 
     info!(
-        "Got command 'register' by user '{}' with args: {:#?}",
-        user.name, arg
+        "Got command 'register' by user '{}' with args: {arg:#?}",
+        user.name
     );
 
     let anilist_username = match arg {

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -1,0 +1,94 @@
+use crate::{models::db::user::User, utils::database};
+
+use serenity::{
+    builder::CreateApplicationCommand,
+    client::Context,
+    model::{
+        application::interaction::{
+            application_command::ApplicationCommandInteraction, InteractionResponseType,
+        },
+        prelude::{
+            command::CommandOptionType,
+            interaction::application_command::CommandDataOptionValue::String as StringArg,
+        },
+    },
+};
+use tokio::task;
+use tracing::info;
+
+pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
+    command
+        .name("register")
+        .description("Command to register your user's Anilist account")
+        .create_option(|option| {
+            option
+                .name("anilist")
+                .description("Anilist username")
+                .kind(CommandOptionType::String)
+        })
+}
+
+pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction) {
+    let user = &interaction.user;
+    let arg = interaction.data.options[0].resolved.to_owned().unwrap();
+
+    info!(
+        "Got command 'register' by user '{}' with args: {:#?}",
+        user.name, arg
+    );
+
+    let anilist_username = match arg {
+        StringArg(name) => name,
+        _ => panic!("Invalid argument type"),
+    };
+
+    let response_message = register_new_user(anilist_username.to_owned(), user).await;
+
+    let _register = interaction
+        .create_interaction_response(&ctx.http, |response| {
+            { response.kind(InteractionResponseType::ChannelMessageWithSource) }
+                .interaction_response_data(|m| m.content(response_message))
+        })
+        .await;
+}
+
+async fn register_new_user(anilist_username: String, user: &serenity::model::user::User) -> String {
+    let username = anilist_username.to_string();
+    let anilist_id =
+        task::spawn_blocking(move || User::get_anilist_id_from_username(username.as_ref()))
+            .await
+            .unwrap();
+
+    let connection = &mut database::establish_connection();
+
+    let response = match User::get_user_by_discord_id(user.id.into(), connection) {
+        Some(db_user) => {
+            info!(
+                "User with details: id: {}, anilist_id: {}, anilist_username: {} already exists",
+                db_user.discord_id, db_user.anilist_id, db_user.anilist_username
+            );
+            format!(
+                "Hello {}, This account is already associated with the Anilist user {}.",
+                user.name, db_user.anilist_username
+            )
+        }
+        None => {
+            User::create_user(
+                user.id.into(),
+                anilist_id,
+                anilist_username.to_owned(),
+                connection,
+            );
+
+            info!(
+                "Created user with details: id: {}, anilist_id: {}, anilist_username: {}",
+                user.id, anilist_id, anilist_username
+            );
+            format!(
+                "Hello {}, I have linked your Anilist account {} to your user.",
+                user.name, anilist_username
+            )
+        }
+    };
+    response
+}

--- a/src/commands/register/mod.rs
+++ b/src/commands/register/mod.rs
@@ -1,0 +1,1 @@
+pub mod command;

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -41,8 +41,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
     let arg = interaction.data.options[0].resolved.to_owned().unwrap();
 
     info!(
-        "Got command 'songs' by user '{}' with args: {:#?}",
-        user.name, arg
+        "Got command 'songs' by user '{}' with args: {arg:#?}",
+        user.name
     );
 
     let response = task::spawn_blocking(move || SongFetcher(arg))

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,7 @@ impl EventHandler for Handler {
                 "songs" => commands::songs::command::run(&ctx, &mut command).await,
                 "manga" => commands::manga::command::run(&ctx, &mut command).await,
                 "anime" => commands::anime::command::run(&ctx, &mut command).await,
+                "register" => commands::register::command::run(&ctx, &mut command).await,
                 _ => {
                     let msg = command
                         .channel_id
@@ -112,6 +113,9 @@ impl EventHandler for Handler {
                 .create_application_command(|command| commands::songs::command::register(command))
                 .create_application_command(|command| commands::manga::command::register(command))
                 .create_application_command(|command| commands::anime::command::register(command))
+                .create_application_command(|command| {
+                    commands::register::command::register(command)
+                })
         })
         .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,8 @@ async fn main() {
         },
     ));
 
+    let _connection = &mut utils::database::establish_connection();
+
     let framework = StandardFramework::new()
         .configure(|c| c.prefix("!"))
         .before(before)

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ use serenity::{
     utils::parse_emoji,
 };
 
-use utils::statics::{DISCORD_TOKEN, ENV, SENTRY_DSN};
+use utils::{
+    database::run_migration,
+    statics::{DISCORD_TOKEN, ENV, SENTRY_DSN},
+};
 
 #[hook]
 #[instrument]
@@ -148,7 +151,8 @@ async fn main() {
         },
     ));
 
-    let _connection = &mut utils::database::establish_connection();
+    let connection = &mut utils::database::establish_connection();
+    run_migration(connection);
 
     let framework = StandardFramework::new()
         .configure(|c| c.prefix("!"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,7 @@ use utils::statics::{DISCORD_TOKEN, ENV, SENTRY_DSN};
 #[hook]
 #[instrument]
 async fn before(_: &Context, msg: &Message, command_name: &str) -> bool {
-    info!(
-        "Got command '{}' by user '{}'",
-        command_name, msg.author.name
-    );
+    info!("Got command '{command_name}' by user '{}'", msg.author.name);
     true
 }
 
@@ -38,8 +35,8 @@ async fn before(_: &Context, msg: &Message, command_name: &str) -> bool {
 #[instrument]
 async fn after(_: &Context, _msg: &Message, command_name: &str, command_result: CommandResult) {
     match command_result {
-        Ok(()) => info!("Processed command '{}'", command_name),
-        Err(why) => info!("Command '{}' returned error {:?}", command_name, why),
+        Ok(()) => info!("Processed command '{command_name}'"),
+        Err(why) => info!("Command '{command_name}' returned error {:?}", why),
     }
 }
 
@@ -47,7 +44,7 @@ async fn after(_: &Context, _msg: &Message, command_name: &str, command_result: 
 #[hook]
 #[instrument]
 async fn unknown_command(ctx: &Context, msg: &Message, unknown_command_name: &str) {
-    info!("Could not find command named '{}'", unknown_command_name);
+    info!("Could not find command named '{unknown_command_name}'");
     let reaction = parse_emoji("<:wtf:953730408158228570>").unwrap();
     let _ = msg.react(ctx, reaction).await;
 }
@@ -98,7 +95,7 @@ impl EventHandler for Handler {
                         .await;
                     if let Err(why) = msg {
                         println!("Error sending message: {:?}", why);
-                        info!("Cannot respond to slash command: {}", why);
+                        info!("Cannot respond to slash command: {why}");
                     }
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod models;
+mod schema;
 mod utils;
 
 use std::env;

--- a/src/models/anilist_anime.rs
+++ b/src/models/anilist_anime.rs
@@ -96,7 +96,7 @@ impl Anime {
 
     pub fn transform_duration(&self) -> String {
         match &self.duration {
-            Some(duration) => format!("{} mins", duration),
+            Some(duration) => format!("{duration} mins"),
             None => EMPTY_STR.to_string(),
         }
     }
@@ -257,6 +257,6 @@ impl Transformers for Anime {
 
     fn transform_mal_id(&self) -> Option<String> {
         self.id_mal
-            .map(|mal_id| format!("https://www.myanimelist.net/anime/{}", mal_id))
+            .map(|mal_id| format!("https://www.myanimelist.net/anime/{mal_id}"))
     }
 }

--- a/src/models/anilist_manga.rs
+++ b/src/models/anilist_manga.rs
@@ -85,7 +85,7 @@ impl Manga {
         if is_end_date_available {
             let end_date = self.end_date.as_ref().unwrap();
             let formatted_end_date = get_formatted_date_string(end_date);
-            format!("{} - {}", formatted_start_date, formatted_end_date)
+            format!("{formatted_start_date} - {formatted_end_date}")
         } else {
             formatted_start_date
         }

--- a/src/models/db/mod.rs
+++ b/src/models/db/mod.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -1,8 +1,54 @@
 use diesel::prelude::*;
+use serde_json::json;
+use tracing::info;
+
+use crate::utils::requests::anilist::send_request;
 
 #[derive(Queryable)]
 pub struct User {
     pub discord_id: i64,
     pub anilist_id: i64,
     pub anilist_username: String,
+}
+
+impl User {
+    pub fn get_user_by_discord_id(user_discord_id: i64, conn: &mut PgConnection) -> Option<User> {
+        use crate::schema::users::dsl::*;
+        users
+            .filter(discord_id.eq(user_discord_id))
+            .first::<User>(conn)
+            .ok()
+    }
+
+    pub fn create_user(
+        discord_id: i64,
+        anilist_id: i64,
+        anilist_username: String,
+        conn: &mut PgConnection,
+    ) -> User {
+        use crate::schema::users;
+        diesel::insert_into(users::table)
+            .values((
+                users::discord_id.eq(discord_id),
+                users::anilist_id.eq(anilist_id),
+                users::anilist_username.eq(anilist_username),
+            ))
+            .get_result(conn)
+            .expect("Error saving new user")
+    }
+
+    pub fn get_anilist_id_from_username(username: &str) -> i64 {
+        let body = json!({
+            "query": "query ($username: String) { User (name: $username) { id } }",
+            "variables": {
+                "username": username
+            }
+        });
+        info!("Body: {:#?}", body);
+        let result: String = send_request(body);
+        info!("Result: {:#?}", result);
+        let result: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        result["data"]["User"]["id"].as_i64().unwrap()
+    }
 }

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -1,0 +1,8 @@
+use diesel::prelude::*;
+
+#[derive(Queryable)]
+pub struct User {
+    pub discord_id: i64,
+    pub anilist_id: i64,
+    pub anilist_username: String,
+}

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -53,7 +53,7 @@ pub trait Response {
                 fetch_response.data.unwrap().media
             }
             Argument::Search(value) => {
-                let cache_key = format!("{}:{}", media_type.as_ref(), value);
+                let cache_key = format!("{}:{value}", media_type.as_ref());
                 let fetched_data = match check_cache(&cache_key) {
                     Ok(value) => {
                         info!("Cache hit for {:#?}", cache_key);

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod anilist_anime;
 pub mod anilist_common;
 pub mod anilist_manga;
+pub mod db;
 pub mod fetcher;
 pub mod id_response;
 pub mod mal_response;

--- a/src/models/transformers.rs
+++ b/src/models/transformers.rs
@@ -122,7 +122,7 @@ pub trait Transformers {
 
     fn transform_score(&self) -> String {
         match self.get_average_score() {
-            Some(score) => format!("{}/100", score),
+            Some(score) => format!("{score}/100"),
             None => EMPTY_STR.to_string(),
         }
     }
@@ -142,8 +142,7 @@ pub trait Transformers {
 
         match url {
             Some(link) => format!(
-                "{}\n\n**{}**",
-                description,
+                "{description}\n\n**{}**",
                 linker("MyAnimeList".to_string(), link),
             ),
             None => description,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,9 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    users (discord_id) {
+        discord_id -> Int8,
+        anilist_id -> Int8,
+        anilist_username -> Text,
+    }
+}

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -1,0 +1,9 @@
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use std::env;
+
+pub fn establish_connection() -> PgConnection {
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    PgConnection::establish(&database_url)
+        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
+}

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -7,5 +7,5 @@ use std::env;
 pub fn establish_connection() -> PgConnection {
     let database_url = env::var(DATABASE_URL).expect("DATABASE_URL must be set");
     PgConnection::establish(&database_url)
-        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
+        .unwrap_or_else(|_| panic!("Error connecting to {database_url}"))
 }

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -1,9 +1,11 @@
+use crate::utils::statics::DATABASE_URL;
+
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use std::env;
 
 pub fn establish_connection() -> PgConnection {
-    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url = env::var(DATABASE_URL).expect("DATABASE_URL must be set");
     PgConnection::establish(&database_url)
         .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -2,10 +2,18 @@ use crate::utils::statics::DATABASE_URL;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use std::env;
+use tracing::info;
 
 pub fn establish_connection() -> PgConnection {
     let database_url = env::var(DATABASE_URL).expect("DATABASE_URL must be set");
     PgConnection::establish(&database_url)
         .unwrap_or_else(|_| panic!("Error connecting to {database_url}"))
+}
+
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+pub fn run_migration(conn: &mut PgConnection) {
+    info!("Running database migrations ... ");
+    conn.run_pending_migrations(MIGRATIONS).unwrap();
 }

--- a/src/utils/formatter.rs
+++ b/src/utils/formatter.rs
@@ -1,24 +1,24 @@
 use titlecase::titlecase as imported_titlecase;
 
 pub fn bold(input: String) -> String {
-    format!("**{}**", input)
+    format!("**{input}**")
 }
 
 pub fn italics(input: String) -> String {
-    format!("*{}*", input)
+    format!("*{input}*")
 }
 
 pub fn code(input: String) -> String {
-    format!("`{}`", input)
+    format!("`{input}`")
 }
 
 #[allow(dead_code)]
 pub fn strike(input: String) -> String {
-    format!("~~{}~~", input)
+    format!("~~{input}~~")
 }
 
 pub fn linker(text: String, link: String) -> String {
-    format!("[{}]({})", text, link)
+    format!("[{text}]({link})")
 }
 
 pub fn remove_underscores_and_titlecase(text: &str) -> String {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod database;
 pub mod fetch_by_arguments;
 pub mod formatter;
 pub mod fuzzy;

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -9,7 +9,7 @@ fn get_redis_client() -> RedisResult<Connection> {
     let password = env::var(REDIS_PASSWORD).expect("Expected a redis password in the environment");
     let host = env::var(REDIS_HOST).expect("Expected a redis host in the environment");
 
-    let redis_connection_string = format!("redis://{}:{}@{}", user_name, password, host);
+    let redis_connection_string = format!("redis://{user_name}:{password}@{host}");
 
     let client = redis::Client::open(redis_connection_string)?;
     let connection = client.get_connection()?;

--- a/src/utils/requests/my_anime_list.rs
+++ b/src/utils/requests/my_anime_list.rs
@@ -10,13 +10,11 @@ const FIELDS_TO_FETCH: [&str; 3] = ["id", "opening_themes", "ending_themes"];
 
 fn build_mal_url(mal_id: u32) -> String {
     let mal_url = format!(
-        "{}/anime/{}?fields={}",
-        MY_ANIME_LIST_BASE,
-        mal_id,
+        "{MY_ANIME_LIST_BASE}/anime/{mal_id}?fields={}",
         FIELDS_TO_FETCH.join(",")
     );
 
-    info!("Sent MAL Request to URL: {:#?}", mal_url);
+    info!("Sent MAL Request to URL: {mal_url:#?}");
     mal_url
 }
 

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -33,7 +33,7 @@ pub fn get_song_url(
 ) -> Option<String> {
     // TODO: Clean up nested Matches
     // If cached response if found, return it
-    let cache_key = format!("{}:{:#?}:{}", romaji_name, kana_name, artist_name);
+    let cache_key = format!("{romaji_name}:{kana_name:#?}:{artist_name}");
     match check_cache(&cache_key) {
         Ok(value) => {
             info!("Cache hit for {:#?}", cache_key);
@@ -93,7 +93,7 @@ fn send_search_request(
     let spotify = get_spotify_client();
     spotify.request_token().unwrap();
     spotify.search(
-        format!("track:{} artist:{}", song_name, artist_name).as_str(),
+        format!("track:{song_name} artist:{artist_name}").as_str(),
         SearchType::Track,
         Some(Market::Country(Country::UnitedStates)),
         None,

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -12,5 +12,6 @@ pub const REDIS_HOST: &str = "REDIS_HOST";
 pub const SPOTIFY_CLIENT_ID: &str = "SPOTIFY_CLIENT_ID";
 pub const SPOTIFY_CLIENT_SECRET: &str = "SPOTIFY_CLIENT_SECRET";
 pub const MAL_CLIENT_ID: &str = "MAL_CLIENT_ID";
+pub const DATABASE_URL: &str = "DATABASE_URL";
 
 // TODO: Add reaction => <:sadge:868530481208123403>


### PR DESCRIPTION
Adds initial support for Anilist user accounts.
Users can now "register" their Anilist usernames using `\register` and anni-mai will remember the discord_user -> anilist_user association.
This will be used in a future release to support more personalized experiences.