### PR TITLE
[ANN-48]: Fixes register command panicking if an option is not selected

### DIFF
--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -25,6 +25,7 @@ pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicatio
                 .name("anilist")
                 .description("Anilist username")
                 .kind(CommandOptionType::String)
+                .required(true)
         })
 }
 


### PR DESCRIPTION
Make anilist a required subcommand of register