### PR TITLE
[ANNIE-54]/[major] Bump Version -- New Release

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -25,6 +25,8 @@ jobs:
         run: rustup update stable && rustup default stable
       - name: Cache
         uses: Swatinem/rust-cache@v2.2.0
+        with:
+            cache-on-failure: "true"
       - name: Build-cargo-cross
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,6 +25,8 @@ jobs:
         run: rustup update stable && rustup default stable
       - name: Cache
         uses: Swatinem/rust-cache@v2.2.0
+        with:
+            cache-on-failure: "true"
       - name: Build-cargo-cross
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -24,6 +24,9 @@ jobs:
         run: rustup update stable && rustup default stable
       - name: Cache
         uses: Swatinem/rust-cache@v2.2.0
+        with:
+            cache-on-failure: "true"
+            shared-key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install crates
         run: cargo install clippy-sarif sarif-fmt
       - name: Run Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "1.2.6"
+version = "1.3.0"
 dependencies = [
  "chrono",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "1.2.6"
+version = "1.3.0"
 edition = "2021"
 license = "GPL-3.0-or-later"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 - Register an association with your anilist account!
   - `arg`: `anilist`: A string for your Anilist username
-- Annie Mei doesn't use this information for anything right now, but this will enable a more personalized experience in the future, which is in the works right now!
+- This is used to show guild members' Anilist scores!
 
 ###### /anime
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,6 @@ async fn main() {
     let token = env::var(DISCORD_TOKEN).expect("Expected a token in the environment");
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::DIRECT_MESSAGES
-        | GatewayIntents::MESSAGE_CONTENT
         | GatewayIntents::GUILD_PRESENCES
         | GatewayIntents::GUILDS;
 


### PR DESCRIPTION
- Bump up major version
- Also removed the `MESSAGE_CONTENT` gateway as it was unused
- Also using a different key for the Cache Action
- This will be the last merge made directly to `main` for a version release
- Subsequent releases will use the `annie-mai-release-<version>` branches 