### PR TITLE
[ANNIE-76]/ID lookup doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 - Arguments
   - _search_: The Anilist ID or a search term lookup
+  - **Note**: If you want to look up something that has a numeric name, you can wrap the search term in quotes! => `"86"`
 
 ###### `search`
 

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -4,15 +4,19 @@ use crate::models::{
     transformers::Transformers,
 };
 use serenity::model::prelude::interaction::application_command::CommandDataOptionValue::{
-    self, Integer, String,
+    self, String,
 };
 use tracing::info;
 
 fn return_argument(arg: CommandDataOptionValue) -> Argument {
-    match arg {
-        Integer(id) => Argument::Id(id as u32),
-        String(name) => Argument::Search(name),
+    let val = match arg {
+        String(name) => name,
         _ => panic!("Invalid argument type"),
+    };
+
+    match val.parse::<u32>() {
+        Ok(id) => Argument::Id(id),
+        Err(_) => Argument::Search(val),
     }
 }
 

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -9,7 +9,7 @@ use serenity::model::prelude::interaction::application_command::CommandDataOptio
 use tracing::info;
 
 fn strip_quotes(string: &str) -> String {
-    string.replace("\"", "")
+    string.replace('"', "")
 }
 
 fn return_argument(arg: CommandDataOptionValue) -> Argument {

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -4,19 +4,26 @@ use crate::models::{
     transformers::Transformers,
 };
 use serenity::model::prelude::interaction::application_command::CommandDataOptionValue::{
-    self, String,
+    self, String as StringData,
 };
 use tracing::info;
 
+fn strip_quotes(string: &str) -> String {
+    string.replace("\"", "")
+}
+
 fn return_argument(arg: CommandDataOptionValue) -> Argument {
     let val = match arg {
-        String(name) => name,
+        StringData(name) => name,
         _ => panic!("Invalid argument type"),
     };
 
     match val.parse::<u32>() {
         Ok(id) => Argument::Id(id),
-        Err(_) => Argument::Search(val),
+        Err(_) => {
+            let val = strip_quotes(&val);
+            Argument::Search(val)
+        }
     }
 }
 


### PR DESCRIPTION
- /anime with a number would not launch an ID lookup, now it does
- To specify a numeric ID users can wrap the number in quotes -> "3"