### PR TITLE
[ANNIE-86] Upgrade to Serenity v0.12

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -6,9 +6,5 @@ exclude_patterns = ["migrations/**"]
 name = "rust"
 enabled = true
 
-  [analyzers.meta]
-  msrv = "stable"
-
-[[transformers]]
-name = "rustfmt"
-enabled = true
+[analyzers.meta]
+msrv = "stable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,22 +285,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
-]
-
-[[package]]
-name = "async-tungstenite"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b71b31561643aa8e7df3effe284fa83ab1a840e52294c5f4bd7bfd8b2becbb"
-dependencies = [
- "futures-io",
- "futures-util",
- "log",
- "pin-project-lite",
- "tokio",
- "tokio-rustls 0.23.4",
- "tungstenite",
- "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -345,18 +338,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -404,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +409,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -495,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "command_attr"
-version = "0.4.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b787d19b9806dd4c9c34b2b4147d1a61d6120d93ee289521ab9b0294d198e4"
+checksum = "8208103c5e25a091226dfa8d61d08d0561cc14f31b25691811ba37d4ec9b157b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,6 +605,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +677,12 @@ dependencies = [
  "parking_lot_core",
  "serde",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "debugid"
@@ -871,6 +910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,23 +1137,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "h2"
-version = "0.3.27"
+name = "glob"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1221,17 +1256,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1249,7 +1273,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1267,30 +1291,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1299,9 +1299,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1313,32 +1313,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "rustls 0.23.35",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -1349,7 +1336,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1363,14 +1350,14 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1813,6 +1800,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,15 +2165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,6 +2340,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,7 +2381,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
- "ring 0.17.14",
+ "ring",
  "rustc-hash",
  "rustls 0.23.35",
  "rustls-pki-types",
@@ -2540,84 +2544,48 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "mime_guess",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -2626,18 +2594,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -2648,7 +2616,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower",
@@ -2662,21 +2630,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -2685,7 +2638,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2695,7 +2648,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6b781f7f2b4afac99cd6cb9506a427a128601cd3206a59156fad095c7280e1"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "getrandom 0.3.4",
  "log",
@@ -2779,26 +2732,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.9"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.14",
- "rustls-webpki 0.101.7",
- "sct",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2810,7 +2753,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.8",
  "subtle",
@@ -2827,15 +2770,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2877,12 +2811,13 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2892,9 +2827,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -2934,13 +2869,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "secrecy"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -2984,6 +2919,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "sentry"
@@ -3117,22 +3056,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cow"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3182,44 +3120,46 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.7"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7a89cef23483fc9d4caf2df41e6d3928e18aada84c56abd237439d929622c6"
+checksum = "9bde37f42765dfdc34e2a039e0c84afbf79a3101c1941763b0beb816c2f17541"
 dependencies = [
+ "arrayvec",
  "async-trait",
- "async-tungstenite",
- "base64 0.21.7",
- "bitflags 1.3.2",
+ "base64",
+ "bitflags 2.10.0",
  "bytes",
- "cfg-if",
  "chrono",
  "command_attr",
  "dashmap",
  "flate2",
  "futures",
  "levenshtein",
- "mime",
  "mime_guess",
  "parking_lot",
  "percent-encoding",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
+ "rustc-hash",
+ "secrecy",
  "serde",
- "serde-value",
+ "serde_cow",
  "serde_json",
  "static_assertions",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "typemap_rev",
+ "typesize",
  "url",
  "uwl",
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3281,6 +3221,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3328,12 +3283,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3439,12 +3388,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3483,6 +3426,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -3662,22 +3611,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.20.9",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3689,6 +3628,22 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.35",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3752,7 +3707,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3768,7 +3723,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body 1.0.1",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3851,6 +3806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,36 +3819,65 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
- "http 0.2.12",
+ "data-encoding",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.20.9",
- "sha-1",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
  "thiserror 1.0.69",
  "url",
  "utf-8",
- "webpki",
 ]
 
 [[package]]
 name = "typemap_rev"
-version = "0.1.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5b74f0a24b5454580a79abb6994393b09adf0ab8070f15827cb666255de155"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typesize"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da66c62c5b7017a2787e77373c03e6a5aafde77a73bff1ff96e91cd2e128179"
+dependencies = [
+ "chrono",
+ "dashmap",
+ "hashbrown 0.14.5",
+ "mini-moka",
+ "parking_lot",
+ "secrecy",
+ "serde_json",
+ "time",
+ "typesize-derive",
+ "url",
+]
+
+[[package]]
+name = "typesize-derive"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536b6812192bda8551cfa0e52524e328c6a951b48e66529ee4522d6c721243d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
 
 [[package]]
 name = "uname"
@@ -3924,12 +3914,6 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -3940,7 +3924,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "cookie",
  "cookie_store",
  "log",
@@ -3960,7 +3944,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "der",
  "log",
  "native-tls",
@@ -3977,7 +3961,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http 1.4.0",
  "httparse",
  "log",
@@ -4185,16 +4169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4202,21 +4176,6 @@ checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -4348,15 +4307,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4395,21 +4345,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4453,12 +4388,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4477,12 +4406,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4498,12 +4421,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4537,12 +4454,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4558,12 +4469,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4585,12 +4490,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4609,12 +4508,6 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -4630,16 +4523,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rspotify = { version = "0.15.3", default-features = false, features = [
 sentry = { version = "0.46.0", features = ["tracing"] }
 serde = "1.0.228"
 serde_json = "1.0.148"
-serenity = "0.11.7"
+serenity = "0.12"
 strum = { version = "0.27.2", features = ["derive"] }
 titlecase = "3.6.0"
 tokio = { version = "1.49.0", features = ["full"] }

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -36,12 +36,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let user = &interaction.user;
     let arg = interaction.data.options[0].value.clone();
-    let json_arg = json!(arg);
+    let arg_str = format!("{:?}", arg);
 
     sentry::configure_scope(|scope| {
         let mut context = std::collections::BTreeMap::new();
         context.insert("Command".to_string(), "Anime".into());
-        context.insert("Arg".to_string(), json_arg);
+        context.insert("Arg".to_string(), json!(arg_str));
         scope.set_context("Anime", sentry::protocol::Context::Other(context));
         scope.set_user(Some(sentry::User {
             username: Some(user.name.to_string()),

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -9,35 +9,33 @@ use crate::{
 
 use serde_json::json;
 use serenity::{
-    builder::CreateApplicationCommand,
+    all::{CommandInteraction, CreateCommandOption, EditInteractionResponse},
+    builder::CreateCommand,
     client::Context,
-    model::{
-        application::interaction::application_command::ApplicationCommandInteraction,
-        prelude::command::CommandOptionType,
-    },
+    model::application::CommandOptionType,
 };
 
 use tokio::task;
 use tracing::info;
 
-pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
-    command
-        .name("anime")
+pub fn register() -> CreateCommand {
+    CreateCommand::new("anime")
         .description("Fetches the details for an anime")
-        .create_option(|option| {
-            option
-                .name("search")
-                .description("Anilist ID or Search term")
-                .kind(CommandOptionType::String)
-                .required(true)
-        })
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::String,
+                "search",
+                "Anilist ID or Search term",
+            )
+            .required(true),
+        )
 }
 
-pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction) {
+pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _ = interaction.defer(&ctx.http).await;
 
     let user = &interaction.user;
-    let arg = interaction.data.options[0].resolved.to_owned().unwrap();
+    let arg = interaction.data.options[0].value.clone();
     let json_arg = json!(arg);
 
     sentry::configure_scope(|scope| {
@@ -62,11 +60,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
 
     let _anime_response = match response {
         None => {
-            interaction
-                .edit_original_interaction_response(&ctx.http, |response| {
-                    response.content(NOT_FOUND_ANIME)
-                })
-                .await
+            let builder = EditInteractionResponse::new().content(NOT_FOUND_ANIME);
+            interaction.edit_response(&ctx.http, builder).await
         }
         Some(anime_response) => {
             // TODO: Refactor this to fetcher.rs
@@ -94,11 +89,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
 
             let anime_response_embed = anime_response.transform_response_embed(guild_members_data);
 
-            interaction
-                .edit_original_interaction_response(&ctx.http, |response| {
-                    response.set_embed(anime_response_embed)
-                })
-                .await
+            let builder = EditInteractionResponse::new().embed(anime_response_embed);
+            interaction.edit_response(&ctx.http, builder).await
         }
     };
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,16 +1,17 @@
 use serenity::{
-    builder::CreateApplicationCommand,
-    model::application::interaction::{
-        application_command::ApplicationCommandInteraction, InteractionResponseType,
+    all::{
+        CommandInteraction, CreateAttachment, CreateEmbed, CreateEmbedFooter,
+        CreateInteractionResponse, CreateInteractionResponseMessage,
     },
+    builder::CreateCommand,
     prelude::*,
 };
 
-pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
-    command.name("help").description("Shows how to use the bot")
+pub fn register() -> CreateCommand {
+    CreateCommand::new("help").description("Shows how to use the bot")
 }
 
-pub async fn run(ctx: &Context, interaction: &ApplicationCommandInteraction) {
+pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
     let user = &interaction.user;
 
     sentry::configure_scope(|scope| {
@@ -23,26 +24,26 @@ pub async fn run(ctx: &Context, interaction: &ApplicationCommandInteraction) {
         }));
     });
 
-    let _help = interaction
-        .create_interaction_response(&ctx.http, |response| {
-            { response.kind(InteractionResponseType::ChannelMessageWithSource) }
-                .interaction_response_data(|m| {
-                    m.embed(|e| {
-                        e.colour(0x00ff00)
-                            .title(format!("Hello there {}!", user.mention()))
-                            .description("Use these commands to interact with Annie Mei!")
-                            .field("/anime", "Search for an anime", false)
-                            .field("/manga", "Search for a manga", false)
-                            .field("/songs", "Lookup an anime's songs", false)
-                            .field("/register", "Tell me your Anilist username", false)
-                            .field("/help", "Show this message", false)
-                            .field("/ping", "Check if I'm reachable", false)
-                            .footer(|f| f.text("Annie Mei"))
-                            .timestamp(chrono::Utc::now())
-                            .thumbnail("attachment://mei.jpg")
-                    })
-                    .add_file("./mei.jpg")
-                })
-        })
-        .await;
+    let embed = CreateEmbed::new()
+        .colour(0x00ff00)
+        .title(format!("Hello there {}!", user.mention()))
+        .description("Use these commands to interact with Annie Mei!")
+        .field("/anime", "Search for an anime", false)
+        .field("/manga", "Search for a manga", false)
+        .field("/songs", "Lookup an anime's songs", false)
+        .field("/register", "Tell me your Anilist username", false)
+        .field("/help", "Show this message", false)
+        .field("/ping", "Check if I'm reachable", false)
+        .footer(CreateEmbedFooter::new("Annie Mei"))
+        .timestamp(chrono::Utc::now())
+        .thumbnail("attachment://mei.jpg");
+
+    let attachment = CreateAttachment::path("./mei.jpg").await.unwrap();
+
+    let response_message = CreateInteractionResponseMessage::new()
+        .embed(embed)
+        .add_file(attachment);
+    let response = CreateInteractionResponse::Message(response_message);
+
+    let _ = interaction.create_response(&ctx.http, response).await;
 }

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -9,35 +9,33 @@ use crate::{
 
 use serde_json::json;
 use serenity::{
-    builder::CreateApplicationCommand,
+    all::{CommandInteraction, CreateCommandOption, EditInteractionResponse},
+    builder::CreateCommand,
     client::Context,
-    model::{
-        application::interaction::application_command::ApplicationCommandInteraction,
-        prelude::command::CommandOptionType,
-    },
+    model::application::CommandOptionType,
 };
 
 use tokio::task;
 use tracing::info;
 
-pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
-    command
-        .name("manga")
+pub fn register() -> CreateCommand {
+    CreateCommand::new("manga")
         .description("Fetches the details for a manga")
-        .create_option(|option| {
-            option
-                .name("search")
-                .description("Anilist ID or Search term")
-                .kind(CommandOptionType::String)
-                .required(true)
-        })
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::String,
+                "search",
+                "Anilist ID or Search term",
+            )
+            .required(true),
+        )
 }
 
-pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction) {
+pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _ = interaction.defer(&ctx.http).await;
 
     let user = &interaction.user;
-    let arg = interaction.data.options[0].resolved.to_owned().unwrap();
+    let arg = interaction.data.options[0].value.clone();
     let json_arg = json!(arg);
 
     sentry::configure_scope(|scope| {
@@ -62,11 +60,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
 
     let _manga_response = match response {
         None => {
-            interaction
-                .edit_original_interaction_response(&ctx.http, |response| {
-                    response.content(NOT_FOUND_MANGA)
-                })
-                .await
+            let builder = EditInteractionResponse::new().content(NOT_FOUND_MANGA);
+            interaction.edit_response(&ctx.http, builder).await
         }
         Some(manga_response) => {
             // TODO: Refactor this to fetcher.rs
@@ -94,11 +89,8 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
 
             let manga_response_embed = manga_response.transform_response_embed(guild_members_data);
 
-            interaction
-                .edit_original_interaction_response(&ctx.http, |response| {
-                    response.set_embed(manga_response_embed)
-                })
-                .await
+            let builder = EditInteractionResponse::new().embed(manga_response_embed);
+            interaction.edit_response(&ctx.http, builder).await
         }
     };
 }

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -36,12 +36,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let user = &interaction.user;
     let arg = interaction.data.options[0].value.clone();
-    let json_arg = json!(arg);
+    let arg_str = format!("{:?}", arg);
 
     sentry::configure_scope(|scope| {
         let mut context = std::collections::BTreeMap::new();
         context.insert("Command".to_string(), "Manga".into());
-        context.insert("Arg".to_string(), json_arg);
+        context.insert("Arg".to_string(), json!(arg_str));
         scope.set_context("Manga", sentry::protocol::Context::Other(context));
         scope.set_user(Some(sentry::User {
             username: Some(user.name.to_string()),

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,16 +1,14 @@
 use serenity::{
-    builder::CreateApplicationCommand,
-    model::application::interaction::{
-        application_command::ApplicationCommandInteraction, InteractionResponseType,
-    },
+    all::{CommandInteraction, CreateInteractionResponse, CreateInteractionResponseMessage},
+    builder::CreateCommand,
     prelude::*,
 };
 
-pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
-    command.name("ping").description("A ping command")
+pub fn register() -> CreateCommand {
+    CreateCommand::new("ping").description("A ping command")
 }
 
-pub async fn run(ctx: &Context, interaction: &ApplicationCommandInteraction) {
+pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
     let user = &interaction.user;
 
     sentry::configure_scope(|scope| {
@@ -23,15 +21,11 @@ pub async fn run(ctx: &Context, interaction: &ApplicationCommandInteraction) {
         }));
     });
 
-    let _ping = interaction
-        .create_interaction_response(&ctx.http, |response| {
-            { response.kind(InteractionResponseType::ChannelMessageWithSource) }
-                .interaction_response_data(|m| {
-                    m.content(format!(
-                        "Hello {}! I'm Annie Mei, a bot that helps you find anime and manga!",
-                        user.mention()
-                    ))
-                })
-        })
-        .await;
+    let response_message = CreateInteractionResponseMessage::new().content(format!(
+        "Hello {}! I'm Annie Mei, a bot that helps you find anime and manga!",
+        user.mention()
+    ));
+    let response = CreateInteractionResponse::Message(response_message);
+
+    let _ = interaction.create_response(&ctx.http, response).await;
 }

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -25,12 +25,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let user = &interaction.user;
     let options = interaction.data.options();
     let arg = &options[0].value;
-    let json_arg = json!(interaction.data.options[0].value);
+    let arg_str = format!("{:?}", arg);
 
     sentry::configure_scope(|scope| {
         let mut context = std::collections::BTreeMap::new();
         context.insert("Command".to_string(), "Register".into());
-        context.insert("Arg".to_string(), json_arg);
+        context.insert("Arg".to_string(), json!(arg_str));
         scope.set_context("Register", sentry::protocol::Context::Other(context));
         scope.set_user(Some(sentry::User {
             username: Some(user.name.to_string()),

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -2,38 +2,30 @@ use crate::{models::db::user::User, utils::database};
 
 use serde_json::json;
 use serenity::{
-    builder::CreateApplicationCommand,
+    all::{CommandInteraction, CreateCommandOption, EditInteractionResponse, ResolvedValue},
+    builder::CreateCommand,
     client::Context,
-    model::{
-        application::interaction::application_command::ApplicationCommandInteraction,
-        prelude::{
-            command::CommandOptionType,
-            interaction::application_command::CommandDataOptionValue::String as StringArg,
-        },
-    },
+    model::application::CommandOptionType,
 };
 use tokio::task;
 use tracing::info;
 
-pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
-    command
-        .name("register")
+pub fn register() -> CreateCommand {
+    CreateCommand::new("register")
         .description("Command to register your user's Anilist account")
-        .create_option(|option| {
-            option
-                .name("anilist")
-                .description("Anilist username")
-                .kind(CommandOptionType::String)
-                .required(true)
-        })
+        .add_option(
+            CreateCommandOption::new(CommandOptionType::String, "anilist", "Anilist username")
+                .required(true),
+        )
 }
 
-pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction) {
+pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _ = interaction.defer(&ctx.http).await;
 
     let user = &interaction.user;
-    let arg = interaction.data.options[0].resolved.to_owned().unwrap();
-    let json_arg = json!(arg);
+    let options = interaction.data.options();
+    let arg = &options[0].value;
+    let json_arg = json!(interaction.data.options[0].value);
 
     sentry::configure_scope(|scope| {
         let mut context = std::collections::BTreeMap::new();
@@ -52,17 +44,14 @@ pub async fn run(ctx: &Context, interaction: &mut ApplicationCommandInteraction)
     );
 
     let anilist_username = match arg {
-        StringArg(name) => name,
+        ResolvedValue::String(name) => name.to_string(),
         _ => panic!("Invalid argument type"),
     };
 
     let response_message = register_new_user(anilist_username.to_owned(), user).await;
 
-    let _register = interaction
-        .edit_original_interaction_response(&ctx.http, |response| {
-            response.content(response_message)
-        })
-        .await;
+    let builder = EditInteractionResponse::new().content(response_message);
+    let _register = interaction.edit_response(&ctx.http, builder).await;
 }
 
 async fn register_new_user(anilist_username: String, user: &serenity::model::user::User) -> String {
@@ -84,7 +73,7 @@ async fn register_new_user(anilist_username: String, user: &serenity::model::use
     {
         let anilist_id = anilist_id.unwrap();
         User::create_or_update_user(
-            user.id.into(),
+            user.id.get() as i64,
             anilist_id,
             anilist_username.to_owned(),
             connection,

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -32,12 +32,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let user = &interaction.user;
     let arg = interaction.data.options[0].value.clone();
-    let json_arg = json!(arg);
+    let arg_str = format!("{:?}", arg);
 
     sentry::configure_scope(|scope| {
         let mut context = std::collections::BTreeMap::new();
         context.insert("Command".to_string(), "Songs".into());
-        context.insert("Arg".to_string(), json_arg);
+        context.insert("Arg".to_string(), json!(arg_str));
         scope.set_context("Songs", sentry::protocol::Context::Other(context));
         scope.set_user(Some(sentry::User {
             username: Some(user.name.to_string()),

--- a/src/commands/songs/fetcher.rs
+++ b/src/commands/songs/fetcher.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::{requests::my_anime_list, response_fetcher::fetcher as anime_fetcher},
 };
 
-use serenity::model::prelude::interaction::application_command::CommandDataOptionValue;
+use serenity::all::CommandDataOptionValue;
 use tracing::info;
 
 pub fn fetcher(args: CommandDataOptionValue) -> Option<MalResponse> {

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -19,7 +19,8 @@ impl User {
         conn: &mut PgConnection,
     ) -> Option<Vec<User>> {
         use crate::schema::users::dsl::*;
-        let user_discord_ids: Vec<i64> = user_discord_ids.iter().map(|id| id.0 as i64).collect();
+        let user_discord_ids: Vec<i64> =
+            user_discord_ids.iter().map(|id| id.get() as i64).collect();
         users
             .filter(discord_id.eq_any(user_discord_ids))
             .load::<User>(conn)

--- a/src/models/transformers.rs
+++ b/src/models/transformers.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use html2md::parse_html;
-use serenity::builder::CreateEmbed;
+use serenity::all::{CreateEmbed, CreateEmbedFooter};
 
 pub trait Transformers {
     fn get_id(&self) -> u32;
@@ -169,15 +169,14 @@ pub trait Transformers {
         guild_members_data: Option<HashMap<i64, MediaListData>>,
     ) -> CreateEmbed {
         let is_anime = self.get_type() == "anime";
-        let mut embed = CreateEmbed::default();
-        embed
+        let mut embed = CreateEmbed::new()
             // General Embed Fields
             .color(self.transform_color())
             .title(self.transform_romaji_title())
             .description(self.transform_description_and_mal_link())
             .url(self.transform_anilist())
             .thumbnail(self.transform_thumbnail())
-            .footer(|f| f.text(self.transform_english_title()))
+            .footer(CreateEmbedFooter::new(self.transform_english_title()))
             // self Data Fields
             // First line after MAL link
             .fields(vec![
@@ -221,14 +220,14 @@ pub trait Transformers {
 
         // Sixth line after MAL link (Only for Anime response)
         if is_anime {
-            embed.fields(vec![
+            embed = embed.fields(vec![
                 ("Streaming", self.transform_links(), true), // Field 11
                 ("Trailer", self.transform_trailer(), true), // Field 12
             ]);
         }
 
         // Build the scores field and return the embed
-        let embed = match guild_members_data {
+        match guild_members_data {
             Some(guild_members_data) => {
                 let mut guild_members_data_string = String::default();
                 for (user_id, score) in guild_members_data {
@@ -238,8 +237,7 @@ pub trait Transformers {
                 }
                 embed.field("Guild Members", &guild_members_data_string, false)
             }
-            None => &mut embed,
-        };
-        embed.clone()
+            None => embed,
+        }
     }
 }

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 
 use serenity::{
+    all::CommandInteraction,
     client::Context,
-    model::application::interaction::application_command::ApplicationCommandInteraction,
     model::prelude::{Guild, UserId},
 };
 
@@ -22,30 +22,24 @@ use serde_json::json;
 use tokio::task;
 use tracing::info;
 
-fn get_guild_member_ids(guild: Guild) -> Vec<UserId> {
+fn get_guild_member_ids(guild: &Guild) -> Vec<UserId> {
     let members: Vec<UserId> = guild.members.keys().copied().collect();
     info!("Found {:#?} members in guild", members.len());
     members
 }
 
-fn get_guild_from_interaction(
-    ctx: &Context,
-    interaction: &ApplicationCommandInteraction,
-) -> Option<Guild> {
+fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -> Option<Guild> {
     match interaction.guild_id {
         None => None,
-        Some(guild_id) => guild_id.to_guild_cached(&ctx.cache),
+        Some(guild_id) => guild_id.to_guild_cached(&ctx.cache).map(|g| g.clone()),
     }
 }
 
-pub fn get_current_guild_members(
-    ctx: &Context,
-    interaction: &ApplicationCommandInteraction,
-) -> Vec<UserId> {
+pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction) -> Vec<UserId> {
     let guild = get_guild_from_interaction(ctx, interaction);
     match guild {
         None => vec![],
-        Some(guild) => get_guild_member_ids(guild),
+        Some(ref guild) => get_guild_member_ids(guild),
     }
 }
 

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -32,6 +32,7 @@ fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -
     interaction
         .guild_id
         .and_then(|guild_id| guild_id.to_guild_cached(&ctx.cache))
+        // skipcq: RS-W1206 - CacheRef requires explicit clone via Deref
         .map(|g| g.clone())
 }
 

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -29,18 +29,16 @@ fn get_guild_member_ids(guild: &Guild) -> Vec<UserId> {
 }
 
 fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -> Option<Guild> {
-    match interaction.guild_id {
-        None => None,
-        Some(guild_id) => guild_id.to_guild_cached(&ctx.cache).map(|g| g.clone()),
-    }
+    interaction
+        .guild_id
+        .and_then(|guild_id| guild_id.to_guild_cached(&ctx.cache).map(|g| g.clone()))
 }
 
 pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction) -> Vec<UserId> {
-    let guild = get_guild_from_interaction(ctx, interaction);
-    match guild {
-        None => vec![],
-        Some(ref guild) => get_guild_member_ids(guild),
-    }
+    get_guild_from_interaction(ctx, interaction)
+        .as_ref()
+        .map(get_guild_member_ids)
+        .unwrap_or_default()
 }
 
 pub async fn get_guild_data_for_media<T: Transformers>(

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -31,7 +31,8 @@ fn get_guild_member_ids(guild: &Guild) -> Vec<UserId> {
 fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -> Option<Guild> {
     interaction
         .guild_id
-        .and_then(|guild_id| guild_id.to_guild_cached(&ctx.cache).map(|g| g.clone()))
+        .and_then(|guild_id| guild_id.to_guild_cached(&ctx.cache))
+        .map(|g| g.clone())
 }
 
 pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction) -> Vec<UserId> {

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -3,9 +3,7 @@ use crate::models::{
     media_type::MediaType as Type,
     transformers::Transformers,
 };
-use serenity::model::prelude::interaction::application_command::CommandDataOptionValue::{
-    self, String as StringData,
-};
+use serenity::all::CommandDataOptionValue;
 use tracing::info;
 
 fn strip_quotes(string: &str) -> String {
@@ -14,7 +12,7 @@ fn strip_quotes(string: &str) -> String {
 
 fn return_argument(arg: CommandDataOptionValue) -> Argument {
     let val = match arg {
-        StringData(name) => name,
+        CommandDataOptionValue::String(name) => name,
         _ => panic!("Invalid argument type"),
     };
 


### PR DESCRIPTION
## Summary
- Upgrade serenity dependency from 0.11.7 to 0.12
- Migrate to new builder pattern API (closure-based → direct construction)
- Remove deprecated StandardFramework (not needed for slash commands)

## Breaking Changes in Serenity 0.12 Addressed
- `ApplicationCommandInteraction` → `CommandInteraction`
- `Interaction::ApplicationCommand` → `Interaction::Command`
- `create_interaction_response` → `create_response`
- `edit_original_interaction_response` → `edit_response`
- `UserId.0` → `UserId.get()` for ID access
- `Activity::listening()` → `ActivityData::listening()` with `Option` wrapper
- `to_guild_cached()` now returns `CacheRef`, requires `.clone()` for owned value
- Builder methods now take `self` and return `Self` instead of `&mut self`

## Files Changed
- `Cargo.toml` / `Cargo.lock` - dependency update
- `src/main.rs` - interaction handling, activity API, removed StandardFramework
- `src/commands/*.rs` - all command files updated for new builder patterns
- `src/utils/guild.rs` - CommandInteraction type, cache API changes
- `src/utils/response_fetcher.rs` - import path updates
- `src/models/transformers.rs` - CreateEmbed builder changes
- `src/models/db/user.rs` - UserId.get() change

## Testing
- [x] `cargo build` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` - code is formatted

## Linear Issue
Closes ANNIE-86