### PR TITLE
[ANNIE-87] Bump Rust to v1.92

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "annie-mei"
 version = "1.4.2"
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0-or-later"
-rust-version = "1.85"
+rust-version = "1.92"
 
 [package.metadata.cross.target.armv7-unknown-linux-gnueabihf]
 pre-build = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.92"
 components = ["rust-analyzer"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::env;
 
 use sentry::integrations::tracing as sentry_tracing;
 use tracing::{info, instrument};
-use tracing_subscriber::{prelude::*, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, prelude::*, util::SubscriberInitExt};
 
 use serenity::{
     all::{CreateEmbed, CreateMessage},

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -44,7 +44,7 @@ pub trait Response {
         &self,
         media_type: Type,
     ) -> Option<T> {
-        let response = match self.get_argument() {
+        match self.get_argument() {
             Argument::Id(value) => {
                 let fetched_data = fetch_by_id(self.get_id_query(), *value);
                 let fetch_response: IdResponse<T> = serde_json::from_str(&fetched_data).unwrap();
@@ -71,9 +71,7 @@ pub trait Response {
                 debug!("Fuzzy Response: {:#?}", result);
                 result
             }
-        };
-
-        response
+        }
     }
 }
 

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -83,14 +83,13 @@ impl MalResponse {
             }
 
             // Add artist names if they exist
-            if artist_names.is_some() {
-                write!(song_string, " by {}", artist_names.unwrap()).unwrap();
+            if let Some(artist_names) = artist_names {
+                write!(song_string, " by {}", artist_names).unwrap();
             }
 
             // Add episode numbers if they exist
-            if episode_numbers.is_some() {
-                // Use write
-                write!(song_string, " | {}", episode_numbers.unwrap()).unwrap();
+            if let Some(episode_numbers) = episode_numbers {
+                write!(song_string, " | {}", episode_numbers).unwrap();
             }
             return_string.push(song_string);
         }

--- a/src/models/user_media_list.rs
+++ b/src/models/user_media_list.rs
@@ -74,10 +74,10 @@ impl MediaListData {
             if let Some(progress) = &self.progress {
                 embed.push_str(&format!("**Progress:** {progress}"));
             }
-            if let Some(progress_volumes) = &self.progress_volumes {
-                if progress_volumes != &0 {
-                    embed.push_str(&format!("[{progress_volumes}]"));
-                }
+            if let Some(progress_volumes) = &self.progress_volumes
+                && progress_volumes != &0
+            {
+                embed.push_str(&format!("[{progress_volumes}]"));
             }
         }
 

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -2,7 +2,7 @@ use crate::utils::statics::DATABASE_URL;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use std::env;
 use tracing::info;
 

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -4,9 +4,9 @@ use crate::utils::{
 };
 
 use rspotify::{
+    ClientCredsSpotify, ClientError, Credentials,
     model::{Country, Market, SearchResult, SearchType},
     prelude::*,
-    ClientCredsSpotify, ClientError, Credentials,
 };
 
 use std::env;
@@ -57,7 +57,9 @@ pub fn get_song_url(
                 let kana_search = send_search_request(&kana_name, &artist_name);
                 match kana_search {
                     Ok(search_result) => {
-                        info!("Searched track using Track: {kana_name:#?} Artist: {artist_name:#?}: {search_result:#?}");
+                        info!(
+                            "Searched track using Track: {kana_name:#?} Artist: {artist_name:#?}: {search_result:#?}"
+                        );
                         match get_url_from_search_result(search_result) {
                             Some(url) => {
                                 try_to_cache_response(&cache_key, &url);


### PR DESCRIPTION
## Summary
- Upgrade Rust toolchain from 1.85 to 1.92
- Update edition from 2021 to 2024
- Fix clippy warnings for the new Rust version
- Apply rustfmt changes for Rust 2024 edition

Closes ANNIE-87