### PR TITLE
[ANNIE-92]/Migrate to trunk-based development

### DIFF
--- a/.cursor/rules/annie-mei.mdc
+++ b/.cursor/rules/annie-mei.mdc
@@ -160,10 +160,7 @@ This project uses trunk-based development with a single `main` branch. Releases 
    git tag vX.X.X
    git push origin vX.X.X
    ```
-3. Create the GitHub release with AI-generated notes:
-   ```bash
-   gh release create vX.X.X --generate-notes
-   ```
+3. The `build-release.yml` workflow automatically creates the GitHub release
 4. Edit release notes to include these sections:
    - **Breaking Changes** - API changes, major upgrades
    - **Improvements** - New features, enhancements

--- a/.cursor/rules/annie-mei.mdc
+++ b/.cursor/rules/annie-mei.mdc
@@ -150,28 +150,28 @@ Examples:
 - Always link to Linear issue in PR body
 - Always assign PRs to `@InfernapeXavier`
 
-### Release Pull Requests
-- Title format: `[Annie Mei]/Release X.X.X`
-- Example: `[Annie Mei]/Release 2.0.0`
-- Add the `release` label
-- Assign to `@InfernapeXavier`
-- Target branch: `current` (from `next`)
-
 ### Creating Releases
-After the release PR is merged:
-1. Create the release with AI-generated notes:
+
+This project uses trunk-based development with a single `main` branch. Releases are created by tagging commits.
+
+1. Ensure the version is bumped in `Cargo.toml` (should already be done per PR)
+2. Create and push a tag:
    ```bash
-   gh release create vX.X.X --target current --notes "AI-generated release notes"
+   git tag vX.X.X
+   git push origin vX.X.X
    ```
-2. Release notes sections:
+3. Create the GitHub release with AI-generated notes:
+   ```bash
+   gh release create vX.X.X --generate-notes
+   ```
+4. Edit release notes to include these sections:
    - **Breaking Changes** - API changes, major upgrades
    - **Improvements** - New features, enhancements
    - **Dependencies** - Package updates with version changes
 
 ### Branches
 - Use Linear's suggested branch name: `annie-XXX-description`
-- `next` - Development branch (default)
-- `current` - Production/release branch
+- `main` - Single trunk branch (all PRs target this)
 
 ## Formatting
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    target-branch: "next"
+    target-branch: "main"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "next"
+    target-branch: "main"

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -6,7 +6,7 @@ on:
       - "dependabot/*"
   push:
     branches:
-      - "next"
+      - "main"
     paths-ignore:
       - "**/README.md"
 

--- a/.opencode/skills/create-release/SKILL.md
+++ b/.opencode/skills/create-release/SKILL.md
@@ -65,19 +65,22 @@ The `build-release.yml` workflow will automatically:
 - Create a GitHub release with the binary attached
 - Deploy to Oracle Cloud
 
-### Step 4: Generate Release Notes
+### Step 4: Wait for Workflow and Edit Release Notes
 
-Create the GitHub release with auto-generated notes:
+The `build-release.yml` workflow automatically creates the release. Wait for it to complete:
 
 ```bash
-gh release create vX.X.X --generate-notes
+# Wait for and verify the workflow completed
+gh run list --workflow=build-release.yml --limit=1
+
+# View the created release
+gh release view vX.X.X
 ```
 
-Then edit the release to organize notes into these sections:
+Then edit the release notes to organize them into these sections:
 
-#### Release Notes Template
-
-```markdown
+```bash
+gh release edit vX.X.X --notes "$(cat <<'EOF'
 ## Breaking Changes
 - List any breaking changes (API changes, major upgrades)
 
@@ -90,17 +93,11 @@ Then edit the release to organize notes into these sections:
 
 ## Dependencies
 - Package updates with version changes (e.g., "Bump serde from 1.0.148 to 1.0.149")
+EOF
+)"
 ```
 
-### Step 5: Verify Release
-
-```bash
-# Check the release was created
-gh release view vX.X.X
-
-# Verify the workflow completed
-gh run list --workflow=build-release.yml --limit=1
-```
+Or edit directly in the GitHub UI.
 
 ## Rollback Procedure
 

--- a/.opencode/skills/create-release/SKILL.md
+++ b/.opencode/skills/create-release/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: create-release
+description: Create a GitHub release with version tag and release notes for Annie Mei
+license: MIT
+compatibility: opencode
+metadata:
+  audience: maintainers
+  workflow: github
+---
+
+## Overview
+
+This skill guides you through creating a release for Annie Mei using trunk-based development. Releases are created by tagging commits on `main` and creating a GitHub release.
+
+## Prerequisites
+
+Before creating a release, verify:
+1. You are on the `main` branch
+2. The branch is up to date with `origin/main`
+3. All CI checks are passing
+4. The version in `Cargo.toml` has been bumped appropriately
+
+## Release Process
+
+### Step 1: Verify State
+
+```bash
+# Ensure you're on main and up to date
+git checkout main
+git pull origin main
+
+# Check current version
+grep '^version' Cargo.toml
+```
+
+### Step 2: Determine Version
+
+Check the commits since the last release to determine the appropriate version bump:
+
+```bash
+# Find the last release tag
+git describe --tags --abbrev=0
+
+# See commits since last release
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+```
+
+Apply semantic versioning:
+- **MAJOR** (X.0.0): Breaking changes, incompatible API changes
+- **MINOR** (0.X.0): New features, new commands, backwards-compatible functionality
+- **PATCH** (0.0.X): Bug fixes, refactors, dependency updates
+
+### Step 3: Create and Push Tag
+
+```bash
+# Create the tag (replace X.X.X with the version)
+git tag vX.X.X
+
+# Push the tag to trigger the release workflow
+git push origin vX.X.X
+```
+
+The `build-release.yml` workflow will automatically:
+- Build the ARM64 binary
+- Create a GitHub release with the binary attached
+- Deploy to Oracle Cloud
+
+### Step 4: Generate Release Notes
+
+Create the GitHub release with auto-generated notes:
+
+```bash
+gh release create vX.X.X --generate-notes
+```
+
+Then edit the release to organize notes into these sections:
+
+#### Release Notes Template
+
+```markdown
+## Breaking Changes
+- List any breaking changes (API changes, major upgrades)
+
+## Improvements
+- New features and enhancements
+- New commands added
+
+## Bug Fixes
+- Bug fixes and corrections
+
+## Dependencies
+- Package updates with version changes (e.g., "Bump serde from 1.0.148 to 1.0.149")
+```
+
+### Step 5: Verify Release
+
+```bash
+# Check the release was created
+gh release view vX.X.X
+
+# Verify the workflow completed
+gh run list --workflow=build-release.yml --limit=1
+```
+
+## Rollback Procedure
+
+If a release needs to be rolled back:
+
+```bash
+# Delete the release
+gh release delete vX.X.X --yes
+
+# Delete the tag (remote and local)
+git push origin --delete vX.X.X
+git tag -d vX.X.X
+```
+
+## Notes
+
+- The CI workflow triggers on tags matching `v[0-9]+.[0-9]+.[0-9]+`
+- Releases are built on ARM64 runners for Oracle Cloud deployment
+- The binary is validated before deployment; if validation fails, the deploy auto-rolls back

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,22 +87,21 @@ Examples:
 - Always link to Linear issue in PR body
 - Always assign the PR to `@InfernapeXavier`
 
-### Release Pull Requests
-
-- Title format: `[Annie Mei]/Release X.X.X`
-- Example: `[Annie Mei]/Release 2.0.0`
-- Add the `release` label to the PR
-- Always assign the PR to `@InfernapeXavier`
-- Target branch: `current` (from `next`)
-
 ### Creating Releases
 
-After the release PR is merged:
-1. Create the release with AI-generated notes:
+This project uses trunk-based development with a single `main` branch. Releases are created by tagging commits.
+
+1. Ensure the version is bumped in `Cargo.toml` (should already be done per PR)
+2. Create and push a tag:
    ```bash
-   gh release create vX.X.X --target current --notes "AI-generated release notes here"
+   git tag vX.X.X
+   git push origin vX.X.X
    ```
-2. Generate release notes with these sections:
+3. Create the GitHub release with AI-generated notes:
+   ```bash
+   gh release create vX.X.X --generate-notes
+   ```
+4. Edit release notes to include these sections:
    - **Breaking Changes** - API changes, major upgrades
    - **Improvements** - New features, enhancements
    - **Dependencies** - Package updates with version changes
@@ -110,8 +109,7 @@ After the release PR is merged:
 ### Branches
 
 - Use Linear's suggested branch name: `annie-XXX-description`
-- `next` - Development branch (default)
-- `current` - Production/release branch
+- `main` - Single trunk branch (all PRs target this)
 
 ### Adding Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,7 @@ This project uses trunk-based development with a single `main` branch. Releases 
    git tag vX.X.X
    git push origin vX.X.X
    ```
-3. Create the GitHub release with AI-generated notes:
-   ```bash
-   gh release create vX.X.X --generate-notes
-   ```
+3. The `build-release.yml` workflow automatically creates the GitHub release
 4. Edit release notes to include these sections:
    - **Breaking Changes** - API changes, major upgrades
    - **Improvements** - New features, enhancements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,7 @@ This project uses trunk-based development with a single `main` branch. Releases 
    git tag vX.X.X
    git push origin vX.X.X
    ```
-3. Create the GitHub release with AI-generated notes:
-   ```bash
-   gh release create vX.X.X --generate-notes
-   ```
+3. The `build-release.yml` workflow automatically creates the GitHub release
 4. Edit release notes to include these sections:
    - **Breaking Changes** - API changes, major upgrades
    - **Improvements** - New features, enhancements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,21 +150,21 @@ Examples:
 - Always assign PRs to `@InfernapeXavier`
 - Always link to Linear issue in PR body
 
-### Release Process
+### Creating Releases
 
-This project uses trunk-based development. Releases are created by tagging commits on `main`.
+This project uses trunk-based development with a single `main` branch. Releases are created by tagging commits.
 
-1. Ensure version is bumped in `Cargo.toml` (should already be done per PR)
+1. Ensure the version is bumped in `Cargo.toml` (should already be done per PR)
 2. Create and push a tag:
    ```bash
    git tag vX.X.X
    git push origin vX.X.X
    ```
-3. Create GitHub release:
+3. Create the GitHub release with AI-generated notes:
    ```bash
    gh release create vX.X.X --generate-notes
    ```
-4. Edit release notes to include:
+4. Edit release notes to include these sections:
    - **Breaking Changes** - API changes, major upgrades
    - **Improvements** - New features, enhancements
    - **Dependencies** - Package updates with version changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ let result = task::spawn_blocking(move || {
 - **Commits**: Conventional format - `type: description` (feat, fix, docs, chore, refactor, test)
 - **PR titles**: `[ANNIE-XXX]/Description` (e.g., `[ANNIE-84]/Prepare for AI Dev`)
 - **Branches**: Use Linear's format - `annie-XXX-description`
-- **Branch structure**: `next` (development), `current` (production/release)
+- **Branch structure**: Trunk-based development with `main` as the single trunk branch
 
 ### Git Safety
 
@@ -152,17 +152,19 @@ Examples:
 
 ### Release Process
 
-1. Create PR from `next` to `current`:
-   - Title: `[Annie Mei]/Release X.X.X`
-   - Add the `release` label
-   - Assign to `@InfernapeXavier`
+This project uses trunk-based development. Releases are created by tagging commits on `main`.
 
-2. After merge, create release with AI-generated notes:
+1. Ensure version is bumped in `Cargo.toml` (should already be done per PR)
+2. Create and push a tag:
    ```bash
-   gh release create vX.X.X --target current --notes "AI-generated release notes"
+   git tag vX.X.X
+   git push origin vX.X.X
    ```
-
-3. Release notes sections:
+3. Create GitHub release:
+   ```bash
+   gh release create vX.X.X --generate-notes
+   ```
+4. Edit release notes to include:
    - **Breaking Changes** - API changes, major upgrades
    - **Improvements** - New features, enhancements
    - **Dependencies** - Package updates with version changes


### PR DESCRIPTION
## Summary
- Update CI workflows (dependabot, clippy) to target `main` branch instead of `next`
- Update documentation to reflect trunk-based development workflow
- Remove release PR process in favor of tag-based releases
- Add `create-release` skill for agents to guide through the release process

## Linear Issue
https://linear.app/annie-mei/issue/ANNIE-92/migrate-to-trunk-based-development