### PR TITLE
[ANNIE-94]/Add branch safety rules to AI documentation

### DIFF
--- a/.cursor/rules/annie-mei.mdc
+++ b/.cursor/rules/annie-mei.mdc
@@ -135,6 +135,7 @@ Current intents: `GUILD_MESSAGES`, `DIRECT_MESSAGES`, `GUILD_PRESENCES`, `GUILDS
 ### Git Safety
 - **NEVER commit or push directly to `main`** - Always create a feature branch first
 - **All branches must have a Linear ticket** - Use the ticket's suggested branch name (e.g., `annie-XXX-description`). Only create a ticketless branch if the user explicitly approves it
+- **Don't create tickets automatically** - Check for existing/recent tickets that the work might fit under, and ask the user before creating a new one
 - **Never force push** - Always ask before any destructive git operation
 - **When git issues occur** (failed push, wrong commit, merge conflicts, etc.):
   1. Explain what went wrong

--- a/.cursor/rules/annie-mei.mdc
+++ b/.cursor/rules/annie-mei.mdc
@@ -132,6 +132,16 @@ Current intents: `GUILD_MESSAGES`, `DIRECT_MESSAGES`, `GUILD_PRESENCES`, `GUILDS
 - Use conventional commit format: `type: description`
 - Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
 
+### Git Safety
+- **NEVER commit or push directly to `main`** - Always create a feature branch first
+- **All branches must have a Linear ticket** - Use the ticket's suggested branch name (e.g., `annie-XXX-description`). Only create a ticketless branch if the user explicitly approves it
+- **Never force push** - Always ask before any destructive git operation
+- **When git issues occur** (failed push, wrong commit, merge conflicts, etc.):
+  1. Explain what went wrong
+  2. Present the available options
+  3. Ask the user how they want to resolve it
+- If a push didn't go through, prefer `git reset --hard origin/<branch>` over amending and force pushing
+
 ### Versioning
 Bump the version in `Cargo.toml` with every PR using semantic versioning:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ diesel migration run     # Apply database migrations
 
 - **NEVER commit or push directly to `main`** - Always create a feature branch first
 - **All branches must have a Linear ticket** - Use the ticket's suggested branch name (e.g., `annie-XXX-description`). Only create a ticketless branch if the user explicitly approves it
+- **Don't create tickets automatically** - Check for existing/recent tickets that the work might fit under, and ask the user before creating a new one
 - **Never force push** - Always ask before any destructive git operation
 - **When git issues occur** (failed push, wrong commit, merge conflicts, etc.):
   1. Explain what went wrong

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ diesel migration run     # Apply database migrations
 
 ### Git Safety
 
+- **NEVER commit or push directly to `main`** - Always create a feature branch first
+- **All branches must have a Linear ticket** - Use the ticket's suggested branch name (e.g., `annie-XXX-description`). Only create a ticketless branch if the user explicitly approves it
 - **Never force push** - Always ask before any destructive git operation
 - **When git issues occur** (failed push, wrong commit, merge conflicts, etc.):
   1. Explain what went wrong

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ let result = task::spawn_blocking(move || {
 
 - **NEVER commit or push directly to `main`** - Always create a feature branch first
 - **All branches must have a Linear ticket** - Use the ticket's suggested branch name (e.g., `annie-XXX-description`). Only create a ticketless branch if the user explicitly approves it
+- **Don't create tickets automatically** - Check for existing/recent tickets that the work might fit under, and ask the user before creating a new one
 - **Never force push** - Always ask before any destructive git operation
 - **When git issues occur** (failed push, wrong commit, merge conflicts, etc.):
   1. Explain what went wrong

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ let result = task::spawn_blocking(move || {
 
 ### Git Safety
 
+- **NEVER commit or push directly to `main`** - Always create a feature branch first
+- **All branches must have a Linear ticket** - Use the ticket's suggested branch name (e.g., `annie-XXX-description`). Only create a ticketless branch if the user explicitly approves it
 - **Never force push** - Always ask before any destructive git operation
 - **When git issues occur** (failed push, wrong commit, merge conflicts, etc.):
   1. Explain what went wrong


### PR DESCRIPTION
## Summary
- Add explicit rules that agents must NEVER commit or push directly to `main`
- Require all branches to have an associated Linear ticket
- Only create ticketless branches with explicit user approval

## Linear Issue
https://linear.app/annie-mei/issue/ANNIE-94/update-ai-docs-with-branch-safety-rules