### PR TITLE
[ANNIE-91]/Build ARM64 artifacts for OL9

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build ARM64 beta
     runs-on: ubuntu-24.04-arm
+    container: rust:1-bullseye
     env:
       CARGO_TERM_COLOR: always
       RUSTC_WRAPPER: ""
@@ -24,7 +25,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
+        run: apt-get update && apt-get install -y libpq-dev
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,7 +76,16 @@ jobs:
             cd /opt/annie-mei || exit 1
             chmod +x annie-mei.new/annie-mei
             # Validate new binary before stopping service
-            if ldd ./annie-mei.new/annie-mei | grep -q "not found"; then
+            if ! test -x ./annie-mei.new/annie-mei; then
+              echo "Binary validation failed"
+              exit 1
+            fi
+            ldd_output=$(ldd ./annie-mei.new/annie-mei 2>&1) || {
+              echo "Binary validation failed"
+              echo "$ldd_output"
+              exit 1
+            }
+            if echo "$ldd_output" | grep -q "not found"; then
               echo "Binary validation failed"
               exit 1
             fi

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build ARM64
     runs-on: ubuntu-24.04-arm
+    container: rust:1-bullseye
     env:
       CARGO_TERM_COLOR: always
       RUSTC_WRAPPER: ""
@@ -24,7 +25,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev
+        run: apt-get update && apt-get install -y libpq-dev
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,7 +76,10 @@ jobs:
             cd /opt/annie-mei || exit 1
             chmod +x annie-mei.new/annie-mei
             # Validate new binary before stopping service
-            ./annie-mei.new/annie-mei --version || { echo "Binary validation failed"; exit 1; }
+            if ldd ./annie-mei.new/annie-mei | grep -q "not found"; then
+              echo "Binary validation failed"
+              exit 1
+            fi
             # Backup current binary
             cp annie-mei annie-mei.backup || true
             # Stop, replace, start

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "chrono",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.92"


### PR DESCRIPTION
## Summary
- build ARM64 release and beta artifacts inside rust:1-bullseye to match OL9 glibc
- validate release binaries with ldd before swapping them in
- bump version to 2.0.3

## Testing
- not run (workflow changes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/198">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
