### PR TITLE
[ANNIE-99]/Redact PII in Sentry and logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,8 @@ REDIS_URL=redis://localhost:6379
 RSPOTIFY_CLIENT_ID=
 RSPOTIFY_CLIENT_SECRET=
 
+# Secret salt for hashing user IDs in logs (generate a random string)
+USERID_HASH_SALT=
+
 # Tracing/logging level (optional)
 RUST_LOG=info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,9 @@ dependencies = [
 name = "annie-mei"
 version = "2.0.4"
 dependencies = [
+ "blake3",
  "chrono",
+ "clap",
  "diesel",
  "diesel_migrations",
  "env_logger",
@@ -208,6 +210,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wana_kana",
 ]
 
@@ -266,6 +269,12 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -359,6 +368,20 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
 
 [[package]]
 name = "block-buffer"
@@ -487,6 +510,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +584,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.0.4"
+version = "2.1.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "env_logger",
  "futures",
  "html2md",
+ "linkify",
  "log",
  "ngrammatic",
  "openssl",
@@ -1727,6 +1728,15 @@ name = "libc"
 version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+
+[[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ codegen-units = 1
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+blake3 = "1.8"
 chrono = "0.4.43"
+clap = { version = "4", features = ["derive"] }
 diesel = { version = "2.2.12", features = ["postgres"] }
 diesel_migrations = "2.2.0"
 env_logger = "0.11.8"
@@ -39,4 +41,5 @@ titlecase = "3.6.0"
 tokio = { version = "1.49.0", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+url = "2.5"
 wana_kana = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.0.4"
+version = "2.1.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.92"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ diesel_migrations = "2.2.0"
 env_logger = "0.11.8"
 futures = "0.3.31"
 html2md = "0.2.15"
+linkify = "0.10"
 log = "0.4.29"
 ngrammatic = "0.7.0"
 openssl = { version = "0.10.75", features = ["vendored"] }

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -4,7 +4,12 @@
     "linear": {
       "type": "local",
       "command": ["npx", "-y", "mcp-remote", "https://mcp.linear.app/mcp"],
-      "enabled": true
-    }
-  }
+      "enabled": true,
+    },
+    "sentry": {
+      "type": "remote",
+      "url": "https://mcp.sentry.dev/mcp",
+      "enabled": true,
+    },
+  },
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2024"

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,3 +1,5 @@
+use crate::utils::privacy::configure_sentry_scope;
+
 use serenity::{
     all::{
         CommandInteraction, CreateAttachment, CreateEmbed, CreateEmbedFooter,
@@ -14,15 +16,7 @@ pub fn register() -> CreateCommand {
 pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
     let user = &interaction.user;
 
-    sentry::configure_scope(|scope| {
-        let mut context = std::collections::BTreeMap::new();
-        context.insert("Command".to_string(), "Register".into());
-        scope.set_context("Help", sentry::protocol::Context::Other(context));
-        scope.set_user(Some(sentry::User {
-            username: Some(user.name.to_string()),
-            ..Default::default()
-        }));
-    });
+    configure_sentry_scope("Help", user.id.get(), None);
 
     let embed = CreateEmbed::new()
         .colour(0x00ff00)

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -1,3 +1,5 @@
+use crate::utils::privacy::configure_sentry_scope;
+
 use serenity::{
     all::{CommandInteraction, CreateInteractionResponse, CreateInteractionResponseMessage},
     builder::CreateCommand,
@@ -11,15 +13,7 @@ pub fn register() -> CreateCommand {
 pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
     let user = &interaction.user;
 
-    sentry::configure_scope(|scope| {
-        let mut context = std::collections::BTreeMap::new();
-        context.insert("Command".to_string(), "Register".into());
-        scope.set_context("Ping", sentry::protocol::Context::Other(context));
-        scope.set_user(Some(sentry::User {
-            username: Some(user.name.to_string()),
-            ..Default::default()
-        }));
-    });
+    configure_sentry_scope("Ping", user.id.get(), None);
 
     let response_message = CreateInteractionResponseMessage::new().content(format!(
         "Hello {}! I'm Annie Mei, a bot that helps you find anime and manga!",

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -1,4 +1,7 @@
-use crate::{models::db::user::User, utils::database};
+use crate::{
+    models::db::user::User,
+    utils::{database, privacy::configure_sentry_scope},
+};
 
 use serde_json::json;
 use serenity::{
@@ -27,21 +30,9 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let arg = &options[0].value;
     let arg_str = format!("{:?}", arg);
 
-    sentry::configure_scope(|scope| {
-        let mut context = std::collections::BTreeMap::new();
-        context.insert("Command".to_string(), "Register".into());
-        context.insert("Arg".to_string(), json!(arg_str));
-        scope.set_context("Register", sentry::protocol::Context::Other(context));
-        scope.set_user(Some(sentry::User {
-            username: Some(user.name.to_string()),
-            ..Default::default()
-        }));
-    });
+    configure_sentry_scope("Register", user.id.get(), Some(json!(arg_str)));
 
-    info!(
-        "Got command 'register' by user '{}' with args: {arg:#?}",
-        user.name
-    );
+    info!("Got command 'register' with args: {arg:#?}");
 
     let anilist_username = match arg {
         ResolvedValue::String(name) => name.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod utils;
 use std::env;
 use std::sync::Arc;
 
+use clap::{Parser, Subcommand};
 use sentry::integrations::tracing as sentry_tracing;
 use tracing::{info, instrument};
 use tracing_subscriber::{EnvFilter, prelude::*, util::SubscriberInitExt};
@@ -22,9 +23,27 @@ use serenity::{
 
 use utils::{
     database::run_migration,
-    privacy::redact_url_credentials,
+    privacy::{hash_user_id, redact_url_credentials},
     statics::{DISCORD_TOKEN, ENV, SENTRY_DSN},
 };
+
+/// Annie Mei Discord Bot
+#[derive(Parser)]
+#[command(name = "annie-mei")]
+#[command(about = "A Discord bot for anime and manga information", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Compute the hashed user ID for Sentry log lookup
+    Hash {
+        /// The Discord user ID to hash
+        user_id: u64,
+    },
+}
 
 struct Handler;
 
@@ -81,6 +100,16 @@ impl EventHandler for Handler {
 #[tokio::main]
 #[instrument]
 async fn main() {
+    let cli = Cli::parse();
+
+    // Handle CLI subcommands
+    if let Some(Commands::Hash { user_id }) = cli.command {
+        let hashed = hash_user_id(user_id);
+        println!("{}", hashed);
+        return;
+    }
+
+    // Default: run the bot
     let environment = env::var(ENV).expect("Expected an environment in the environment");
     let sentry_dsn = env::var(SENTRY_DSN).expect("Expected a sentry dsn in the environment");
 

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -2,7 +2,7 @@ use crate::utils::statics::DATABASE_URL;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use std::env;
 use tracing::{error, info};
 

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -2,22 +2,21 @@ use crate::utils::statics::DATABASE_URL;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use std::env;
 use tracing::{error, info};
 
 pub fn establish_connection() -> PgConnection {
     let database_url = env::var(DATABASE_URL).expect("DATABASE_URL must be set");
-    PgConnection::establish(&database_url)
-        .unwrap_or_else(|error| {
-            let redacted_url = redact_database_url(&database_url);
-            error!(
-                error = %error,
-                database_url = %redacted_url,
-                "Failed to connect to database"
-            );
-            panic!("Error connecting to {redacted_url}: {error}")
-        })
+    PgConnection::establish(&database_url).unwrap_or_else(|error| {
+        let redacted_url = redact_database_url(&database_url);
+        error!(
+            error = %error,
+            database_url = %redacted_url,
+            "Failed to connect to database"
+        );
+        panic!("Error connecting to {redacted_url}: {error}")
+    })
 }
 
 fn redact_database_url(database_url: &str) -> String {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod fetch_by_arguments;
 pub mod formatter;
 pub mod fuzzy;
 pub mod guild;
+pub mod privacy;
 pub mod queries;
 pub mod redis;
 pub mod requests;

--- a/src/utils/privacy.rs
+++ b/src/utils/privacy.rs
@@ -1,0 +1,136 @@
+//! Privacy utilities for PII handling and redaction.
+//!
+//! This module provides utilities for hashing user IDs and redacting
+//! sensitive information from logs and error reports.
+
+use std::env;
+use std::fmt;
+
+use crate::utils::statics::USERID_HASH_SALT;
+
+/// A hashed user ID that can be safely logged without exposing PII.
+///
+/// The hash is a 16-character hex string (64 bits) derived from the
+/// Discord user ID using blake3 with a secret salt.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HashedUserId(String);
+
+impl HashedUserId {
+    /// Returns the hash as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for HashedUserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl fmt::Debug for HashedUserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HashedUserId({})", self.0)
+    }
+}
+
+/// Hashes a Discord user ID using blake3 with a secret salt.
+///
+/// The resulting hash is truncated to 16 hex characters (64 bits),
+/// which provides sufficient uniqueness for correlation while being
+/// compact enough for readable logs.
+///
+/// # Panics
+///
+/// Panics if the `USERID_HASH_SALT` environment variable is not set.
+///
+/// # Example
+///
+/// ```ignore
+/// let hashed = hash_user_id(123456789012345678);
+/// println!("User: {}", hashed); // e.g., "a1b2c3d4e5f6g7h8"
+/// ```
+pub fn hash_user_id(user_id: u64) -> HashedUserId {
+    let salt =
+        env::var(USERID_HASH_SALT).expect("USERID_HASH_SALT environment variable must be set");
+
+    let input = format!("{}{}", salt, user_id);
+    let hash = blake3::hash(input.as_bytes());
+    let hex = hash.to_hex();
+
+    // Truncate to 16 characters (64 bits)
+    HashedUserId(hex[..16].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    fn with_salt<F, R>(salt: &str, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        // SAFETY: Tests run single-threaded with --test-threads=1,
+        // so no data races from env var modification.
+        unsafe {
+            env::set_var(USERID_HASH_SALT, salt);
+        }
+        let result = f();
+        unsafe {
+            env::remove_var(USERID_HASH_SALT);
+        }
+        result
+    }
+
+    #[test]
+    fn test_hash_determinism() {
+        with_salt("test_salt_123", || {
+            let hash1 = hash_user_id(123456789012345678);
+            let hash2 = hash_user_id(123456789012345678);
+            assert_eq!(hash1, hash2, "Same input should produce same hash");
+        });
+    }
+
+    #[test]
+    fn test_hash_length() {
+        with_salt("test_salt_123", || {
+            let hash = hash_user_id(123456789012345678);
+            assert_eq!(hash.as_str().len(), 16, "Hash should be 16 characters");
+        });
+    }
+
+    #[test]
+    fn test_different_users_different_hashes() {
+        with_salt("test_salt_123", || {
+            let hash1 = hash_user_id(123456789012345678);
+            let hash2 = hash_user_id(987654321098765432);
+            assert_ne!(hash1, hash2, "Different users should have different hashes");
+        });
+    }
+
+    #[test]
+    fn test_different_salts_different_hashes() {
+        let user_id = 123456789012345678;
+
+        let hash1 = with_salt("salt_one", || hash_user_id(user_id));
+        let hash2 = with_salt("salt_two", || hash_user_id(user_id));
+
+        assert_ne!(
+            hash1, hash2,
+            "Different salts should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_display_and_debug() {
+        with_salt("test_salt_123", || {
+            let hash = hash_user_id(123456789012345678);
+            let display = format!("{}", hash);
+            let debug = format!("{:?}", hash);
+
+            assert_eq!(display.len(), 16);
+            assert!(debug.contains("HashedUserId("));
+        });
+    }
+}

--- a/src/utils/privacy.rs
+++ b/src/utils/privacy.rs
@@ -20,7 +20,8 @@ pub struct HashedUserId(String);
 
 impl HashedUserId {
     /// Returns the hash as a string slice.
-    pub fn as_str(&self) -> &str {
+    #[cfg(test)]
+    fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/src/utils/privacy.rs
+++ b/src/utils/privacy.rs
@@ -57,12 +57,61 @@ pub fn hash_user_id(user_id: u64) -> HashedUserId {
     let salt =
         env::var(USERID_HASH_SALT).expect("USERID_HASH_SALT environment variable must be set");
 
+    hash_user_id_with_salt(user_id, &salt)
+}
+
+/// Internal function that hashes a user ID with a given salt.
+/// Used by tests to avoid unsafe env var manipulation.
+fn hash_user_id_with_salt(user_id: u64, salt: &str) -> HashedUserId {
     let input = format!("{}{}", salt, user_id);
     let hash = blake3::hash(input.as_bytes());
     let hex = hash.to_hex();
 
     // Truncate to 16 characters (64 bits)
     HashedUserId(hex[..16].to_string())
+}
+
+/// Redacts credentials from a URL string.
+///
+/// If the URL contains a username or password, they are replaced with
+/// `REDACTED_USERNAME` and `REDACTED_PASSWORD` respectively.
+///
+/// # Arguments
+///
+/// * `input` - A string that may contain a URL with credentials
+///
+/// # Returns
+///
+/// The input string with any URL credentials redacted. If the input is not
+/// a valid URL, it is returned unchanged.
+///
+/// # Example
+///
+/// ```ignore
+/// let url = "postgres://user:pass@localhost:5432/db";
+/// let redacted = redact_url_credentials(url);
+/// assert_eq!(redacted, "postgres://REDACTED_USERNAME:REDACTED_PASSWORD@localhost:5432/db");
+/// ```
+pub fn redact_url_credentials(input: &str) -> String {
+    match url::Url::parse(input) {
+        Ok(mut parsed_url) => {
+            let has_username = !parsed_url.username().is_empty();
+            let has_password = parsed_url.password().is_some();
+
+            if has_username || has_password {
+                if has_username {
+                    let _ = parsed_url.set_username("REDACTED_USERNAME");
+                }
+                if has_password {
+                    let _ = parsed_url.set_password(Some("REDACTED_PASSWORD"));
+                }
+                parsed_url.to_string()
+            } else {
+                input.to_string()
+            }
+        }
+        Err(_) => input.to_string(),
+    }
 }
 
 /// Configures the Sentry scope for a command with privacy-safe user identification.
@@ -102,57 +151,32 @@ pub fn configure_sentry_scope(command: &str, user_id: u64, args: Option<Value>) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
-
-    fn with_salt<F, R>(salt: &str, f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        // SAFETY: Tests run single-threaded with --test-threads=1,
-        // so no data races from env var modification.
-        unsafe {
-            env::set_var(USERID_HASH_SALT, salt);
-        }
-        let result = f();
-        unsafe {
-            env::remove_var(USERID_HASH_SALT);
-        }
-        result
-    }
 
     #[test]
     fn test_hash_determinism() {
-        with_salt("test_salt_123", || {
-            let hash1 = hash_user_id(123456789012345678);
-            let hash2 = hash_user_id(123456789012345678);
-            assert_eq!(hash1, hash2, "Same input should produce same hash");
-        });
+        let hash1 = hash_user_id_with_salt(123456789012345678, "test_salt_123");
+        let hash2 = hash_user_id_with_salt(123456789012345678, "test_salt_123");
+        assert_eq!(hash1, hash2, "Same input should produce same hash");
     }
 
     #[test]
     fn test_hash_length() {
-        with_salt("test_salt_123", || {
-            let hash = hash_user_id(123456789012345678);
-            assert_eq!(hash.as_str().len(), 16, "Hash should be 16 characters");
-        });
+        let hash = hash_user_id_with_salt(123456789012345678, "test_salt_123");
+        assert_eq!(hash.as_str().len(), 16, "Hash should be 16 characters");
     }
 
     #[test]
     fn test_different_users_different_hashes() {
-        with_salt("test_salt_123", || {
-            let hash1 = hash_user_id(123456789012345678);
-            let hash2 = hash_user_id(987654321098765432);
-            assert_ne!(hash1, hash2, "Different users should have different hashes");
-        });
+        let hash1 = hash_user_id_with_salt(123456789012345678, "test_salt_123");
+        let hash2 = hash_user_id_with_salt(987654321098765432, "test_salt_123");
+        assert_ne!(hash1, hash2, "Different users should have different hashes");
     }
 
     #[test]
     fn test_different_salts_different_hashes() {
         let user_id = 123456789012345678;
-
-        let hash1 = with_salt("salt_one", || hash_user_id(user_id));
-        let hash2 = with_salt("salt_two", || hash_user_id(user_id));
-
+        let hash1 = hash_user_id_with_salt(user_id, "salt_one");
+        let hash2 = hash_user_id_with_salt(user_id, "salt_two");
         assert_ne!(
             hash1, hash2,
             "Different salts should produce different hashes"
@@ -161,13 +185,59 @@ mod tests {
 
     #[test]
     fn test_display_and_debug() {
-        with_salt("test_salt_123", || {
-            let hash = hash_user_id(123456789012345678);
-            let display = format!("{}", hash);
-            let debug = format!("{:?}", hash);
+        let hash = hash_user_id_with_salt(123456789012345678, "test_salt_123");
+        let display = format!("{}", hash);
+        let debug = format!("{:?}", hash);
 
-            assert_eq!(display.len(), 16);
-            assert!(debug.contains("HashedUserId("));
-        });
+        assert_eq!(display.len(), 16);
+        assert!(debug.contains("HashedUserId("));
+    }
+
+    #[test]
+    fn test_redact_url_with_username_and_password() {
+        let url = "postgres://myuser:secretpass@localhost:5432/mydb";
+        let redacted = redact_url_credentials(url);
+        assert_eq!(
+            redacted,
+            "postgres://REDACTED_USERNAME:REDACTED_PASSWORD@localhost:5432/mydb"
+        );
+    }
+
+    #[test]
+    fn test_redact_url_with_password_only() {
+        let url = "redis://:secretpass@localhost:6379";
+        let redacted = redact_url_credentials(url);
+        assert_eq!(redacted, "redis://:REDACTED_PASSWORD@localhost:6379");
+    }
+
+    #[test]
+    fn test_redact_url_with_username_only() {
+        let url = "ftp://user@example.com/file.txt";
+        let redacted = redact_url_credentials(url);
+        assert_eq!(redacted, "ftp://REDACTED_USERNAME@example.com/file.txt");
+    }
+
+    #[test]
+    fn test_redact_url_without_credentials() {
+        let url = "https://example.com/api/endpoint";
+        let redacted = redact_url_credentials(url);
+        assert_eq!(redacted, url);
+    }
+
+    #[test]
+    fn test_redact_url_invalid_url() {
+        let not_a_url = "this is not a url";
+        let redacted = redact_url_credentials(not_a_url);
+        assert_eq!(redacted, not_a_url);
+    }
+
+    #[test]
+    fn test_redact_url_with_special_characters() {
+        let url = "postgres://user%40domain:p%3Ass%40word@localhost:5432/db";
+        let redacted = redact_url_credentials(url);
+        assert!(redacted.contains("REDACTED_USERNAME"));
+        assert!(redacted.contains("REDACTED_PASSWORD"));
+        assert!(!redacted.contains("user%40domain"));
+        assert!(!redacted.contains("p%3Ass%40word"));
     }
 }

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -4,9 +4,9 @@ use crate::utils::{
 };
 
 use rspotify::{
+    ClientCredsSpotify, ClientError, Credentials,
     model::{Country, Market, SearchResult, SearchType},
     prelude::*,
-    ClientCredsSpotify, ClientError, Credentials,
 };
 
 use std::env;

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -4,9 +4,9 @@ use crate::utils::{
 };
 
 use rspotify::{
-    ClientCredsSpotify, ClientError, Credentials,
     model::{Country, Market, SearchResult, SearchType},
     prelude::*,
+    ClientCredsSpotify, ClientError, Credentials,
 };
 
 use std::env;

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -11,3 +11,4 @@ pub const SPOTIFY_CLIENT_ID: &str = "SPOTIFY_CLIENT_ID";
 pub const SPOTIFY_CLIENT_SECRET: &str = "SPOTIFY_CLIENT_SECRET";
 pub const MAL_CLIENT_ID: &str = "MAL_CLIENT_ID";
 pub const DATABASE_URL: &str = "DATABASE_URL";
+pub const USERID_HASH_SALT: &str = "USERID_HASH_SALT";


### PR DESCRIPTION
## Summary

- Add privacy utilities for hashing user IDs (blake3, 16-char truncated)
- Replace raw Discord usernames with hashed user IDs in Sentry scope
- Add URL credential redaction in Sentry `before_send` hook (uses `url` crate)
- Add CLI subcommand `annie-mei hash <user_id>` for log lookup
- Bump version to 2.1.0

## Changes

- New `src/utils/privacy.rs` module with:
  - `hash_user_id()` - salted blake3 hash
  - `configure_sentry_scope()` - consistent PII-safe scope setup
  - `redact_url_credentials()` - replaces credentials with `REDACTED_USERNAME`/`REDACTED_PASSWORD`
- All 6 commands migrated to use `configure_sentry_scope`
- New required env var: `USERID_HASH_SALT`

## Testing

- 11 unit tests for privacy utilities
- Manually verified user field shows hashed ID in Sentry
- Manually verified CLI hash command works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
