### PR TITLE
[ANNIE-101]/Add tracing contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ diesel migration run     # Apply database migrations
 
 - Use conventional commit format: `type: description`
 - Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+- Make small, sensible commits as you go; avoid batching unrelated changes into one commit
 
 ### Git Safety
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ let result = task::spawn_blocking(move || {
 ## Git Conventions
 
 - **Commits**: Conventional format - `type: description` (feat, fix, docs, chore, refactor, test)
+- **Commit cadence**: Make small, sensible commits as you go; avoid batching unrelated changes into one commit
 - **PR titles**: `[ANNIE-XXX]/Description` (e.g., `[ANNIE-84]/Prepare for AI Dev`)
 - **Branches**: Use Linear's format - `annie-XXX-description`
 - **Branch structure**: Trunk-based development with `main` as the single trunk branch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -63,12 +63,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 info!("No users found in guild");
                 None
             } else {
-                let guild_members_data = task::spawn_blocking(move || {
-                    get_guild_data_for_media(also_anime, guild_members)
-                })
-                .await
-                .unwrap()
-                .await;
+                let guild_members_data = get_guild_data_for_media(also_anime, guild_members).await;
                 info!("Guild members data: {:#?}", guild_members_data);
                 if guild_members_data.is_empty() {
                     None

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -17,7 +17,7 @@ use serenity::{
 };
 
 use tokio::task;
-use tracing::info;
+use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("anime")
@@ -32,6 +32,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
+#[instrument(name = "command.anime.run", skip(ctx, interaction))]
 pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _ = interaction.defer(&ctx.http).await;
 

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -63,7 +63,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 info!("No users found in guild");
                 None
             } else {
-                let guild_members_data = get_guild_data_for_media(also_anime, guild_members).await;
+                let guild_members_data = task::spawn_blocking(move || {
+                    get_guild_data_for_media(also_anime, guild_members)
+                })
+                .await
+                .unwrap()
+                .await;
                 info!("Guild members data: {:#?}", guild_members_data);
                 if guild_members_data.is_empty() {
                     None

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -63,12 +63,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 info!("No users found in guild");
                 None
             } else {
-                let guild_members_data = task::spawn_blocking(move || {
-                    get_guild_data_for_media(also_manga, guild_members)
-                })
-                .await
-                .unwrap()
-                .await;
+                let guild_members_data = get_guild_data_for_media(also_manga, guild_members).await;
                 info!("Guild members data: {:#?}", guild_members_data);
                 if guild_members_data.is_empty() {
                     None

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -63,7 +63,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 info!("No users found in guild");
                 None
             } else {
-                let guild_members_data = get_guild_data_for_media(also_manga, guild_members).await;
+                let guild_members_data = task::spawn_blocking(move || {
+                    get_guild_data_for_media(also_manga, guild_members)
+                })
+                .await
+                .unwrap()
+                .await;
                 info!("Guild members data: {:#?}", guild_members_data);
                 if guild_members_data.is_empty() {
                     None

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -17,7 +17,7 @@ use serenity::{
 };
 
 use tokio::task;
-use tracing::info;
+use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("manga")
@@ -32,6 +32,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
+#[instrument(name = "command.manga.run", skip(ctx, interaction))]
 pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _ = interaction.defer(&ctx.http).await;
 

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -11,7 +11,7 @@ use serenity::{
     model::application::CommandOptionType,
 };
 use tokio::task;
-use tracing::info;
+use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("register")
@@ -22,6 +22,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
+#[instrument(name = "command.register.run", skip(ctx, interaction))]
 pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _ = interaction.defer(&ctx.http).await;
 
@@ -45,6 +46,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _register = interaction.edit_response(&ctx.http, builder).await;
 }
 
+#[instrument(name = "command.register.register_new_user", skip(user, anilist_username), fields(discord_user_id = user.id.get(), username_len = anilist_username.len()))]
 async fn register_new_user(anilist_username: String, user: &serenity::model::user::User) -> String {
     let username = anilist_username.to_string();
     let anilist_id =

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -76,8 +76,10 @@ async fn register_new_user(anilist_username: String, user: &serenity::model::use
         );
 
         info!(
-            "Created user with details: id: {}, anilist_id: {}, anilist_username: {}",
-            user.id, anilist_id, anilist_username
+            discord_user_id = %hash_user_id(user.id.get()),
+            anilist_id,
+            anilist_username = %anilist_username,
+            "Created user with details"
         );
         format!(
             "Hello {}, I have linked the Anilist account {} to your user.",

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -49,7 +49,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _register = interaction.edit_response(&ctx.http, builder).await;
 }
 
-#[instrument(name = "command.register.register_new_user", skip(user, anilist_username), fields(discord_user_id = %hash_user_id(user.id.get()), username_len = anilist_username.len()))]
+#[instrument(name = "command.register.register_new_user", skip(user), fields(discord_user_id = %hash_user_id(user.id.get()), username_len = anilist_username.len()))]
 async fn register_new_user(anilist_username: String, user: &serenity::model::user::User) -> String {
     let username = anilist_username.to_string();
     let anilist_id =

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -1,6 +1,9 @@
 use crate::{
     models::db::user::User,
-    utils::{database, privacy::configure_sentry_scope},
+    utils::{
+        database,
+        privacy::{configure_sentry_scope, hash_user_id},
+    },
 };
 
 use serde_json::json;
@@ -46,7 +49,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _register = interaction.edit_response(&ctx.http, builder).await;
 }
 
-#[instrument(name = "command.register.register_new_user", skip(user, anilist_username), fields(discord_user_id = user.id.get(), username_len = anilist_username.len()))]
+#[instrument(name = "command.register.register_new_user", skip(user, anilist_username), fields(discord_user_id = %hash_user_id(user.id.get()), username_len = anilist_username.len()))]
 async fn register_new_user(anilist_username: String, user: &serenity::model::user::User) -> String {
     let username = anilist_username.to_string();
     let anilist_id =

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -13,7 +13,7 @@ use serenity::{
 };
 
 use tokio::task;
-use tracing::info;
+use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("songs")
@@ -28,6 +28,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
+#[instrument(name = "command.songs.run", skip(ctx, interaction))]
 pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let _ = interaction.defer(&ctx.http).await;
 
@@ -56,6 +57,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
 }
 
+#[instrument(name = "command.songs.build_message", skip(mal_response))]
 fn build_message_from_song_response(mal_response: MalResponse) -> CreateEmbed {
     CreateEmbed::new()
         .title(mal_response.transform_title())

--- a/src/commands/songs/fetcher.rs
+++ b/src/commands/songs/fetcher.rs
@@ -7,8 +7,9 @@ use crate::{
 };
 
 use serenity::all::CommandDataOptionValue;
-use tracing::info;
+use tracing::{info, instrument};
 
+#[instrument(name = "command.songs.fetcher", skip(args))]
 pub fn fetcher(args: CommandDataOptionValue) -> Option<MalResponse> {
     let anime_response: Option<Anime> = anime_fetcher(Type::Anime, args);
     match anime_response {

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,8 +128,7 @@ async fn main() {
     let sentry_traces_sample_rate = env::var(SENTRY_TRACES_SAMPLE_RATE)
         .ok()
         .and_then(|raw| raw.parse::<f32>().ok())
-        .map(|rate| rate.clamp(0.0, 1.0))
-        .unwrap_or(0.0);
+        .map_or(0.0, |rate| rate.clamp(0.0, 1.0));
 
     let _guard = sentry::init((
         sentry_dsn,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use clap::{Parser, Subcommand};
 use sentry::integrations::tracing as sentry_tracing;
 use tracing::{info, info_span, instrument};
-use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan, prelude::*, util::SubscriberInitExt};
+use tracing_subscriber::{EnvFilter, prelude::*, util::SubscriberInitExt};
 
 use serenity::{
     all::{CreateEmbed, CreateMessage},
@@ -167,10 +167,10 @@ async fn main() {
         },
     ));
 
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,serenity=warn"));
     let subscriber = tracing_subscriber::fmt()
         .with_env_filter(env_filter)
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .finish();
 
     subscriber.with(sentry_tracing::layer()).init();

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -54,7 +54,7 @@ impl User {
             .expect("Error saving user")
     }
 
-    #[instrument(name = "http.anilist.lookup_user", fields(username_len = username.len()))]
+    #[instrument(name = "http.anilist.lookup_user", skip(username), fields(username_len = username.len()))]
     pub fn get_anilist_id_from_username(username: &str) -> Option<i64> {
         let body = json!({
             "query": FETCH_ANILIST_USER,

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -30,7 +30,7 @@ impl User {
             .ok()
     }
 
-    #[instrument(name = "db.user.create_or_update", skip(conn, anilist_username), fields(discord_user_id = %hash_user_id(discord_id as u64), anilist_id = anilist_id, username_len = anilist_username.len()))]
+    #[instrument(name = "db.user.create_or_update", skip(conn, anilist_username, discord_id), fields(discord_user_id = %hash_user_id(discord_id as u64), anilist_id = anilist_id, username_len = anilist_username.len()))]
     pub fn create_or_update_user(
         discord_id: i64,
         anilist_id: i64,

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -28,7 +28,7 @@ impl User {
             .ok()
     }
 
-    #[instrument(name = "db.user.create_or_update", skip(conn, anilist_username), fields(discord_id, anilist_id, username_len = anilist_username.len()))]
+    #[instrument(name = "db.user.create_or_update", skip(conn, anilist_username), fields(discord_id = discord_id, anilist_id = anilist_id, username_len = anilist_username.len()))]
     pub fn create_or_update_user(
         discord_id: i64,
         anilist_id: i64,

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -3,7 +3,9 @@ use serde_json::json;
 use serenity::model::prelude::UserId;
 use tracing::{info, instrument};
 
-use crate::utils::{queries::FETCH_ANILIST_USER, requests::anilist::send_request};
+use crate::utils::{
+    privacy::hash_user_id, queries::FETCH_ANILIST_USER, requests::anilist::send_request,
+};
 
 #[derive(Queryable)]
 #[allow(dead_code)]
@@ -28,7 +30,7 @@ impl User {
             .ok()
     }
 
-    #[instrument(name = "db.user.create_or_update", skip(conn, anilist_username), fields(discord_id = discord_id, anilist_id = anilist_id, username_len = anilist_username.len()))]
+    #[instrument(name = "db.user.create_or_update", skip(conn, anilist_username), fields(discord_user_id = %hash_user_id(discord_id as u64), anilist_id = anilist_id, username_len = anilist_username.len()))]
     pub fn create_or_update_user(
         discord_id: i64,
         anilist_id: i64,

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -54,7 +54,7 @@ impl User {
             .expect("Error saving user")
     }
 
-    #[instrument(name = "http.anilist.lookup_user", skip(username), fields(username_len = username.len()))]
+    #[instrument(name = "http.anilist.lookup_user", fields(username_len = username.len()))]
     pub fn get_anilist_id_from_username(username: &str) -> Option<i64> {
         let body = json!({
             "query": FETCH_ANILIST_USER,

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -4,8 +4,9 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use std::env;
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 
+#[instrument(name = "db.establish_connection", skip_all)]
 pub fn establish_connection() -> PgConnection {
     let database_url = env::var(DATABASE_URL).expect("DATABASE_URL must be set");
     PgConnection::establish(&database_url).unwrap_or_else(|error| {
@@ -36,6 +37,8 @@ fn redact_database_url(database_url: &str) -> String {
 }
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+
+#[instrument(name = "db.run_migrations", skip(conn))]
 pub fn run_migration(conn: &mut PgConnection) {
     info!("Running database migrations ... ");
     conn.run_pending_migrations(MIGRATIONS).unwrap();

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -20,14 +20,16 @@ use serenity::{
 
 use serde_json::json;
 use tokio::task;
-use tracing::info;
+use tracing::{info, instrument};
 
+#[instrument(name = "discord.guild.member_ids", skip(guild))]
 fn get_guild_member_ids(guild: &Guild) -> Vec<UserId> {
     let members: Vec<UserId> = guild.members.keys().copied().collect();
     info!("Found {:#?} members in guild", members.len());
     members
 }
 
+#[instrument(name = "discord.guild.from_interaction", skip(ctx, interaction))]
 fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -> Option<Guild> {
     interaction
         .guild_id
@@ -36,6 +38,7 @@ fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -
         .map(|g| g.clone())
 }
 
+#[instrument(name = "discord.guild.current_members", skip(ctx, interaction))]
 pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction) -> Vec<UserId> {
     get_guild_from_interaction(ctx, interaction)
         .as_ref()
@@ -43,6 +46,7 @@ pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction
         .unwrap_or_default()
 }
 
+#[instrument(name = "guild.fetch_media_data", skip(media, guild_members), fields(member_count = guild_members.len()))]
 pub async fn get_guild_data_for_media<T: Transformers>(
     media: T,
     guild_members: Vec<UserId>,
@@ -54,6 +58,7 @@ pub async fn get_guild_data_for_media<T: Transformers>(
     get_guild_anilist_data(anilist_users, media.get_id(), media.get_type()).await
 }
 
+#[instrument(name = "guild.fetch_anilist_data", skip(guild_members, media_type), fields(member_count = guild_members.len(), media_id, media_type = %media_type))]
 async fn get_guild_anilist_data(
     guild_members: Vec<User>,
     media_id: u32,

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -51,17 +51,11 @@ pub async fn get_guild_data_for_media<T: Transformers>(
     media: T,
     guild_members: Vec<UserId>,
 ) -> HashMap<i64, MediaListData> {
-    let media_id = media.get_id();
-    let media_type = media.get_type();
+    let mut conn = establish_connection();
+    let anilist_users = User::get_users_by_discord_id(guild_members, &mut conn);
+    let anilist_users = anilist_users.unwrap();
 
-    let anilist_users = task::spawn_blocking(move || {
-        let mut conn = establish_connection();
-        User::get_users_by_discord_id(guild_members, &mut conn).unwrap()
-    })
-    .await
-    .unwrap();
-
-    get_guild_anilist_data(anilist_users, media_id, media_type).await
+    get_guild_anilist_data(anilist_users, media.get_id(), media.get_type()).await
 }
 
 #[instrument(name = "guild.fetch_anilist_data", skip(guild_members, media_type), fields(member_count = guild_members.len(), media_id = media_id, media_type = %media_type))]

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -22,14 +22,14 @@ use serde_json::json;
 use tokio::task;
 use tracing::{info, instrument};
 
-#[instrument(name = "discord.guild.member_ids", skip(guild))]
+#[instrument(name = "discord.guild.member_ids", skip(guild), fields(member_count = guild.members.len()))]
 fn get_guild_member_ids(guild: &Guild) -> Vec<UserId> {
     let members: Vec<UserId> = guild.members.keys().copied().collect();
     info!("Found {:#?} members in guild", members.len());
     members
 }
 
-#[instrument(name = "discord.guild.from_interaction", skip(ctx, interaction))]
+#[instrument(name = "discord.guild.from_interaction", skip(ctx, interaction), fields(has_guild_id = interaction.guild_id.is_some()))]
 fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -> Option<Guild> {
     interaction
         .guild_id
@@ -38,7 +38,7 @@ fn get_guild_from_interaction(ctx: &Context, interaction: &CommandInteraction) -
         .map(|g| g.clone())
 }
 
-#[instrument(name = "discord.guild.current_members", skip(ctx, interaction))]
+#[instrument(name = "discord.guild.current_members", skip(ctx, interaction), fields(has_guild_id = interaction.guild_id.is_some()))]
 pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction) -> Vec<UserId> {
     get_guild_from_interaction(ctx, interaction)
         .as_ref()

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -58,7 +58,7 @@ pub async fn get_guild_data_for_media<T: Transformers>(
     get_guild_anilist_data(anilist_users, media.get_id(), media.get_type()).await
 }
 
-#[instrument(name = "guild.fetch_anilist_data", skip(guild_members, media_type), fields(member_count = guild_members.len(), media_id, media_type = %media_type))]
+#[instrument(name = "guild.fetch_anilist_data", skip(guild_members, media_type), fields(member_count = guild_members.len(), media_id = media_id, media_type = %media_type))]
 async fn get_guild_anilist_data(
     guild_members: Vec<User>,
     media_id: u32,

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -1,9 +1,10 @@
 use redis::{Commands, Connection, RedisResult};
 use std::env;
-use tracing::info;
+use tracing::{info, instrument};
 
 use crate::utils::statics::REDIS_URL;
 
+#[instrument(name = "redis.get_connection", skip_all)]
 fn get_redis_client() -> RedisResult<Connection> {
     let redis_url = env::var(REDIS_URL).expect("Expected REDIS_URL in the environment");
 
@@ -13,18 +14,21 @@ fn get_redis_client() -> RedisResult<Connection> {
     Ok(connection)
 }
 
+#[instrument(name = "redis.check_cache", skip_all, fields(key_len = key.len()))]
 pub fn check_cache(key: &str) -> RedisResult<String> {
     let mut redis_client_connection = get_redis_client().unwrap();
     let cached_value: String = redis_client_connection.get(key)?;
     Ok(cached_value)
 }
 
+#[instrument(name = "redis.cache_response", skip(response), fields(key_len = key.len(), response_len = response.len()))]
 fn cache_response(key: &str, response: &str) -> RedisResult<()> {
     let mut redis_client_connection = get_redis_client().unwrap();
     // Expires cached value in 5 hours
     redis_client_connection.set_ex(key, response, 18_000)
 }
 
+#[instrument(name = "redis.try_cache_response", skip(response), fields(key_len = key.len(), response_len = response.len()))]
 pub fn try_to_cache_response(key: &str, response: &str) {
     match cache_response(key, response) {
         Ok(()) => {

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -14,21 +14,21 @@ fn get_redis_client() -> RedisResult<Connection> {
     Ok(connection)
 }
 
-#[instrument(name = "redis.check_cache", skip_all, fields(key_len = key.len()))]
+#[instrument(name = "redis.check_cache", fields(key = %key, key_len = key.len()))]
 pub fn check_cache(key: &str) -> RedisResult<String> {
     let mut redis_client_connection = get_redis_client().unwrap();
     let cached_value: String = redis_client_connection.get(key)?;
     Ok(cached_value)
 }
 
-#[instrument(name = "redis.cache_response", skip(response), fields(key_len = key.len(), response_len = response.len()))]
+#[instrument(name = "redis.cache_response", skip(response), fields(key = %key, key_len = key.len(), response_len = response.len()))]
 fn cache_response(key: &str, response: &str) -> RedisResult<()> {
     let mut redis_client_connection = get_redis_client().unwrap();
     // Expires cached value in 5 hours
     redis_client_connection.set_ex(key, response, 18_000)
 }
 
-#[instrument(name = "redis.try_cache_response", skip(response), fields(key_len = key.len(), response_len = response.len()))]
+#[instrument(name = "redis.try_cache_response", skip(response), fields(key = %key, key_len = key.len(), response_len = response.len()))]
 pub fn try_to_cache_response(key: &str, response: &str) {
     match cache_response(key, response) {
         Ok(()) => {

--- a/src/utils/requests/anilist.rs
+++ b/src/utils/requests/anilist.rs
@@ -1,6 +1,12 @@
 use reqwest::blocking::Client;
 use serde_json::Value;
+use tracing::instrument;
 
+#[instrument(
+    name = "http.anilist.send_request",
+    skip(json),
+    fields(endpoint = "https://graphql.anilist.co/")
+)]
 pub fn send_request(json: Value) -> String {
     let client = Client::new();
     let response = client

--- a/src/utils/requests/my_anime_list.rs
+++ b/src/utils/requests/my_anime_list.rs
@@ -1,13 +1,14 @@
 use std::env;
 
 use reqwest::blocking::Client;
-use tracing::info;
+use tracing::{info, instrument};
 
 use crate::utils::statics::MAL_CLIENT_ID;
 
 const MY_ANIME_LIST_BASE: &str = "https://api.myanimelist.net/v2";
 const FIELDS_TO_FETCH: [&str; 3] = ["id", "opening_themes", "ending_themes"];
 
+#[instrument(name = "http.mal.build_url", fields(mal_id))]
 fn build_mal_url(mal_id: u32) -> String {
     let mal_url = format!(
         "{MY_ANIME_LIST_BASE}/anime/{mal_id}?fields={}",
@@ -18,6 +19,7 @@ fn build_mal_url(mal_id: u32) -> String {
     mal_url
 }
 
+#[instrument(name = "http.mal.send_request", skip_all, fields(mal_id))]
 pub fn send_request(mal_id: u32) -> String {
     let mal_client_id =
         env::var(MAL_CLIENT_ID).expect("Expected a MAL Client ID in the environment");

--- a/src/utils/requests/my_anime_list.rs
+++ b/src/utils/requests/my_anime_list.rs
@@ -8,7 +8,7 @@ use crate::utils::statics::MAL_CLIENT_ID;
 const MY_ANIME_LIST_BASE: &str = "https://api.myanimelist.net/v2";
 const FIELDS_TO_FETCH: [&str; 3] = ["id", "opening_themes", "ending_themes"];
 
-#[instrument(name = "http.mal.build_url", fields(mal_id))]
+#[instrument(name = "http.mal.build_url")]
 fn build_mal_url(mal_id: u32) -> String {
     let mal_url = format!(
         "{MY_ANIME_LIST_BASE}/anime/{mal_id}?fields={}",
@@ -19,7 +19,7 @@ fn build_mal_url(mal_id: u32) -> String {
     mal_url
 }
 
-#[instrument(name = "http.mal.send_request", skip_all, fields(mal_id))]
+#[instrument(name = "http.mal.send_request", skip_all, fields(mal_id = mal_id))]
 pub fn send_request(mal_id: u32) -> String {
     let mal_client_id =
         env::var(MAL_CLIENT_ID).expect("Expected a MAL Client ID in the environment");

--- a/src/utils/requests/my_anime_list.rs
+++ b/src/utils/requests/my_anime_list.rs
@@ -8,7 +8,6 @@ use crate::utils::statics::MAL_CLIENT_ID;
 const MY_ANIME_LIST_BASE: &str = "https://api.myanimelist.net/v2";
 const FIELDS_TO_FETCH: [&str; 3] = ["id", "opening_themes", "ending_themes"];
 
-#[instrument(name = "http.mal.build_url")]
 fn build_mal_url(mal_id: u32) -> String {
     let mal_url = format!(
         "{MY_ANIME_LIST_BASE}/anime/{mal_id}?fields={}",

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -4,12 +4,14 @@ use crate::models::{
     transformers::Transformers,
 };
 use serenity::all::CommandDataOptionValue;
-use tracing::info;
+use tracing::{info, instrument};
 
+#[instrument(name = "fetcher.strip_quotes", skip(string), fields(input_len = string.len()))]
 fn strip_quotes(string: &str) -> String {
     string.replace('"', "")
 }
 
+#[instrument(name = "fetcher.return_argument", skip(arg))]
 fn return_argument(arg: CommandDataOptionValue) -> Argument {
     let val = match arg {
         CommandDataOptionValue::String(name) => name,
@@ -25,6 +27,7 @@ fn return_argument(arg: CommandDataOptionValue) -> Argument {
     }
 }
 
+#[instrument(name = "fetcher.fetch", skip(arg), fields(media_type = ?media_type))]
 pub fn fetcher<
     T: serde::de::DeserializeOwned + Transformers + std::fmt::Debug + std::clone::Clone,
 >(

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -6,7 +6,6 @@ use crate::models::{
 use serenity::all::CommandDataOptionValue;
 use tracing::{info, instrument};
 
-#[instrument(name = "fetcher.strip_quotes", skip(string), fields(input_len = string.len()))]
 fn strip_quotes(string: &str) -> String {
     string.replace('"', "")
 }

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -5,6 +5,7 @@ pub const EMPTY_STR: &str = "-";
 // Environment variables
 pub const ENV: &str = "ENV";
 pub const SENTRY_DSN: &str = "SENTRY_DSN";
+pub const SENTRY_TRACES_SAMPLE_RATE: &str = "SENTRY_TRACES_SAMPLE_RATE";
 pub const DISCORD_TOKEN: &str = "DISCORD_TOKEN";
 pub const REDIS_URL: &str = "REDIS_URL";
 pub const SPOTIFY_CLIENT_ID: &str = "SPOTIFY_CLIENT_ID";


### PR DESCRIPTION
## Linear
- https://linear.app/annie-mei/issue/ANNIE-101/add-tracing-contexts

## Summary
- add structured `tracing` spans (`#[instrument]`) across Discord command handlers, runtime startup, database, Redis, and HTTP request paths
- standardize command-level tracing for `/anime`, `/manga`, `/songs`, and `/register` flows with non-sensitive span fields to improve observability in logs/Sentry
- document agent commit cadence in `AGENTS.md` and `CLAUDE.md` to keep changes in small, sensible commits

## Validation
- `cargo fmt`
- `cargo check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
