### PR TITLE
[ANNIE-93]/Show media current progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.1.4"
+version = "2.2.0"
 dependencies = [
  "blake3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.1.4"
+version = "2.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"

--- a/src/commands/anime/queries.rs
+++ b/src/commands/anime/queries.rs
@@ -15,6 +15,9 @@ query ($id: Int) {
     format
     status
     episodes
+    nextAiringEpisode {
+      episode
+    }
     duration
     genres
     source
@@ -77,6 +80,9 @@ query ($page: Int, $perPage: Int, $search: String) {
       format
       status
       episodes
+      nextAiringEpisode {
+        episode
+      }
       duration
       genres
       source

--- a/src/models/anilist_anime.rs
+++ b/src/models/anilist_anime.rs
@@ -96,7 +96,13 @@ impl Anime {
             && let Some(next_airing_episode) = &self.next_airing_episode
             && let Some(next_episode) = next_airing_episode.episode
         {
-            return next_episode.saturating_sub(1).to_string();
+            let aired_episodes = next_episode.saturating_sub(1);
+
+            if let Some(total_episodes) = self.episodes {
+                return format!("{aired_episodes}/{total_episodes}");
+            }
+
+            return aired_episodes.to_string();
         }
 
         match &self.episodes {
@@ -345,7 +351,7 @@ mod tests {
     fn transform_episodes_uses_aired_count_for_releasing_anime() {
         let anime = sample_anime("RELEASING", Some(12), Some(8));
 
-        assert_eq!(anime.transform_episodes(), "7");
+        assert_eq!(anime.transform_episodes(), "7/12");
     }
 
     #[test]
@@ -353,5 +359,12 @@ mod tests {
         let anime = sample_anime("FINISHED", Some(12), Some(8));
 
         assert_eq!(anime.transform_episodes(), "12");
+    }
+
+    #[test]
+    fn transform_episodes_uses_aired_count_when_total_is_unknown() {
+        let anime = sample_anime("RELEASING", None, Some(8));
+
+        assert_eq!(anime.transform_episodes(), "7");
     }
 }

--- a/src/models/anilist_anime.rs
+++ b/src/models/anilist_anime.rs
@@ -26,6 +26,7 @@ pub struct Anime {
     format: Option<String>,
     status: Option<String>,
     episodes: Option<u32>,
+    next_airing_episode: Option<NextAiringEpisode>,
     duration: Option<u32>,
     genres: Vec<String>,
     source: Option<String>,
@@ -64,6 +65,12 @@ pub struct Trailer {
     pub site: String,
 }
 
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct NextAiringEpisode {
+    pub episode: Option<u32>,
+}
+
 impl Anime {
     pub fn transform_season(&self) -> String {
         let season = match &self.season {
@@ -85,6 +92,13 @@ impl Anime {
     }
 
     pub fn transform_episodes(&self) -> String {
+        if self.status.as_deref() == Some("RELEASING")
+            && let Some(next_airing_episode) = &self.next_airing_episode
+            && let Some(next_episode) = next_airing_episode.episode
+        {
+            return next_episode.saturating_sub(1).to_string();
+        }
+
         match &self.episodes {
             Some(episodes) => episodes.to_string(),
             None => EMPTY_STR.to_string(),
@@ -282,5 +296,62 @@ impl Transformers for Anime {
 
     fn get_studios_staff_text(&self) -> &str {
         "Studios"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Anime;
+    use serde_json::json;
+
+    fn sample_anime(status: &str, episodes: Option<u32>, next_episode: Option<u32>) -> Anime {
+        serde_json::from_value(json!({
+            "type": "ANIME",
+            "id": 1,
+            "idMal": null,
+            "title": {
+                "romaji": "Sample",
+                "english": "Sample",
+                "native": "サンプル"
+            },
+            "synonyms": null,
+            "season": null,
+            "seasonYear": null,
+            "format": null,
+            "status": status,
+            "episodes": episodes,
+            "nextAiringEpisode": next_episode.map(|episode| json!({ "episode": episode })),
+            "duration": null,
+            "genres": [],
+            "source": null,
+            "coverImage": {
+                "extraLarge": null,
+                "large": null,
+                "medium": "https://example.com/image.jpg",
+                "color": null
+            },
+            "averageScore": null,
+            "studios": null,
+            "siteUrl": "https://anilist.co/anime/1",
+            "externalLinks": null,
+            "trailer": null,
+            "description": null,
+            "tags": []
+        }))
+        .expect("sample anime JSON should deserialize")
+    }
+
+    #[test]
+    fn transform_episodes_uses_aired_count_for_releasing_anime() {
+        let anime = sample_anime("RELEASING", Some(12), Some(8));
+
+        assert_eq!(anime.transform_episodes(), "7");
+    }
+
+    #[test]
+    fn transform_episodes_uses_total_for_non_releasing_anime() {
+        let anime = sample_anime("FINISHED", Some(12), Some(8));
+
+        assert_eq!(anime.transform_episodes(), "12");
     }
 }

--- a/src/models/anilist_anime.rs
+++ b/src/models/anilist_anime.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     utils::{
         formatter::{code, linker, titlecase},
-        statics::EMPTY_STR,
+        statics::{ANILIST_STATUS_RELEASING, EMPTY_STR},
     },
 };
 
@@ -92,7 +92,7 @@ impl Anime {
     }
 
     pub fn transform_episodes(&self) -> String {
-        if self.status.as_deref() == Some("RELEASING")
+        if self.status.as_deref() == Some(ANILIST_STATUS_RELEASING)
             && let Some(next_airing_episode) = &self.next_airing_episode
             && let Some(next_episode) = next_airing_episode.episode
         {
@@ -308,6 +308,7 @@ impl Transformers for Anime {
 #[cfg(test)]
 mod tests {
     use super::Anime;
+    use crate::utils::statics::{ANILIST_STATUS_FINISHED, ANILIST_STATUS_RELEASING};
     use serde_json::json;
 
     fn sample_anime(status: &str, episodes: Option<u32>, next_episode: Option<u32>) -> Anime {
@@ -349,21 +350,21 @@ mod tests {
 
     #[test]
     fn transform_episodes_uses_aired_count_for_releasing_anime() {
-        let anime = sample_anime("RELEASING", Some(12), Some(8));
+        let anime = sample_anime(ANILIST_STATUS_RELEASING, Some(12), Some(8));
 
         assert_eq!(anime.transform_episodes(), "7/12");
     }
 
     #[test]
     fn transform_episodes_uses_total_for_non_releasing_anime() {
-        let anime = sample_anime("FINISHED", Some(12), Some(8));
+        let anime = sample_anime(ANILIST_STATUS_FINISHED, Some(12), Some(8));
 
         assert_eq!(anime.transform_episodes(), "12");
     }
 
     #[test]
     fn transform_episodes_uses_aired_count_when_total_is_unknown() {
-        let anime = sample_anime("RELEASING", None, Some(8));
+        let anime = sample_anime(ANILIST_STATUS_RELEASING, None, Some(8));
 
         assert_eq!(anime.transform_episodes(), "7");
     }

--- a/src/models/anilist_manga.rs
+++ b/src/models/anilist_manga.rs
@@ -3,7 +3,10 @@ use crate::{
         anilist_common::{CoverImage, ExternalLinks, Tag, Title},
         transformers::Transformers,
     },
-    utils::{formatter::code, statics::EMPTY_STR},
+    utils::{
+        formatter::code,
+        statics::{ANILIST_STATUS_RELEASING, EMPTY_STR},
+    },
 };
 
 use chrono::NaiveDate;
@@ -90,7 +93,7 @@ impl Manga {
     pub fn transform_chapters(&self) -> String {
         match &self.chapters {
             Some(chapters) => {
-                if self.status.as_deref() == Some("RELEASING") {
+                if self.status.as_deref() == Some(ANILIST_STATUS_RELEASING) {
                     format!("{chapters} written")
                 } else {
                     chapters.to_string()
@@ -304,6 +307,7 @@ impl Transformers for Manga {
 #[cfg(test)]
 mod tests {
     use super::Manga;
+    use crate::utils::statics::{ANILIST_STATUS_FINISHED, ANILIST_STATUS_RELEASING};
     use serde_json::json;
 
     fn sample_manga(status: &str, chapters: Option<u32>) -> Manga {
@@ -343,14 +347,14 @@ mod tests {
 
     #[test]
     fn transform_chapters_uses_written_suffix_for_releasing_manga() {
-        let manga = sample_manga("RELEASING", Some(110));
+        let manga = sample_manga(ANILIST_STATUS_RELEASING, Some(110));
 
         assert_eq!(manga.transform_chapters(), "110 written");
     }
 
     #[test]
     fn transform_chapters_uses_plain_count_for_non_releasing_manga() {
-        let manga = sample_manga("FINISHED", Some(110));
+        let manga = sample_manga(ANILIST_STATUS_FINISHED, Some(110));
 
         assert_eq!(manga.transform_chapters(), "110");
     }

--- a/src/models/anilist_manga.rs
+++ b/src/models/anilist_manga.rs
@@ -89,7 +89,13 @@ impl Manga {
 
     pub fn transform_chapters(&self) -> String {
         match &self.chapters {
-            Some(chapters) => chapters.to_string(),
+            Some(chapters) => {
+                if self.status.as_deref() == Some("RELEASING") {
+                    format!("{chapters} written")
+                } else {
+                    chapters.to_string()
+                }
+            }
             None => EMPTY_STR.to_string(),
         }
     }
@@ -292,5 +298,60 @@ impl Transformers for Manga {
 
     fn get_studios_staff_text(&self) -> &str {
         "Staff"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Manga;
+    use serde_json::json;
+
+    fn sample_manga(status: &str, chapters: Option<u32>) -> Manga {
+        serde_json::from_value(json!({
+            "type": "MANGA",
+            "id": 1,
+            "idMal": null,
+            "title": {
+                "romaji": "Sample",
+                "english": "Sample",
+                "native": "サンプル"
+            },
+            "synonyms": null,
+            "startDate": null,
+            "endDate": null,
+            "format": null,
+            "status": status,
+            "chapters": chapters,
+            "volumes": null,
+            "genres": [],
+            "source": null,
+            "coverImage": {
+                "extraLarge": null,
+                "large": null,
+                "medium": "https://example.com/image.jpg",
+                "color": null
+            },
+            "averageScore": null,
+            "staff": null,
+            "siteUrl": "https://anilist.co/manga/1",
+            "externalLinks": null,
+            "description": null,
+            "tags": []
+        }))
+        .expect("sample manga JSON should deserialize")
+    }
+
+    #[test]
+    fn transform_chapters_uses_written_suffix_for_releasing_manga() {
+        let manga = sample_manga("RELEASING", Some(110));
+
+        assert_eq!(manga.transform_chapters(), "110 written");
+    }
+
+    #[test]
+    fn transform_chapters_uses_plain_count_for_non_releasing_manga() {
+        let manga = sample_manga("FINISHED", Some(110));
+
+        assert_eq!(manga.transform_chapters(), "110");
     }
 }

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -1,6 +1,9 @@
 pub const NOT_FOUND_ANIME: &str = "No such anime";
 pub const NOT_FOUND_MANGA: &str = "No such manga";
 pub const EMPTY_STR: &str = "-";
+pub const ANILIST_STATUS_RELEASING: &str = "RELEASING";
+#[cfg(test)]
+pub const ANILIST_STATUS_FINISHED: &str = "FINISHED";
 
 // Environment variables
 pub const ENV: &str = "ENV";


### PR DESCRIPTION
## Description

Implements ANNIE-93 by showing current media progress in command embeds:
- Anime with `RELEASING` status now shows currently aired episode count (derived from AniList `nextAiringEpisode.episode - 1`)
- Manga with `RELEASING` status now shows current written chapters in the chapters field
- Added unit tests for both anime and manga progress formatting behavior
- Bumped crate version to `2.2.0`

## Related Issue

Closes ANNIE-93

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Checklist

- [x] `cargo fmt` has been run
- [x] `cargo clippy` passes without warnings
- [x] `cargo test` passes
- [x] Changes have been tested locally

## Additional Notes

- Linear issue: https://linear.app/annie-mei/issue/ANNIE-93/show-media-current-progress

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
