### PR TITLE
[ANNIE-104]/Enable Sentry Logs feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -3024,6 +3024,7 @@ dependencies = [
  "sentry-contexts",
  "sentry-core",
  "sentry-debug-images",
+ "sentry-log",
  "sentry-panic",
  "sentry-tracing",
  "tokio",
@@ -3088,6 +3089,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a2778a222fd90ebb01027c341a72f8e24b0c604c6126504a4fe34e5500e646"
 dependencies = [
  "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-log"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a63c02619733e917643fa91ec6744a18a1e48236cd876ce908a4c2b04f17bdf"
+dependencies = [
+ "bitflags 2.10.0",
+ "log",
  "sentry-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"
@@ -35,7 +35,7 @@ rspotify = { version = "0.15.3", default-features = false, features = [
   "client-ureq",
   "ureq-rustls-tls",
 ] }
-sentry = { version = "0.46.0", features = ["tracing"] }
+sentry = { version = "0.46.0", features = ["tracing", "logs"] }
 serde = "1.0.228"
 serde_json = "1.0.149"
 serenity = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,7 @@ async fn main() {
             release: sentry::release_name!(),
             environment: Some(environment.into()),
             traces_sample_rate: sentry_traces_sample_rate,
+            enable_logs: true,
             before_send: Some(Arc::new(|mut event| {
                 // Redact URLs with credentials from exception messages
                 for exception in event.exception.values.iter_mut() {
@@ -162,6 +163,10 @@ async fn main() {
                 }
 
                 Some(event)
+            })),
+            before_send_log: Some(Arc::new(|mut log| {
+                log.body = redact_url_credentials(&log.body);
+                Some(log)
             })),
             ..Default::default()
         },


### PR DESCRIPTION
## Summary

Enable Sentry's structured logging feature to send logs alongside errors for better debugging context.

## Changes

- Add `logs` feature flag to sentry crate
- Set `enable_logs: true` in `ClientOptions`
- Add `before_send_log` hook to redact URL credentials from log bodies (PII filtering)
- Bump version to 2.3.0

## Links

- [ANNIE-104](https://linear.app/annie-mei/issue/ANNIE-104/enable-sentry-logs-feature)
- [Sentry Rust Logs Docs](https://docs.sentry.io/platforms/rust/logs/)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
