### PR TITLE
[ANNIE-114]/Run HTTP server alongside Serenity bot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,8 +185,9 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
+ "axum",
  "blake3",
  "chrono",
  "clap",
@@ -329,6 +330,58 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1379,6 +1432,7 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1829,6 +1883,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-async"
@@ -3196,6 +3256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3801,6 +3872,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"
@@ -17,6 +17,7 @@ split-debuginfo = "packed"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+axum = "0.8"
 blake3 = "1.8"
 chrono = "0.4.43"
 clap = { version = "4", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,5 +235,7 @@ async fn main() {
     info!("Shutting down");
     client.shard_manager.shutdown_all().await;
     let _ = shutdown_tx.send(());
-    let _ = http_handle.await;
+    if let Err(e) = http_handle.await {
+        tracing::error!(error = %e, "HTTP server task join failed");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod models;
 mod schema;
+mod server;
 mod utils;
 
 use std::env;
@@ -211,8 +212,28 @@ async fn main() {
         .await
         .expect("Err creating client");
 
-    info!("Starting Discord client");
-    if let Err(why) = client.start().await {
-        println!("Client error: {why:?}");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+
+    let http_handle = tokio::spawn(async move {
+        if let Err(e) = server::run(shutdown_rx).await {
+            tracing::error!(error = %e, "HTTP server error");
+        }
+    });
+
+    info!("Starting Discord client and HTTP server");
+    tokio::select! {
+        result = client.start() => {
+            if let Err(why) = result {
+                tracing::error!(error = %why, "Discord client error");
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            info!("Received shutdown signal");
+        }
     }
+
+    info!("Shutting down");
+    client.shard_manager.shutdown_all().await;
+    let _ = shutdown_tx.send(());
+    let _ = http_handle.await;
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,25 +12,48 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[instrument(name = "http.healthz", skip_all)]
 async fn healthz() -> (StatusCode, Json<Value>) {
-    let result = tokio::task::spawn_blocking(crate::utils::redis::ping).await;
+    let (redis_result, db_result) = tokio::join!(
+        tokio::task::spawn_blocking(crate::utils::redis::ping),
+        tokio::task::spawn_blocking(crate::utils::database::ping),
+    );
 
-    let (status, redis_ok) = match result {
-        Ok(Ok(())) => (StatusCode::OK, true),
+    let redis_ok = match &redis_result {
+        Ok(Ok(())) => true,
         Ok(Err(e)) => {
             error!(error = %e, "Redis health check failed");
-            (StatusCode::SERVICE_UNAVAILABLE, false)
+            false
         }
         Err(e) => {
-            error!(error = %e, "Health check task panicked");
-            (StatusCode::INTERNAL_SERVER_ERROR, false)
+            error!(error = %e, "Redis health check task panicked");
+            false
         }
     };
 
+    let db_ok = match &db_result {
+        Ok(Ok(())) => true,
+        Ok(Err(e)) => {
+            error!(error = %e, "Database health check failed");
+            false
+        }
+        Err(e) => {
+            error!(error = %e, "Database health check task panicked");
+            false
+        }
+    };
+
+    let all_healthy = redis_ok && db_ok;
+    let status = if all_healthy {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
     let body = json!({
-        "status": if status == StatusCode::OK { "healthy" } else { "unhealthy" },
+        "status": if all_healthy { "healthy" } else { "unhealthy" },
         "version": VERSION,
         "services": {
             "redis": if redis_ok { "up" } else { "down" },
+            "database": if db_ok { "up" } else { "down" },
         }
     });
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,27 +1,40 @@
 use std::env;
 use std::net::SocketAddr;
 
-use axum::{Router, http::StatusCode, routing::get};
+use axum::{Json, Router, http::StatusCode, routing::get};
+use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tracing::{error, info, instrument};
 
 use crate::utils::statics::{DEFAULT_SERVER_PORT, SERVER_PORT};
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[instrument(name = "http.healthz", skip_all)]
-async fn healthz() -> StatusCode {
+async fn healthz() -> (StatusCode, Json<Value>) {
     let result = tokio::task::spawn_blocking(crate::utils::redis::ping).await;
 
-    match result {
-        Ok(Ok(())) => StatusCode::OK,
+    let (status, redis_ok) = match result {
+        Ok(Ok(())) => (StatusCode::OK, true),
         Ok(Err(e)) => {
             error!(error = %e, "Redis health check failed");
-            StatusCode::SERVICE_UNAVAILABLE
+            (StatusCode::SERVICE_UNAVAILABLE, false)
         }
         Err(e) => {
             error!(error = %e, "Health check task panicked");
-            StatusCode::INTERNAL_SERVER_ERROR
+            (StatusCode::INTERNAL_SERVER_ERROR, false)
         }
-    }
+    };
+
+    let body = json!({
+        "status": if status == StatusCode::OK { "healthy" } else { "unhealthy" },
+        "version": VERSION,
+        "services": {
+            "redis": if redis_ok { "up" } else { "down" },
+        }
+    });
+
+    (status, Json(body))
 }
 
 #[instrument(name = "http.server", skip_all)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,48 @@
+use std::env;
+use std::net::SocketAddr;
+
+use axum::{Router, http::StatusCode, routing::get};
+use tokio::net::TcpListener;
+use tracing::{error, info, instrument};
+
+use crate::utils::statics::{DEFAULT_SERVER_PORT, SERVER_PORT};
+
+#[instrument(name = "http.healthz", skip_all)]
+async fn healthz() -> StatusCode {
+    let result = tokio::task::spawn_blocking(crate::utils::redis::ping).await;
+
+    match result {
+        Ok(Ok(())) => StatusCode::OK,
+        Ok(Err(e)) => {
+            error!(error = %e, "Redis health check failed");
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+        Err(e) => {
+            error!(error = %e, "Health check task panicked");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
+#[instrument(name = "http.server", skip_all)]
+pub async fn run(shutdown: tokio::sync::watch::Receiver<()>) -> std::io::Result<()> {
+    let port = env::var(SERVER_PORT)
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(DEFAULT_SERVER_PORT);
+
+    let app = Router::new().route("/healthz", get(healthz));
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = TcpListener::bind(addr).await?;
+
+    info!(%addr, "HTTP server listening");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let mut shutdown = shutdown;
+            let _ = shutdown.changed().await;
+            info!("HTTP server shutting down");
+        })
+        .await
+}

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -2,6 +2,7 @@ use crate::utils::statics::DATABASE_URL;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
+use diesel::sql_query;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use std::env;
 use tracing::{error, info, instrument};
@@ -34,6 +35,14 @@ fn redact_database_url(database_url: &str) -> String {
         }
         _ => database_url.to_string(),
     }
+}
+
+#[instrument(name = "db.ping", skip_all)]
+pub fn ping() -> Result<(), diesel::result::Error> {
+    let mut conn = establish_connection();
+    sql_query("SELECT 1").execute(&mut conn)?;
+    info!("Database ping successful");
+    Ok(())
 }
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -1,4 +1,4 @@
-use redis::{Commands, Connection, RedisResult};
+use redis::{Commands, Connection, ErrorKind, RedisResult};
 use std::env;
 use tracing::{info, instrument};
 
@@ -6,7 +6,13 @@ use crate::utils::statics::REDIS_URL;
 
 #[instrument(name = "redis.get_connection", skip_all)]
 fn get_redis_client() -> RedisResult<Connection> {
-    let redis_url = env::var(REDIS_URL).expect("Expected REDIS_URL in the environment");
+    let redis_url = env::var(REDIS_URL).map_err(|e| {
+        (
+            ErrorKind::InvalidClientConfig,
+            "Missing REDIS_URL environment variable",
+            e.to_string(),
+        )
+    })?;
 
     let client = redis::Client::open(redis_url)?;
     let connection = client.get_connection()?;

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -14,6 +14,14 @@ fn get_redis_client() -> RedisResult<Connection> {
     Ok(connection)
 }
 
+#[instrument(name = "redis.ping", skip_all)]
+pub fn ping() -> RedisResult<()> {
+    let mut connection = get_redis_client()?;
+    redis::cmd("PING").query::<String>(&mut connection)?;
+    info!("Redis ping successful");
+    Ok(())
+}
+
 #[instrument(name = "redis.check_cache", fields(key = %key, key_len = key.len()))]
 pub fn check_cache(key: &str) -> RedisResult<String> {
     let mut redis_client_connection = get_redis_client().unwrap();

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -16,3 +16,5 @@ pub const SPOTIFY_CLIENT_SECRET: &str = "SPOTIFY_CLIENT_SECRET";
 pub const MAL_CLIENT_ID: &str = "MAL_CLIENT_ID";
 pub const DATABASE_URL: &str = "DATABASE_URL";
 pub const USERID_HASH_SALT: &str = "USERID_HASH_SALT";
+pub const SERVER_PORT: &str = "SERVER_PORT";
+pub const DEFAULT_SERVER_PORT: u16 = 8080;


### PR DESCRIPTION
## Summary

Adds a lightweight HTTP server running concurrently with the Serenity Discord client on the same Tokio runtime.

### Changes

- Add `axum` dependency for the HTTP server
- Add `redis::ping()` and `database::ping()` utilities for health checks
- Create `src/server.rs` with `/healthz` endpoint that pings both Redis and PostgreSQL
- Return JSON response with status, version, and per-service health
- Wire both services in `main.rs` via `tokio::select!` with graceful shutdown on Ctrl+C
- Port configurable via `SERVER_PORT` env var (default: 8080)
- Propagate missing `REDIS_URL` as `RedisError` instead of panicking
- Log HTTP task join errors instead of silently discarding them

### Health check response

```json
{
  "status": "healthy",
  "version": "2.5.0",
  "services": { "redis": "up", "database": "up" }
}
```

### Notes

- Blocking Redis/DB pings are wrapped in `spawn_blocking` and run concurrently via `tokio::join!`
- Shutdown tears down Discord shards first, then the HTTP server

Resolves [ANNIE-114](https://linear.app/annie-mei/issue/ANNIE-114/run-a-small-http-server-alongside-serenity-bot-runtime)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v2.5.0

* **New Features**
  * Added HTTP health check endpoint providing real-time service health status, including Redis and database connectivity monitoring
  * Implemented graceful shutdown sequence for improved service reliability

* **Chores**
  * Updated package version to 2.5.0
  * Added axum 0.8 web framework dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->