### PR TITLE
[ANNIE-113]/Fix Guild Fetching n+1s

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ diesel migration run     # Apply database migrations
 - Run `cargo clippy` and fix warnings
 - Use `tracing` macros for logging (`info!`, `debug!`, `error!`)
 - Add `#[instrument]` attribute to functions for tracing spans
+- Add `#[instrument]` to private/helper functions too (for example query builders and alias helpers), keeping signatures unchanged and using `skip(...)`/`fields(...)` when useful
+- When implementing review findings, first verify the current code state and only apply changes that are actually missing
 - Prefer `?` operator over `.unwrap()` for error handling
 
 ### Git Commits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ let result = task::spawn_blocking(move || {
 - Edition 2024, rustfmt edition 2024
 - Use `tracing` macros (`info!`, `debug!`, `error!`) for logging
 - Add `#[instrument]` to functions for automatic tracing spans
+- Add `#[instrument]` to private/helper functions too (for example query builders and alias helpers), keeping signatures unchanged and using `skip(...)`/`fields(...)` when useful
+- When implementing review findings, first verify the current code state and only apply changes that are actually missing
 - Prefer `?` operator over `unwrap()` where possible
 - Constants go in `src/utils/statics.rs`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "axum",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.5.2"
+version = "2.5.3"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"

--- a/src/models/user_media_list.rs
+++ b/src/models/user_media_list.rs
@@ -2,17 +2,6 @@ use serde::Deserialize;
 use std::fmt;
 
 #[derive(Deserialize, Debug)]
-pub struct UserMediaList {
-    pub data: Option<MediaList>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct MediaList {
-    #[serde(rename = "MediaList")]
-    pub media_list: Option<MediaListData>,
-}
-
-#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaListData {
     pub status: Option<MediaListStatus>,

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -1,15 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    models::{
-        db::user::User,
-        transformers::Transformers,
-        user_media_list::{MediaListData, UserMediaList},
-    },
-    utils::{
-        database::establish_connection, queries::FETCH_USER_MEDIA_LIST_DATA,
-        requests::anilist::send_request,
-    },
+    models::{db::user::User, transformers::Transformers, user_media_list::MediaListData},
+    utils::{database::establish_connection, requests::anilist::send_request},
 };
 
 use serenity::{
@@ -18,9 +11,42 @@ use serenity::{
     model::prelude::{Guild, UserId},
 };
 
+use serde::Deserialize;
 use serde_json::json;
 use tokio::task;
 use tracing::{info, instrument};
+
+#[derive(Deserialize, Debug)]
+struct BatchUserMediaListResponse {
+    data: Option<HashMap<String, Option<MediaListData>>>,
+}
+
+const MEDIA_LIST_QUERY_FIELDS: &str = "status\nscore(format: POINT_100)\nprogress\nprogressVolumes";
+
+fn media_alias(index: usize) -> String {
+    format!("media_{index}")
+}
+
+fn build_batch_media_list_query(guild_members: &[User]) -> String {
+    let media_lookups = guild_members
+        .iter()
+        .enumerate()
+        .map(|(index, user)| {
+            format!(
+                "  {}: MediaList(userId: {}, type: $type, mediaId: $mediaId) {{\n    {}\n  }}",
+                media_alias(index),
+                user.anilist_id,
+                MEDIA_LIST_QUERY_FIELDS
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        "query ($type: MediaType, $mediaId: Int) {{\n{}\n}}",
+        media_lookups
+    )
+}
 
 #[instrument(name = "discord.guild.member_ids", skip(guild), fields(member_count = guild.members.len()))]
 fn get_guild_member_ids(guild: &Guild) -> Vec<UserId> {
@@ -64,30 +90,72 @@ async fn get_guild_anilist_data(
     media_id: u32,
     media_type: String,
 ) -> HashMap<i64, MediaListData> {
-    let mut guild_members_data: HashMap<i64, MediaListData> = HashMap::new();
-    for user in guild_members {
-        let body = json!({
-            "query": FETCH_USER_MEDIA_LIST_DATA,
-            "variables": {
-                "userId": user.anilist_id,
-                "type": media_type.to_uppercase(),
-                "mediaId": media_id
-            }
-        });
-        info!("Body: {:#?}", body);
-        let user_media_list_response = task::spawn_blocking(move || send_request(body))
-            .await
-            .unwrap();
-        let user_media_list_response: UserMediaList =
-            serde_json::from_str(&user_media_list_response).unwrap();
-
-        let media_list_data = user_media_list_response.data.unwrap();
-        match media_list_data.media_list {
-            None => continue,
-            Some(data) => {
-                guild_members_data.insert(user.discord_id, data);
-            }
-        };
+    if guild_members.is_empty() {
+        return HashMap::new();
     }
+
+    let discord_ids_by_media_alias: HashMap<String, i64> = guild_members
+        .iter()
+        .enumerate()
+        .map(|(index, user)| (media_alias(index), user.discord_id))
+        .collect();
+
+    let query = build_batch_media_list_query(&guild_members);
+
+    let body = json!({
+        "query": query,
+        "variables": {
+            "type": media_type.to_uppercase(),
+            "mediaId": media_id
+        }
+    });
+
+    info!("Body: {:#?}", body);
+    let user_media_list_response = task::spawn_blocking(move || send_request(body))
+        .await
+        .unwrap();
+
+    let user_media_list_response: BatchUserMediaListResponse =
+        serde_json::from_str(&user_media_list_response).unwrap();
+
+    let mut guild_members_data: HashMap<i64, MediaListData> = HashMap::new();
+    if let Some(media_lookup_data) = user_media_list_response.data {
+        for (media_alias, media_list_data) in media_lookup_data {
+            if let (Some(discord_id), Some(data)) = (
+                discord_ids_by_media_alias.get(&media_alias),
+                media_list_data,
+            ) {
+                guild_members_data.insert(*discord_id, data);
+            }
+        }
+    }
+
     guild_members_data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_batch_media_list_query;
+    use crate::models::db::user::User;
+
+    #[test]
+    fn build_batch_media_list_query_adds_one_lookup_per_user() {
+        let guild_members = vec![
+            User {
+                discord_id: 1,
+                anilist_id: 100,
+                anilist_username: "first".to_string(),
+            },
+            User {
+                discord_id: 2,
+                anilist_id: 200,
+                anilist_username: "second".to_string(),
+            },
+        ];
+
+        let query = build_batch_media_list_query(&guild_members);
+
+        assert!(query.contains("media_0: MediaList(userId: 100, type: $type, mediaId: $mediaId)"));
+        assert!(query.contains("media_1: MediaList(userId: 200, type: $type, mediaId: $mediaId)"));
+    }
 }

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -23,10 +23,12 @@ struct BatchUserMediaListResponse {
 
 const MEDIA_LIST_QUERY_FIELDS: &str = "status\nscore(format: POINT_100)\nprogress\nprogressVolumes";
 
+#[instrument(name = "guild.media_alias")]
 fn media_alias(index: usize) -> String {
     format!("media_{index}")
 }
 
+#[instrument(name = "guild.build_batch_media_list_query", skip(guild_members), fields(member_count = guild_members.len()))]
 fn build_batch_media_list_query(guild_members: &[User]) -> String {
     let media_lookups = guild_members
         .iter()

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -14,7 +14,7 @@ use serenity::{
 use serde::Deserialize;
 use serde_json::json;
 use tokio::task;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
 
 #[derive(Deserialize, Debug)]
 struct BatchUserMediaListResponse {
@@ -113,12 +113,22 @@ async fn get_guild_anilist_data(
     });
 
     info!("Body: {:#?}", body);
-    let user_media_list_response = task::spawn_blocking(move || send_request(body))
-        .await
-        .unwrap();
+    let user_media_list_response = match task::spawn_blocking(move || send_request(body)).await {
+        Ok(response) => response,
+        Err(err) => {
+            error!("Failed to fetch guild AniList media data: {err}");
+            return HashMap::new();
+        }
+    };
 
     let user_media_list_response: BatchUserMediaListResponse =
-        serde_json::from_str(&user_media_list_response).unwrap();
+        match serde_json::from_str::<BatchUserMediaListResponse>(&user_media_list_response) {
+            Ok(response) => response,
+            Err(err) => {
+                error!("Failed to parse guild AniList media data response: {err}");
+                return HashMap::new();
+            }
+        };
 
     let mut guild_members_data: HashMap<i64, MediaListData> = HashMap::new();
     if let Some(media_lookup_data) = user_media_list_response.data {

--- a/src/utils/queries.rs
+++ b/src/utils/queries.rs
@@ -5,14 +5,3 @@ query ($username: String) {
   }
 }
 ";
-
-pub const FETCH_USER_MEDIA_LIST_DATA: &str = "
-query ($userId: Int, $type: MediaType, $mediaId: Int) {
-  MediaList(userId: $userId, type: $type, mediaId: $mediaId) {
-    status
-    score(format: POINT_100)
-    progress
-    progressVolumes
-  }
-}
-";


### PR DESCRIPTION
## Summary
- replace per-user AniList MediaList requests with a single batched GraphQL query using aliases
- map aliased results back to Discord users and keep existing response shape
- remove obsolete single-user media list query structs/constants and add batch query unit coverage

## Linear
- https://linear.app/annie-mei/issue/ANNIE-113/fix-guild-fetching-n1s
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized guild member data loading using batched queries to reduce external requests when fetching multiple users' media lists and added an early-exit when no members are present.

* **Bug Fixes**
  * Consolidated error handling for external requests to improve reliability and avoid partial failures.

* **Chores**
  * Simplified internal data model by flattening redundant wrapper layers.
  * Bumped package version.

* **Documentation**
  * Added guidance on instrumenting helper functions and verifying code state before applying changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->