### PR TITLE
[ANNIE-116]/Set up cargo-test GH Action

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,11 +1,10 @@
 on:
   workflow_dispatch:
   pull_request:
-    branches-ignore:
-      - "dependabot/*"
   push:
     branches:
       - "main"
+      - "dependabot/**"
     paths-ignore:
       - "**/README.md"
 
@@ -13,9 +12,8 @@ name: Cargo Test
 
 jobs:
   cargo-test:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always
       RUSTC_WRAPPER: ""

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,0 +1,36 @@
+on:
+  workflow_dispatch:
+  pull_request:
+    branches-ignore:
+      - "dependabot/*"
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - "**/README.md"
+
+name: Cargo Test
+
+jobs:
+  cargo-test:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    name: Run Tests
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUSTC_WRAPPER: ""
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
+      - name: Cache
+        uses: Swatinem/rust-cache@v2.8.2
+        with:
+          cache-on-failure: "true"
+          prefix-key: "annie-mei"
+          shared-key: "cargo"
+      - name: Run tests
+        run: cargo test --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "axum",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.5.3"
+version = "2.5.4"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow to run `cargo test --all-features`
- trigger on pull requests, pushes to `main`, and manual dispatch
- align workflow caching/environment with existing CI workflows
- bump crate version to `2.5.4` per repository versioning policy

Linear issue: https://linear.app/annie-mei/issue/ANNIE-116/set-up-cargo-test-gh-action
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.5.4.
  * Added a new CI workflow that runs Rust tests for pushes, pull requests, and manual triggers to provide automated validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->