### PR TITLE
[ANNIE-117]/Secure healthz access for OCI without load balancer

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,27 +79,42 @@ jobs:
     needs: build
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    env:
+      TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
           name: annie-mei-arm64
+      - name: Install cloudflared
+        run: |
+          curl -fsSL -o cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+          sudo dpkg -i cloudflared.deb
+          cloudflared --version
+      - name: Configure SSH via Cloudflare Access
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.ORACLE_SSH_KEY }}" > ~/.ssh/oracle_key
+          chmod 600 ~/.ssh/oracle_key
+          {
+            printf '%s\n' 'Host oci-via-cloudflare'
+            printf '%s\n' '  HostName ${{ secrets.CF_TUNNEL_SSH_HOSTNAME }}'
+            printf '%s\n' '  User ${{ secrets.ORACLE_USER }}'
+            printf '%s\n' '  IdentityFile ~/.ssh/oracle_key'
+            printf '%s\n' '  StrictHostKeyChecking no'
+            printf '%s\n' '  UserKnownHostsFile /dev/null'
+            printf '%s\n' '  ProxyCommand cloudflared access ssh --hostname %h --id $TUNNEL_SERVICE_TOKEN_ID --secret $TUNNEL_SERVICE_TOKEN_SECRET'
+          } > ~/.ssh/config
+          chmod 600 ~/.ssh/config
+      - name: Prepare remote directory
+        run: ssh oci-via-cloudflare "mkdir -p /opt/annie-mei/annie-mei.new"
       - name: Copy binary to server
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.ORACLE_HOST }}
-          username: ${{ secrets.ORACLE_USER }}
-          key: ${{ secrets.ORACLE_SSH_KEY }}
-          source: "annie-mei,mei.jpg"
-          target: /opt/annie-mei/annie-mei.new
-          strip_components: 0
+        run: scp annie-mei mei.jpg oci-via-cloudflare:/opt/annie-mei/annie-mei.new/
       - name: Restart service
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.ORACLE_HOST }}
-          username: ${{ secrets.ORACLE_USER }}
-          key: ${{ secrets.ORACLE_SSH_KEY }}
-          script: |
+        run: |
+          ssh oci-via-cloudflare <<'EOF'
             cd /opt/annie-mei || exit 1
             chmod +x annie-mei.new/annie-mei
             # Validate new binary before stopping service
@@ -137,3 +152,8 @@ jobs:
               exit 1
             }
             rm -f annie-mei.backup
+          EOF
+      - name: Verify /healthz over Cloudflare
+        run: |
+          curl --fail --silent --show-error --retry 6 --retry-delay 5 "https://${{ secrets.CF_HEALTHZ_HOSTNAME }}/healthz" > healthz.json
+          python3 -c 'import json; from pathlib import Path; payload = json.loads(Path("healthz.json").read_text()); assert payload.get("status") == "healthy", f"Unexpected health payload: {payload}"; print("Cloudflare health check passed")'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.5.4"
+version = "2.5.5"
 dependencies = [
  "axum",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"

--- a/src/server.rs
+++ b/src/server.rs
@@ -69,7 +69,7 @@ pub async fn run(shutdown: tokio::sync::watch::Receiver<()>) -> std::io::Result<
 
     let app = Router::new().route("/healthz", get(healthz));
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(addr).await?;
 
     info!(%addr, "HTTP server listening");


### PR DESCRIPTION
## Summary
- Route release deploys through Cloudflare Access SSH by installing `cloudflared`, configuring an SSH proxy host, and replacing direct Oracle SCP/SSH actions.
- Add post-deploy validation by checking `https://4{{ secrets.CF_HEALTHZ_HOSTNAME }}/healthz` from CI to confirm external health endpoint availability.
- Reduce direct exposure by binding the internal health server to localhost and bump the app version to `2.5.5` for this patch release.

## Linear
- https://linear.app/annie-mei/issue/ANNIE-117/secure-healthz-access-for-oci-without-load-balancer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.5.5
  * Server configuration updated to listen on localhost only, restricting access to local connections
  * Deployment infrastructure enhanced with improved security validations and health check monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->