### PR TITLE
[ANNIE-55]/Rewrite diesel connection logic using r2d2 pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.5.5"
+version = "2.5.6"
 dependencies = [
  "axum",
  "blake3",
@@ -872,6 +872,7 @@ dependencies = [
  "downcast-rs",
  "itoa",
  "pq-sys",
+ "r2d2",
 ]
 
 [[package]]
@@ -2567,6 +2568,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3018,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.5.5"
+version = "2.5.6"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"
@@ -21,7 +21,7 @@ axum = "0.8"
 blake3 = "1.8"
 chrono = "0.4.44"
 clap = { version = "4", features = ["derive"] }
-diesel = { version = "2.3.6", features = ["postgres"] }
+diesel = { version = "2.3.6", features = ["postgres", "r2d2"] }
 diesel_migrations = "2.3.1"
 env_logger = "0.11.9"
 futures = "0.3.32"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -104,7 +104,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 None
             } else {
                 let also_anime = anime_response.clone();
-                let data = get_guild_data_for_media(also_anime, guild_members).await;
+                let data = get_guild_data_for_media(ctx, also_anime, guild_members).await;
                 info!("Guild members data: {} entries", data.len());
                 if data.is_empty() { None } else { Some(data) }
             }

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -104,7 +104,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 None
             } else {
                 let also_manga = manga_response.clone();
-                let data = get_guild_data_for_media(also_manga, guild_members).await;
+                let data = get_guild_data_for_media(ctx, also_manga, guild_members).await;
                 info!("Guild members data: {} entries", data.len());
                 if data.is_empty() { None } else { Some(data) }
             }

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -43,14 +43,26 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         _ => panic!("Invalid argument type"),
     };
 
-    let response_message = register_new_user(anilist_username.to_owned(), user).await;
+    let Some(database_pool) = database::get_pool_from_context(ctx).await else {
+        let builder = EditInteractionResponse::new()
+            .content("Database is not initialized. Please try again later.");
+        let _register = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    };
+
+    let response_message =
+        register_new_user(anilist_username.to_owned(), user, database_pool).await;
 
     let builder = EditInteractionResponse::new().content(response_message);
     let _register = interaction.edit_response(&ctx.http, builder).await;
 }
 
-#[instrument(name = "command.register.register_new_user", skip(user), fields(discord_user_id = %hash_user_id(user.id.get()), username_len = anilist_username.len()))]
-async fn register_new_user(anilist_username: String, user: &serenity::model::user::User) -> String {
+#[instrument(name = "command.register.register_new_user", skip(user, database_pool), fields(discord_user_id = %hash_user_id(user.id.get()), username_len = anilist_username.len()))]
+async fn register_new_user(
+    anilist_username: String,
+    user: &serenity::model::user::User,
+    database_pool: database::DbPool,
+) -> String {
     let username = anilist_username.to_string();
     let anilist_id =
         task::spawn_blocking(move || User::get_anilist_id_from_username(username.as_ref()))
@@ -64,7 +76,7 @@ async fn register_new_user(anilist_username: String, user: &serenity::model::use
         );
     };
 
-    let connection = &mut database::establish_connection();
+    let connection = &mut database::get_connection(&database_pool);
 
     {
         let anilist_id = anilist_id.unwrap();

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -14,7 +14,7 @@ use serenity::{
     model::application::CommandOptionType,
 };
 use tokio::task;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("register")
@@ -76,26 +76,43 @@ async fn register_new_user(
         );
     };
 
-    let connection = &mut database::get_connection(&database_pool);
+    let discord_id = user.id.get() as i64;
+    let user_name = user.name.clone();
+    let anilist_id = anilist_id.unwrap();
+    let anilist_username_for_db = anilist_username.clone();
 
-    {
-        let anilist_id = anilist_id.unwrap();
+    let db_write_result = task::spawn_blocking(move || {
+        let mut connection = database::get_connection(&database_pool);
         User::create_or_update_user(
-            user.id.get() as i64,
+            discord_id,
             anilist_id,
-            anilist_username.to_owned(),
-            connection,
+            anilist_username_for_db,
+            &mut connection,
         );
+    })
+    .await;
 
-        info!(
-            discord_user_id = %hash_user_id(user.id.get()),
-            anilist_id,
-            anilist_username = %anilist_username,
-            "Created user with details"
+    if let Err(err) = db_write_result {
+        error!(
+            error = %err,
+            discord_user_id = %hash_user_id(discord_id as u64),
+            "Failed to save user registration"
         );
-        format!(
-            "Hello {}, I have linked the Anilist account {} to your user.",
-            user.name, anilist_username
-        )
+        return format!(
+            "Hello {}, I hit an internal error while linking your Anilist account. Please try again later.",
+            user_name
+        );
     }
+
+    info!(
+        discord_user_id = %hash_user_id(discord_id as u64),
+        anilist_id,
+        anilist_username = %anilist_username,
+        "Created user with details"
+    );
+
+    format!(
+        "Hello {}, I have linked the Anilist account {} to your user.",
+        user_name, anilist_username
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use serenity::{
 };
 
 use utils::{
-    database::run_migration,
+    database::{DatabasePoolKey, create_pool, get_connection, run_migration},
     privacy::{hash_user_id, redact_url_credentials},
     statics::{DISCORD_TOKEN, ENV, SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE},
 };
@@ -196,8 +196,9 @@ async fn main() {
         );
     }
 
-    info!("Initializing database connection");
-    let connection = &mut utils::database::establish_connection();
+    info!("Initializing database connection pool");
+    let database_pool = create_pool();
+    let connection = &mut get_connection(&database_pool);
     run_migration(connection);
 
     let token = env::var(DISCORD_TOKEN).expect("Expected a token in the environment");
@@ -212,10 +213,16 @@ async fn main() {
         .await
         .expect("Err creating client");
 
+    {
+        let mut data = client.data.write().await;
+        data.insert::<DatabasePoolKey>(database_pool.clone());
+    }
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let http_database_pool = database_pool.clone();
 
     let http_handle = tokio::spawn(async move {
-        if let Err(e) = server::run(shutdown_rx).await {
+        if let Err(e) = server::run(shutdown_rx, http_database_pool).await {
             tracing::error!(error = %e, "HTTP server error");
         }
     });

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::net::SocketAddr;
 
-use axum::{Json, Router, http::StatusCode, routing::get};
+use axum::{Json, Router, extract::State, http::StatusCode, routing::get};
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tracing::{error, info, instrument};
@@ -11,10 +11,13 @@ use crate::utils::statics::{DEFAULT_SERVER_PORT, SERVER_PORT};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[instrument(name = "http.healthz", skip_all)]
-async fn healthz() -> (StatusCode, Json<Value>) {
+async fn healthz(
+    State(database_pool): State<crate::utils::database::DbPool>,
+) -> (StatusCode, Json<Value>) {
+    let health_check_pool = database_pool.clone();
     let (redis_result, db_result) = tokio::join!(
         tokio::task::spawn_blocking(crate::utils::redis::ping),
-        tokio::task::spawn_blocking(crate::utils::database::ping),
+        tokio::task::spawn_blocking(move || crate::utils::database::ping(&health_check_pool)),
     );
 
     let redis_ok = match &redis_result {
@@ -61,13 +64,18 @@ async fn healthz() -> (StatusCode, Json<Value>) {
 }
 
 #[instrument(name = "http.server", skip_all)]
-pub async fn run(shutdown: tokio::sync::watch::Receiver<()>) -> std::io::Result<()> {
+pub async fn run(
+    shutdown: tokio::sync::watch::Receiver<()>,
+    database_pool: crate::utils::database::DbPool,
+) -> std::io::Result<()> {
     let port = env::var(SERVER_PORT)
         .ok()
         .and_then(|p| p.parse().ok())
         .unwrap_or(DEFAULT_SERVER_PORT);
 
-    let app = Router::new().route("/healthz", get(healthz));
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .with_state(database_pool);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(addr).await?;

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -2,23 +2,50 @@ use crate::utils::statics::DATABASE_URL;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::sql_query;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+use serenity::{client::Context, prelude::TypeMapKey};
 use std::env;
 use tracing::{error, info, instrument};
 
-#[instrument(name = "db.establish_connection", skip_all)]
-pub fn establish_connection() -> PgConnection {
+pub type DbPool = Pool<ConnectionManager<PgConnection>>;
+pub type DbConnection = PooledConnection<ConnectionManager<PgConnection>>;
+
+pub struct DatabasePoolKey;
+
+impl TypeMapKey for DatabasePoolKey {
+    type Value = DbPool;
+}
+
+#[instrument(name = "db.create_pool", skip_all)]
+pub fn create_pool() -> DbPool {
     let database_url = env::var(DATABASE_URL).expect("DATABASE_URL must be set");
-    PgConnection::establish(&database_url).unwrap_or_else(|error| {
+    let manager = ConnectionManager::<PgConnection>::new(database_url.clone());
+
+    Pool::builder().build(manager).unwrap_or_else(|error| {
         let redacted_url = redact_database_url(&database_url);
         error!(
             error = %error,
             database_url = %redacted_url,
-            "Failed to connect to database"
+            "Failed to create database connection pool"
         );
-        panic!("Error connecting to {redacted_url}: {error}")
+        panic!("Error creating pool for {redacted_url}: {error}")
     })
+}
+
+#[instrument(name = "db.get_connection", skip(pool))]
+pub fn get_connection(pool: &DbPool) -> DbConnection {
+    pool.get().unwrap_or_else(|error| {
+        error!(error = %error, "Failed to get database connection from pool");
+        panic!("Error retrieving pooled database connection: {error}")
+    })
+}
+
+#[instrument(name = "db.pool_from_context", skip(ctx))]
+pub async fn get_pool_from_context(ctx: &Context) -> Option<DbPool> {
+    let data = ctx.data.read().await;
+    data.get::<DatabasePoolKey>().cloned()
 }
 
 fn redact_database_url(database_url: &str) -> String {
@@ -38,8 +65,8 @@ fn redact_database_url(database_url: &str) -> String {
 }
 
 #[instrument(name = "db.ping", skip_all)]
-pub fn ping() -> Result<(), diesel::result::Error> {
-    let mut conn = establish_connection();
+pub fn ping(pool: &DbPool) -> Result<(), diesel::result::Error> {
+    let mut conn = get_connection(pool);
     sql_query("SELECT 1").execute(&mut conn)?;
     info!("Database ping successful");
     Ok(())

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use crate::{
     models::{db::user::User, transformers::Transformers, user_media_list::MediaListData},
-    utils::{database::establish_connection, requests::anilist::send_request},
+    utils::{
+        database::{get_connection, get_pool_from_context},
+        requests::anilist::send_request,
+    },
 };
 
 use serenity::{
@@ -74,14 +77,30 @@ pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction
         .unwrap_or_default()
 }
 
-#[instrument(name = "guild.fetch_media_data", skip(media, guild_members), fields(member_count = guild_members.len()))]
+#[instrument(name = "guild.fetch_media_data", skip(ctx, media, guild_members), fields(member_count = guild_members.len()))]
 pub async fn get_guild_data_for_media<T: Transformers>(
+    ctx: &Context,
     media: T,
     guild_members: Vec<UserId>,
 ) -> HashMap<i64, MediaListData> {
-    let mut conn = establish_connection();
-    let anilist_users = User::get_users_by_discord_id(guild_members, &mut conn);
-    let anilist_users = anilist_users.unwrap();
+    let Some(database_pool) = get_pool_from_context(ctx).await else {
+        error!("Database pool is not available in Serenity context");
+        return HashMap::new();
+    };
+
+    let anilist_users = match task::spawn_blocking(move || {
+        let mut conn = get_connection(&database_pool);
+        User::get_users_by_discord_id(guild_members, &mut conn)
+    })
+    .await
+    {
+        Ok(Some(users)) => users,
+        Ok(None) => return HashMap::new(),
+        Err(err) => {
+            error!(error = %err, "Failed to fetch registered guild members from database");
+            return HashMap::new();
+        }
+    };
 
     get_guild_anilist_data(anilist_users, media.get_id(), media.get_type()).await
 }


### PR DESCRIPTION
## Summary
This PR rewrites Diesel DB usage to use a shared r2d2 connection pool instead of establishing a new PostgreSQL connection per operation, wires that pool through bot/runtime state, and moves register DB writes off the async runtime via `spawn_blocking`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- 406e28f4ff7de053364499a2dba1eb035d8e5930: Replace per-call Diesel connections with a shared r2d2 pool, add typed pool helpers/state key, and use pooled connections in register/guild DB paths plus healthz DB ping.
- 406e28f4ff7de053364499a2dba1eb035d8e5930: Enable Diesel `r2d2` feature and bump crate version/lockfile to 2.5.6.
- 33b81c5b1262ff7907f3756e3f9849889f633b88: Wrap register command DB write path (`get_connection` + `create_or_update_user`) in `tokio::task::spawn_blocking`, moving owned values into the closure and handling join errors.

### Notes
- Rebase onto latest `main` introduced version conflicts; resolved by applying the next patch bump (`2.5.6`) to keep semver progression consistent.

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `RUSTC_WRAPPER= cargo clippy --all-targets --all-features`
- [x] `RUSTC_WRAPPER= cargo test --all-targets`
- [ ] Discord runtime QA (not executed in this environment)

## References
- Linear issue: https://linear.app/annie-mei/issue/ANNIE-55/re-write-diesel-connection-logic-using-connection-pool
- PR: https://github.com/annie-mei/annie-mei/pull/236

---
This PR description was written by GPT-5.3-Codex.
