### PR TITLE
[ANNIE-80] Only allow NSFW searches in NSFW channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "axum",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.93"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -7,9 +7,10 @@ use crate::{
     },
     models::{anilist_anime::Anime, transformers::Transformers, user_media_list::MediaListData},
     utils::{
+        channel::is_nsfw_channel,
         guild::{get_current_guild_members, get_guild_data_for_media},
         privacy::configure_sentry_scope,
-        statics::NOT_FOUND_ANIME,
+        statics::{NOT_FOUND_ANIME, NSFW_NOT_ALLOWED},
     },
 };
 
@@ -94,6 +95,16 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
             }
         };
 
+    // Block adult content in non-NSFW channels.
+    if let Some(ref anime) = anime_result
+        && anime.is_adult()
+        && !is_nsfw_channel(ctx, interaction.channel_id).await
+    {
+        let builder = EditInteractionResponse::new().content(NSFW_NOT_ALLOWED);
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
+
     // Gather guild-member data when the anime was found.
     let guild_members_data = match &anime_result {
         None => None,
@@ -143,6 +154,7 @@ mod tests {
             "type": "ANIME",
             "id": 21,
             "idMal": 21,
+            "isAdult": false,
             "title": {
                 "romaji": "One Piece",
                 "english": "One Piece",

--- a/src/commands/anime/queries.rs
+++ b/src/commands/anime/queries.rs
@@ -4,6 +4,7 @@ query ($id: Int) {
     type
     id
     idMal
+    isAdult
     title {
       romaji
       english
@@ -69,6 +70,7 @@ query ($page: Int, $perPage: Int, $search: String) {
       type
       id
       idMal
+      isAdult
       title {
         romaji
         english

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -7,9 +7,10 @@ use crate::{
     },
     models::{anilist_manga::Manga, transformers::Transformers, user_media_list::MediaListData},
     utils::{
+        channel::is_nsfw_channel,
         guild::{get_current_guild_members, get_guild_data_for_media},
         privacy::configure_sentry_scope,
-        statics::NOT_FOUND_MANGA,
+        statics::{NOT_FOUND_MANGA, NSFW_NOT_ALLOWED},
     },
 };
 
@@ -94,6 +95,16 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
             }
         };
 
+    // Block adult content in non-NSFW channels.
+    if let Some(ref manga) = manga_result
+        && manga.is_adult()
+        && !is_nsfw_channel(ctx, interaction.channel_id).await
+    {
+        let builder = EditInteractionResponse::new().content(NSFW_NOT_ALLOWED);
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
+
     // Gather guild-member data when the manga was found.
     let guild_members_data = match &manga_result {
         None => None,
@@ -143,6 +154,7 @@ mod tests {
             "type": "MANGA",
             "id": 30013,
             "idMal": 13,
+            "isAdult": false,
             "title": {
                 "romaji": "One Piece",
                 "english": "One Piece",

--- a/src/commands/manga/queries.rs
+++ b/src/commands/manga/queries.rs
@@ -4,6 +4,7 @@ query ($id: Int) {
     type
     id
     idMal
+    isAdult
     title {
       romaji
       english
@@ -73,6 +74,7 @@ query ($page: Int, $perPage: Int, $search: String) {
       type
       id
       idMal
+      isAdult
       title {
         romaji
         english

--- a/src/models/anilist_anime.rs
+++ b/src/models/anilist_anime.rs
@@ -19,6 +19,7 @@ pub struct Anime {
     #[allow(dead_code)]
     id: u32,
     id_mal: Option<u32>,
+    is_adult: Option<bool>,
     title: Title,
     synonyms: Option<Vec<String>>,
     season: Option<String>,
@@ -164,6 +165,10 @@ impl Transformers for Anime {
 
     fn get_type(&self) -> String {
         self.media_type.as_ref().unwrap().to_string().to_lowercase()
+    }
+
+    fn is_adult(&self) -> bool {
+        self.is_adult.unwrap_or(false)
     }
 
     fn get_mal_id(&self) -> Option<u32> {
@@ -316,6 +321,7 @@ mod tests {
             "type": "ANIME",
             "id": 1,
             "idMal": null,
+            "isAdult": false,
             "title": {
                 "romaji": "Sample",
                 "english": "Sample",

--- a/src/models/anilist_manga.rs
+++ b/src/models/anilist_manga.rs
@@ -21,6 +21,7 @@ pub struct Manga {
     #[allow(dead_code)]
     id: u32,
     id_mal: Option<u32>,
+    is_adult: Option<bool>,
     title: Title,
     synonyms: Option<Vec<String>>,
     start_date: Option<AnilistDate>,
@@ -202,6 +203,10 @@ impl Transformers for Manga {
         self.media_type.as_ref().unwrap().to_string().to_lowercase()
     }
 
+    fn is_adult(&self) -> bool {
+        self.is_adult.unwrap_or(false)
+    }
+
     fn get_mal_id(&self) -> Option<u32> {
         self.id_mal
     }
@@ -315,6 +320,7 @@ mod tests {
             "type": "MANGA",
             "id": 1,
             "idMal": null,
+            "isAdult": false,
             "title": {
                 "romaji": "Sample",
                 "english": "Sample",

--- a/src/models/transformers.rs
+++ b/src/models/transformers.rs
@@ -14,6 +14,7 @@ use serenity::all::{CreateEmbed, CreateEmbedFooter};
 pub trait Transformers {
     fn get_id(&self) -> u32;
     fn get_type(&self) -> String;
+    fn is_adult(&self) -> bool;
     fn get_mal_id(&self) -> Option<u32>;
     fn get_english_title(&self) -> Option<String>;
     fn get_romaji_title(&self) -> Option<String>;

--- a/src/utils/channel.rs
+++ b/src/utils/channel.rs
@@ -1,0 +1,16 @@
+use serenity::all::{Channel, ChannelId};
+use serenity::client::Context;
+use tracing::instrument;
+
+/// Returns `true` when the given channel is marked as NSFW (age-restricted).
+///
+/// For guild text channels this checks the `nsfw` flag.
+/// DM channels and any channels that cannot be resolved are treated as
+/// **not** NSFW (i.e. adult content will be blocked).
+#[instrument(name = "utils.channel.is_nsfw", skip(ctx), fields(channel_id = %channel_id))]
+pub async fn is_nsfw_channel(ctx: &Context, channel_id: ChannelId) -> bool {
+    match channel_id.to_channel(&ctx.http).await {
+        Ok(Channel::Guild(gc)) => gc.nsfw,
+        _ => false,
+    }
+}

--- a/src/utils/channel.rs
+++ b/src/utils/channel.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 /// **not** NSFW (i.e. adult content will be blocked).
 #[instrument(name = "utils.channel.is_nsfw", skip(ctx), fields(channel_id = %channel_id))]
 pub async fn is_nsfw_channel(ctx: &Context, channel_id: ChannelId) -> bool {
-    match channel_id.to_channel(&ctx.http).await {
+    match channel_id.to_channel(ctx).await {
         Ok(Channel::Guild(gc)) => gc.nsfw,
         _ => false,
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod channel;
 pub mod database;
 pub mod fetch_by_arguments;
 pub mod formatter;

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -1,5 +1,7 @@
 pub const NOT_FOUND_ANIME: &str = "No such anime";
 pub const NOT_FOUND_MANGA: &str = "No such manga";
+pub const NSFW_NOT_ALLOWED: &str =
+    "This content is age-restricted and can only be viewed in NSFW channels";
 pub const EMPTY_STR: &str = "-";
 pub const ANILIST_STATUS_RELEASING: &str = "RELEASING";
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Blocks adult/NSFW anime and manga results from being displayed in non-NSFW Discord channels. This is required for Top.gg compliance.

When a search result has `isAdult: true` from AniList and the channel is not marked as age-restricted, the bot responds with a short denial message instead of the embed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes

- 2f40fc9002b741dff59489c09eac869281f0cc58: Add `isAdult` to AniList GraphQL queries, model structs, `Transformers` trait, and gate adult results behind NSFW channel checks in anime/manga command adapters
- 5ef84b5c88eb84b4527861b162409c00251fdb8a: Bump version to 2.7.0

### Notes

- `isAdult` is fetched from AniList in all four queries (anime/manga × by-ID/by-search)
- `is_adult()` on the `Transformers` trait defaults to `false` when the field is absent
- The new `is_nsfw_channel()` utility resolves the channel via HTTP and checks the guild channel `nsfw` flag; DM channels and unresolvable channels are treated as non-NSFW (adult content blocked)
- The NSFW check runs in the adapter (`run()`) after fetching data but before guild-member lookups, so no unnecessary work is done for blocked results

## Validation

- [x] `cargo test` — 48 tests pass
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt` — clean
- [ ] Discord QA: search for a known adult anime (e.g. AniList ID 101759) in a regular channel (blocked) vs an NSFW channel (allowed)

## References

- [ANNIE-80](https://linear.app/annie-mei/issue/ANNIE-80/only-allow-nsfw-searches-in-nsfw-channels)
- [AniList GraphQL `isAdult` field](https://anilist.gitbook.io/anilist-apiv2-docs/)

---

This PR description was written by Claude Sonnet 4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
