### PR TITLE
[ANNIE-124]/upgrade-rust-cache-action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: apt-get update && apt-get install -y libpq-dev
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.9.1
         with:
           cache-on-failure: "true"
           prefix-key: "annie-mei"
@@ -145,7 +145,7 @@ jobs:
             sudo systemctl start annie-mei
             # Verify service started
             sleep 2
-            sudo systemctl is-active annie-mei || { 
+            sudo systemctl is-active annie-mei || {
               echo "Service failed to start, rolling back"
               mv annie-mei.backup annie-mei
               sudo systemctl start annie-mei

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Cache
-        uses: Swatinem/rust-cache@v2.8.2
+        uses: Swatinem/rust-cache@v2.9.1
         with:
           cache-on-failure: "true"
           prefix-key: "annie-mei"

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - name: Cache
-        uses: Swatinem/rust-cache@v2.8.2
+        uses: Swatinem/rust-cache@v2.9.1
         with:
           cache-on-failure: "true"
           prefix-key: "annie-mei"


### PR DESCRIPTION
## Summary
Upgrade all GitHub Actions workflow usages of Swatinem/rust-cache to v2.9.1.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- 175223bc0ecaaf75b03b86bc85acd290bdcf0cb8: bump rust-cache to v2.9.1 in clippy, test, and release workflows

### Notes
- A pre-commit hook also removed trailing whitespace in `.github/workflows/build-release.yml`.

## Validation
- [x] `RUSTC_WRAPPER="" cargo fmt --check`
- [x] `RUSTC_WRAPPER="" cargo clippy --all-targets --all-features` (passes with pre-existing dead_code warnings)
- [x] `RUSTC_WRAPPER="" cargo test --all-features`
- [x] pre-commit checks: trailing-whitespace, end-of-file-fixer, check-yaml

## References (optional)
- https://github.com/Swatinem/rust-cache/releases/tag/v2.9.1

---

This PR description was written by GPT-5.3-Codex.
