### PR TITLE
[ANNIE-122]/make-sccache-opt-in-remove-ci-workarounds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
-[build]
-rustc-wrapper = "sccache"
+# sccache is opt-in via environment variable (RUSTC_WRAPPER=sccache)
+# rather than hardcoded here, so environments without sccache installed
+# (CI, Factory cloud) don't fail. See ANNIE-122 for rationale.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,7 +23,6 @@ jobs:
     container: rust:1-bullseye
     env:
       CARGO_TERM_COLOR: always
-      RUSTC_WRAPPER: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always
-      RUSTC_WRAPPER: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always
-      RUSTC_WRAPPER: ""
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary

Make sccache opt-in rather than hardcoded, eliminating Factory cloud setup failures and removing unnecessary CI workarounds.

## Type of Change

- [ ] Bug fix
- [x] Refactor
- [x] Infrastructure

## Changes
- 2fb67221927cedd5f851704db06ce9bc862bd15d: Remove hardcoded `rustc-wrapper = "sccache"` from `.cargo/config.toml`, remove `RUSTC_WRAPPER: ""` overrides from all 3 CI workflows

### Notes

Evaluated shared remote sccache (S3/R2/Redis) and decided against it — cross-architecture builds (macOS ARM64 / Linux x86_64 / Linux ARM64 container) produce different artifacts so cache sharing is limited, and `Swatinem/rust-cache@v2` already covers CI caching. Full rationale is documented as a comment on ANNIE-122.

Developers who want sccache locally can opt in via `export RUSTC_WRAPPER=sccache` or `~/.cargo/config.toml`.

## Validation
- [x] CI workflows pass without `RUSTC_WRAPPER` override
- [x] Local `cargo check` / `cargo clippy` work without sccache installed

## References
- [ANNIE-122](https://linear.app/annie-mei/issue/ANNIE-122/evaluate-shared-sccache-for-local-ci-and-factory-cloud-builds)

---

This PR description was written by Claude Sonnet 4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use environment-based settings for the Rust compiler wrapper instead of hard-coded configuration files.
  * Streamlined CI/CD workflows to align with the new build configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->