### PR TITLE
[ANNIE-120]/harden-rust-ci-cache-policy

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
       - name: Install Rust
         run: |
-          toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
           rustup toolchain install "$toolchain" --profile minimal
       - name: Install dependencies
         run: apt-get update && apt-get install -y libpq-dev

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
       - name: Install Rust
-        run: rustup update stable && rustup default stable
+        run: |
+          toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
       - name: Install dependencies
         run: apt-get update && apt-get install -y libpq-dev
       - name: Cache

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           cache-on-failure: "true"
           prefix-key: "annie-mei"
-          shared-key: "cargo"
+          shared-key: "cargo-release"
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       - name: Build
         run: cargo build --release
       - name: Upload debug symbols to Sentry

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install Rust
-        run: rustup update stable && rustup default stable
+        run: |
+          toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Cache

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Rust
         run: |
-          toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
           rustup toolchain install "$toolchain" --profile minimal
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libpq-dev

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           cache-on-failure: "true"
           prefix-key: "annie-mei"
-          shared-key: "cargo"
+          shared-key: "cargo-ci"
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       - name: Run tests
         run: cargo test --all-features

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Build-checkout
         uses: actions/checkout@v6
       - name: Install Rust
-        run: rustup update stable && rustup default stable
+        run: |
+          toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
       - name: Cache
         uses: Swatinem/rust-cache@v2.9.1
         with:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -32,7 +32,9 @@ jobs:
         with:
           cache-on-failure: "true"
           prefix-key: "annie-mei"
-          shared-key: "cargo"
+          shared-key: "cargo-ci"
+          key: "clippy-tooling"
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       - name: Install crates
         run: cargo install clippy-sarif sarif-fmt
       - name: Run Clippy

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Rust
         run: |
-          toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
+          toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
           rustup toolchain install "$toolchain" --profile minimal --component clippy
       - name: Cache
         uses: Swatinem/rust-cache@v2.9.1

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Rust
         run: |
           toolchain="$(awk -F'"' '/^channel/ { print $2 }' rust-toolchain.toml)"
-          rustup toolchain install "$toolchain" --profile minimal
+          rustup toolchain install "$toolchain" --profile minimal --component clippy
       - name: Cache
         uses: Swatinem/rust-cache@v2.9.1
         with:


### PR DESCRIPTION
## Summary
Improve Rust CI cache reuse and stability by scoping cache writes to trusted refs, separating cache namespaces by workload, and aligning workflow Rust installation with the pinned `rust-toolchain.toml` channel.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- a753c71c481fdf8c203e1dd0f32b588bbc6a5d3a: scope rust-cache save behavior to `main`/tags and split shared keys between CI and release workflows
- 176a65dd9d02e6ec3696f9cb9f3fa83889cfca1e: replace rolling `stable` updates with install of the pinned toolchain channel from `rust-toolchain.toml` in all Rust workflows
- 32da1daa22f263f2481f41e0758ec658c0433b2f: install the `clippy` component explicitly when using the minimal profile in the clippy workflow
- 0bad48669f9b3262015a8c0b2ede40a9388bd9a6: make toolchain-channel extraction whitespace-tolerant in all workflow install steps

### Notes
This keeps PR runs fast via cache restore while reducing cache churn from branch-specific cache writes. It also prevents release artifacts from sharing the same rust-cache namespace as lint/test jobs.

## Validation
- [x] YAML parse check for `.github/workflows/*.yml`
- [x] `cargo fmt --check`
- [ ] `cargo clippy --all-targets -- -D warnings` (fails due to unrelated pre-existing dead-code warnings in `src/utils/llm.rs` and `src/utils/statics.rs`)

## References
- https://github.com/Swatinem/rust-cache

---

This PR description was written by GPT-5.
