### PR TITLE
[ANNIE-131]/clarify AniList relink guidance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -28,17 +28,17 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
         )
         .field(
             "Get started",
-            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime` or `/manga` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links",
+            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime` or `/manga` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it",
             false,
         )
         .field(
             "Commands",
-            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth linking flow\n`/ping` - bot health check\n`/help` - show this guide",
+            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/ping` - bot health check\n`/help` - show this guide",
             false,
         )
         .field(
             "Tips",
-            "You can search with full names, short names, or AniList IDs. If the AniList link page expires or fails, run `/register` again to get a fresh secure link.",
+            "You can search with full names, short names, or AniList IDs. If the AniList link page expires or fails, or if you need to reconnect your AniList account later, run `/register` again to get a fresh secure link.",
             false,
         )
         .footer(CreateEmbedFooter::new("Annie Mei"))

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -14,7 +14,8 @@ use serenity::{
 use tracing::{error, info, instrument};
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("register").description("Link your AniList account with a secure OAuth flow")
+    CreateCommand::new("register")
+        .description("Link or relink your AniList account with a secure OAuth flow")
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -38,7 +39,7 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
 
     RegisterResponse {
         content: format!(
-            "Click the button below to link your AniList account. This secure link is only for you and {expires_in}. If the page says the link expired or failed, run `/register` again in Discord.",
+            "Click the button below to link your AniList account. This secure link is only for you and {expires_in}. If the page says the link expired or failed, or if you ever need to reconnect AniList later, run `/register` again in Discord.",
         ),
         oauth_url: Some(oauth_url.to_string()),
     }
@@ -140,6 +141,7 @@ mod tests {
         assert!(response.content.contains("only for you"));
         assert!(response.content.contains("about 5 minutes"));
         assert!(response.content.contains("run `/register` again"));
+        assert!(response.content.contains("reconnect AniList later"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Clarify that `/register` is both the AniList link and relink path now that ANNIE-131 is scoped around expiry awareness plus relink handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 2ca7024a0e388f2786a5020bce9a14534e455ec1: update `/register` and `/help` copy so users are explicitly told to rerun `/register` when they need to relink AniList after expiry or a failed auth page

### Notes

The bot does not currently consume stored AniList OAuth tokens directly, so the concrete bot-side ANNIE-131 follow-up is user guidance rather than token-refresh runtime logic. The auth service PR handles expiry metadata and relink-required state.

### High-risk resources

- Discord slash-command copy and user-facing onboarding text

## Validation
- [x] `cargo fmt`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (currently blocked by pre-existing dead-code warnings in `src/utils/llm.rs` and `src/utils/statics.rs`)

## References (optional)

- ANNIE-131
- auth PR: https://github.com/annie-mei/auth/pull/12

---

This PR description was written by Amp.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
