### PR TITLE
[ANNIE-143]/add whoami command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.9.1"
+version = "2.10.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 - Fetch detailed anime/manga information from AniList
 - Look up opening and ending theme songs with Spotify links
 - Link your AniList account with a secure OAuth flow to show guild members' scores
-- Check your currently linked AniList account from Discord
+- Check your currently linked AniList account
 - Full Japanese kana support for searches
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 - Fetch detailed anime/manga information from AniList
 - Look up opening and ending theme songs with Spotify links
 - Link your AniList account with a secure OAuth flow to show guild members' scores
+- Check your currently linked AniList account from Discord
 - Full Japanese kana support for searches
 
 ## Commands
@@ -21,7 +22,8 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 |---------|-------------|
 | `/help` | Shows available commands |
 | `/ping` | Bot health check |
-| `/register` | Start the secure AniList OAuth linking flow |
+| `/register` | Start or refresh the secure AniList OAuth linking flow |
+| `/whoami` | Show your linked AniList username and profile link |
 | `/anime <search>` | Look up anime by name or AniList ID |
 | `/manga <search>` | Look up manga by name or AniList ID |
 | `/songs <search>` | Find theme songs for an anime |

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -33,7 +33,7 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
         )
         .field(
             "Commands",
-            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/ping` - bot health check\n`/help` - show this guide",
+            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
             false,
         )
         .field(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod register;
 pub mod response;
 pub mod songs;
 pub mod traits;
+pub mod whoami;

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -1,0 +1,128 @@
+use crate::{
+    commands::response::CommandResponse,
+    models::db::user::User,
+    utils::{
+        database,
+        privacy::{configure_sentry_scope, hash_user_id},
+    },
+};
+
+use serenity::{
+    all::{CommandInteraction, EditInteractionResponse},
+    builder::CreateCommand,
+    client::Context,
+};
+use tokio::task;
+use tracing::{error, instrument};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkedAniListProfile {
+    pub username: String,
+}
+
+impl LinkedAniListProfile {
+    fn profile_url(&self) -> String {
+        format!("https://anilist.co/user/{}", self.username)
+    }
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("whoami").description("Show your currently linked AniList account")
+}
+
+#[instrument(name = "command.whoami.handle", skip(profile))]
+pub fn handle_whoami(profile: Option<LinkedAniListProfile>) -> CommandResponse {
+    match profile {
+        Some(profile) => CommandResponse::Content(format!(
+            "Your linked AniList account is **{}**.\nProfile: <{}>",
+            profile.username,
+            profile.profile_url()
+        )),
+        None => CommandResponse::Content(
+            "You have not linked an AniList account yet. Run `/register anilist:<username>` first."
+                .to_string(),
+        ),
+    }
+}
+
+#[instrument(name = "command.whoami.run", skip(ctx, interaction))]
+pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
+    let _ = interaction.defer(&ctx.http).await;
+
+    let user = &interaction.user;
+    configure_sentry_scope("WhoAmI", user.id.get(), None);
+
+    let Some(database_pool) = database::get_pool_from_context(ctx).await else {
+        let builder = EditInteractionResponse::new()
+            .content("Database is not initialized. Please try again later.");
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    };
+
+    let discord_id = user.id.get() as i64;
+    let db_result = task::spawn_blocking(move || {
+        let mut connection = database::get_connection(&database_pool);
+        User::get_user_by_discord_id(discord_id, &mut connection)
+    })
+    .await;
+
+    let response = match db_result {
+        Ok(profile) => handle_whoami(profile.map(|entry| LinkedAniListProfile {
+            username: entry.anilist_username,
+        })),
+        Err(err) => {
+            error!(
+                error = %err,
+                discord_user_id = %hash_user_id(discord_id as u64),
+                "Failed to fetch whoami profile from database"
+            );
+            CommandResponse::Content(
+                "I hit an internal error while looking up your AniList account. Please try again later."
+                    .to_string(),
+            )
+        }
+    };
+
+    let content = match response {
+        CommandResponse::Content(content) => content,
+        _ => unreachable!("/whoami returns Content"),
+    };
+
+    let builder = EditInteractionResponse::new().content(content);
+    let _ = interaction.edit_response(&ctx.http, builder).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_whoami_with_linked_profile_returns_username_and_url() {
+        let response = handle_whoami(Some(LinkedAniListProfile {
+            username: "annie".to_string(),
+        }));
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(
+            content.contains("**annie**"),
+            "expected username in response"
+        );
+        assert!(
+            content.contains("https://anilist.co/user/annie"),
+            "expected AniList profile URL in response"
+        );
+    }
+
+    #[test]
+    fn handle_whoami_without_linked_profile_returns_register_guidance() {
+        let response = handle_whoami(None);
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(
+            content.contains("/register"),
+            "expected /register guidance for unlinked users"
+        );
+    }
+}

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -39,15 +39,14 @@ pub fn handle_whoami(profile: Option<LinkedAniListProfile>) -> CommandResponse {
             profile.profile_url()
         )),
         None => CommandResponse::Content(
-            "You have not linked an AniList account yet. Run `/register anilist:<username>` first."
-                .to_string(),
+            "You have not linked an AniList account yet. Run `/register` first.".to_string(),
         ),
     }
 }
 
 #[instrument(name = "command.whoami.run", skip(ctx, interaction))]
 pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
-    let _ = interaction.defer(&ctx.http).await;
+    let _ = interaction.defer_ephemeral(&ctx.http).await;
 
     let user = &interaction.user;
     configure_sentry_scope("WhoAmI", user.id.get(), None);

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -67,10 +67,10 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     .await;
 
     let response = match db_result {
-        Ok(profile) => handle_whoami(profile.map(|entry| LinkedAniListProfile {
+        Ok(Ok(profile)) => handle_whoami(profile.map(|entry| LinkedAniListProfile {
             username: entry.anilist_username,
         })),
-        Err(err) => {
+        Ok(Err(err)) => {
             error!(
                 error = %err,
                 discord_user_id = %hash_user_id(discord_id as u64),
@@ -81,14 +81,25 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                     .to_string(),
             )
         }
+        Err(err) => {
+            error!(
+                error = %err,
+                discord_user_id = %hash_user_id(discord_id as u64),
+                "Failed to join whoami database task"
+            );
+            CommandResponse::Content(
+                "I hit an internal error while looking up your AniList account. Please try again later."
+                    .to_string(),
+            )
+        }
     };
 
-    let content = match response {
-        CommandResponse::Content(content) => content,
-        _ => unreachable!("/whoami returns Content"),
+    let builder = match response {
+        CommandResponse::Content(content) => EditInteractionResponse::new().content(content),
+        CommandResponse::Embed(embed) => EditInteractionResponse::new().embed(*embed),
+        CommandResponse::Message(content) => EditInteractionResponse::new().content(content),
     };
 
-    let builder = EditInteractionResponse::new().content(content);
     let _ = interaction.edit_response(&ctx.http, builder).await;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ impl EventHandler for Handler {
                     "manga" => commands::manga::command::run(&ctx, &mut command).await,
                     "anime" => commands::anime::command::run(&ctx, &mut command).await,
                     "register" => commands::register::command::run(&ctx, &command).await,
+                    "whoami" => commands::whoami::run(&ctx, &mut command).await,
                     _ => {
                         let embed = CreateEmbed::new()
                             .title("Error")
@@ -98,6 +99,7 @@ impl EventHandler for Handler {
             commands::manga::command::register(),
             commands::anime::command::register(),
             commands::register::command::register(),
+            commands::whoami::register(),
         ];
 
         let guild_commands = Command::set_global_commands(&ctx.http, commands).await;

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -11,6 +11,18 @@ pub struct User {
 }
 
 impl User {
+    #[instrument(name = "db.user.get_by_discord_id", skip(conn), fields(discord_user_id = %hash_user_id(user_discord_id as u64)))]
+    pub fn get_user_by_discord_id(user_discord_id: i64, conn: &mut PgConnection) -> Option<User> {
+        use crate::schema::users::dsl::*;
+
+        users
+            .filter(discord_id.eq(user_discord_id))
+            .first::<User>(conn)
+            .optional()
+            .ok()
+            .flatten()
+    }
+
     #[instrument(name = "db.user.get_by_discord_ids", skip(conn, user_discord_ids), fields(user_count = user_discord_ids.len()))]
     pub fn get_users_by_discord_id(
         user_discord_ids: Vec<UserId>,

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -1,3 +1,4 @@
+use crate::utils::privacy::hash_user_id;
 use diesel::prelude::*;
 use serenity::model::prelude::UserId;
 use tracing::instrument;
@@ -12,15 +13,16 @@ pub struct User {
 
 impl User {
     #[instrument(name = "db.user.get_by_discord_id", skip(conn), fields(discord_user_id = %hash_user_id(user_discord_id as u64)))]
-    pub fn get_user_by_discord_id(user_discord_id: i64, conn: &mut PgConnection) -> Option<User> {
+    pub fn get_user_by_discord_id(
+        user_discord_id: i64,
+        conn: &mut PgConnection,
+    ) -> Result<Option<User>, diesel::result::Error> {
         use crate::schema::users::dsl::*;
 
         users
             .filter(discord_id.eq(user_discord_id))
             .first::<User>(conn)
             .optional()
-            .ok()
-            .flatten()
     }
 
     #[instrument(name = "db.user.get_by_discord_ids", skip(conn, user_discord_ids), fields(user_count = user_discord_ids.len()))]


### PR DESCRIPTION
## Summary
Adds a new /whoami slash command so users can see their currently linked AniList account and profile URL, with a fallback message when no account is linked.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- ef4ff53823d5df3e4163c34fba983c7d82126c81: add a new /whoami command with deferred DB lookup, response formatting, and unit tests; register and dispatch it in main; add DB helper to fetch a user by Discord ID

### Notes
- /whoami returns the linked AniList username and https://anilist.co/user/<username> when available.
- Unlinked users are guided to run /register.

## Validation
- [x] cargo fmt --manifest-path /project/workspace/annie-mei/Cargo.toml
- [x] RUSTC_WRAPPER= cargo clippy --manifest-path /project/workspace/annie-mei/Cargo.toml --all-targets --all-features
- [x] RUSTC_WRAPPER= cargo test --manifest-path /project/workspace/annie-mei/Cargo.toml

## References (optional)
- https://linear.app/annie-mei/issue/ANNIE-143/add-a-whoami

---

This PR description was written by GPT-5.3-Codex.
