### PR TITLE
[ANNIE-140]/automate-app-version-bumps-for-dependabot

### DIFF
--- a/.github/workflows/dependabot-version-bump-apply.yml
+++ b/.github/workflows/dependabot-version-bump-apply.yml
@@ -18,33 +18,46 @@ permissions:
 jobs:
   apply-version-bump:
     name: Apply Version Bump
-    # Only run if the check workflow succeeded and found a bump is needed
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.outputs.bump_needed == 'true'
+    # Only run if the check workflow succeeded
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always
     steps:
+      - name: Download bump info artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: version-bump-outputs
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load bump info
+        id: load
+        run: cat outputs.env >> $GITHUB_OUTPUT
+
       - name: Checkout PR branch
+        if: steps.load.outputs.bump_needed == 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.outputs.head_ref }}
+          ref: ${{ steps.load.outputs.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
+        if: steps.load.outputs.bump_needed == 'true'
         run: |
           toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
           rustup toolchain install "$toolchain" --profile minimal
 
       - name: Install dependencies
+        if: steps.load.outputs.bump_needed == 'true'
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
 
       - name: Apply version bump
+        if: steps.load.outputs.bump_needed == 'true'
+        env:
+          CURRENT_VERSION: ${{ steps.load.outputs.current_version }}
+          NEW_VERSION: ${{ steps.load.outputs.new_version }}
         run: |
-          CURRENT_VERSION="${{ github.event.workflow_run.outputs.current_version }}"
-          NEW_VERSION="${{ github.event.workflow_run.outputs.new_version }}"
-          
           echo "Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
           
           # Update Cargo.toml using sed
@@ -54,6 +67,7 @@ jobs:
           grep -E '^version\s*=' Cargo.toml
 
       - name: Setup Rust cache
+        if: steps.load.outputs.bump_needed == 'true'
         uses: Swatinem/rust-cache@v2.9.1
         with:
           cache-on-failure: "true"
@@ -61,15 +75,17 @@ jobs:
           shared-key: "cargo-version-bump"
 
       - name: Run cargo check to update Cargo.lock
+        if: steps.load.outputs.bump_needed == 'true'
         run: cargo check
 
       - name: Commit version bump
+        if: steps.load.outputs.bump_needed == 'true'
+        env:
+          NEW_VERSION: ${{ steps.load.outputs.new_version }}
+          HEAD_REF: ${{ steps.load.outputs.head_ref }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          NEW_VERSION="${{ github.event.workflow_run.outputs.new_version }}"
-          HEAD_REF="${{ github.event.workflow_run.outputs.head_ref }}"
           
           # Stage the changes
           git add Cargo.toml Cargo.lock
@@ -88,5 +104,9 @@ jobs:
 
       - name: Summary
         run: |
-          echo "✅ Version bumped to ${{ github.event.workflow_run.outputs.new_version }}"
-          echo "Changes committed to branch: ${{ github.event.workflow_run.outputs.head_ref }}"
+          if [ "${{ steps.load.outputs.bump_needed }}" == "true" ]; then
+            echo "✅ Version bumped to ${{ steps.load.outputs.new_version }}"
+            echo "Changes committed to branch: ${{ steps.load.outputs.head_ref }}"
+          else
+            echo "ℹ️ No version bump needed"
+          fi

--- a/.github/workflows/dependabot-version-bump-apply.yml
+++ b/.github/workflows/dependabot-version-bump-apply.yml
@@ -18,8 +18,10 @@ permissions:
 jobs:
   apply-version-bump:
     name: Apply Version Bump
-    # Only run if the check workflow succeeded
-    if: github.event.workflow_run.conclusion == 'success'
+    # Only run if the check workflow succeeded and was triggered by Dependabot
+    if: |
+      github.event.workflow_run.conclusion == 'success' && 
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/dependabot-version-bump-apply.yml
+++ b/.github/workflows/dependabot-version-bump-apply.yml
@@ -1,0 +1,92 @@
+# Part 2: Apply the version bump for Dependabot PRs
+#
+# This workflow runs after the check workflow completes.
+# It runs in the base repo context (not the fork) so it has write permissions
+# to push commits back to the Dependabot PR branch.
+
+name: Dependabot Version Bump - Apply
+
+on:
+  workflow_run:
+    workflows: ["Dependabot Version Bump - Check"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  apply-version-bump:
+    name: Apply Version Bump
+    # Only run if the check workflow succeeded and found a bump is needed
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.outputs.bump_needed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.outputs.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        run: |
+          toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
+
+      - name: Apply version bump
+        run: |
+          CURRENT_VERSION="${{ github.event.workflow_run.outputs.current_version }}"
+          NEW_VERSION="${{ github.event.workflow_run.outputs.new_version }}"
+          
+          echo "Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
+          
+          # Update Cargo.toml using sed
+          sed -i "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" Cargo.toml
+          
+          # Verify the change
+          grep -E '^version\s*=' Cargo.toml
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          cache-on-failure: "true"
+          prefix-key: "annie-mei"
+          shared-key: "cargo-version-bump"
+
+      - name: Run cargo check to update Cargo.lock
+        run: cargo check
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          NEW_VERSION="${{ github.event.workflow_run.outputs.new_version }}"
+          HEAD_REF="${{ github.event.workflow_run.outputs.head_ref }}"
+          
+          # Stage the changes
+          git add Cargo.toml Cargo.lock
+          
+          # Check if there are changes to commit
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          
+          # Commit with a concise message
+          git commit -m "chore(version): bump app version to ${NEW_VERSION} for Dependabot update"
+          
+          # Push back to the PR branch
+          git push origin HEAD:${HEAD_REF}
+
+      - name: Summary
+        run: |
+          echo "✅ Version bumped to ${{ github.event.workflow_run.outputs.new_version }}"
+          echo "Changes committed to branch: ${{ github.event.workflow_run.outputs.head_ref }}"

--- a/.github/workflows/dependabot-version-bump-apply.yml
+++ b/.github/workflows/dependabot-version-bump-apply.yml
@@ -105,10 +105,14 @@ jobs:
           git push origin HEAD:${HEAD_REF}
 
       - name: Summary
+        env:
+          BUMP_NEEDED: ${{ steps.load.outputs.bump_needed }}
+          NEW_VERSION: ${{ steps.load.outputs.new_version }}
+          HEAD_REF: ${{ steps.load.outputs.head_ref }}
         run: |
-          if [ "${{ steps.load.outputs.bump_needed }}" == "true" ]; then
-            echo "✅ Version bumped to ${{ steps.load.outputs.new_version }}"
-            echo "Changes committed to branch: ${{ steps.load.outputs.head_ref }}"
+          if [ "$BUMP_NEEDED" == "true" ]; then
+            echo "✅ Version bumped to $NEW_VERSION"
+            echo "Changes committed to branch: $HEAD_REF"
           else
             echo "ℹ️ No version bump needed"
           fi

--- a/.github/workflows/dependabot-version-bump-apply.yml
+++ b/.github/workflows/dependabot-version-bump-apply.yml
@@ -27,6 +27,8 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Download bump info artifact
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: version-bump-outputs
@@ -35,6 +37,7 @@ jobs:
 
       - name: Load bump info
         id: load
+        if: steps.download.outcome == 'success'
         run: cat outputs.env >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch

--- a/.github/workflows/dependabot-version-bump-apply.yml
+++ b/.github/workflows/dependabot-version-bump-apply.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Download bump info artifact
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: version-bump-outputs
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/dependabot-version-bump-check.yml
+++ b/.github/workflows/dependabot-version-bump-check.yml
@@ -69,7 +69,6 @@ jobs:
           fi
 
       - name: Save bump info as artifact
-        if: steps.check.outputs.bump_needed == 'true'
         run: |
           mkdir -p /tmp/bump-info
           echo "bump_needed=${{ steps.check.outputs.bump_needed }}" > /tmp/bump-info/outputs.env
@@ -78,7 +77,6 @@ jobs:
           echo "head_ref=${{ github.head_ref }}" >> /tmp/bump-info/outputs.env
 
       - name: Upload bump info artifact
-        if: steps.check.outputs.bump_needed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: version-bump-outputs

--- a/.github/workflows/dependabot-version-bump-check.yml
+++ b/.github/workflows/dependabot-version-bump-check.yml
@@ -83,7 +83,7 @@ jobs:
           echo "head_ref=$HEAD_REF" >> /tmp/bump-info/outputs.env
 
       - name: Upload bump info artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: version-bump-outputs
           path: /tmp/bump-info/outputs.env

--- a/.github/workflows/dependabot-version-bump-check.yml
+++ b/.github/workflows/dependabot-version-bump-check.yml
@@ -46,11 +46,12 @@ jobs:
           # Fetch main to compare
           git fetch origin main
           
-          # Get the diff of Cargo.toml between main and this branch
-          DIFF=$(git diff origin/main -- Cargo.toml || true)
+          # Get the package version from main branch (not the diff, to avoid matching dependency versions)
+          MAIN_VERSION=$(git show origin/main:Cargo.toml | grep -E '^version\s*=' | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+          echo "Main branch version: $MAIN_VERSION"
           
-          # Check if version line was modified in this PR
-          if echo "$DIFF" | grep -q '^[+-]version\s*='; then
+          # Check if package version was already modified (differs from main)
+          if [ "$CURRENT_VERSION" != "$MAIN_VERSION" ]; then
             echo "Version was already modified in this PR - no bump needed"
             echo "bump_needed=false" >> $GITHUB_OUTPUT
             echo "new_version=" >> $GITHUB_OUTPUT
@@ -69,12 +70,17 @@ jobs:
           fi
 
       - name: Save bump info as artifact
+        env:
+          BUMP_NEEDED: ${{ steps.check.outputs.bump_needed }}
+          CURRENT_VERSION: ${{ steps.check.outputs.current_version }}
+          NEW_VERSION: ${{ steps.check.outputs.new_version }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           mkdir -p /tmp/bump-info
-          echo "bump_needed=${{ steps.check.outputs.bump_needed }}" > /tmp/bump-info/outputs.env
-          echo "current_version=${{ steps.check.outputs.current_version }}" >> /tmp/bump-info/outputs.env
-          echo "new_version=${{ steps.check.outputs.new_version }}" >> /tmp/bump-info/outputs.env
-          echo "head_ref=${{ github.head_ref }}" >> /tmp/bump-info/outputs.env
+          echo "bump_needed=$BUMP_NEEDED" > /tmp/bump-info/outputs.env
+          echo "current_version=$CURRENT_VERSION" >> /tmp/bump-info/outputs.env
+          echo "new_version=$NEW_VERSION" >> /tmp/bump-info/outputs.env
+          echo "head_ref=$HEAD_REF" >> /tmp/bump-info/outputs.env
 
       - name: Upload bump info artifact
         uses: actions/upload-artifact@v4
@@ -84,9 +90,13 @@ jobs:
           retention-days: 1
 
       - name: Summary
+        env:
+          BUMP_NEEDED: ${{ steps.check.outputs.bump_needed }}
+          CURRENT_VERSION: ${{ steps.check.outputs.current_version }}
+          NEW_VERSION: ${{ steps.check.outputs.new_version }}
         run: |
-          if [ "${{ steps.check.outputs.bump_needed }}" == "true" ]; then
-            echo "✅ Version bump needed: ${{ steps.check.outputs.current_version }} -> ${{ steps.check.outputs.new_version }}"
+          if [ "$BUMP_NEEDED" == "true" ]; then
+            echo "✅ Version bump needed: $CURRENT_VERSION -> $NEW_VERSION"
           else
             echo "ℹ️ No version bump needed"
           fi

--- a/.github/workflows/dependabot-version-bump-check.yml
+++ b/.github/workflows/dependabot-version-bump-check.yml
@@ -1,0 +1,77 @@
+# Part 1: Detect if version bump is needed for Dependabot PRs
+#
+# This workflow runs on pull_request (safe, read-only) and:
+# 1. Detects if version bump is needed
+# 2. Calculates the new version
+# 3. Saves bump info as an artifact for the apply workflow
+
+name: Dependabot Version Bump - Check
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-bump:
+    name: Check if Version Bump is Needed
+    # Only run for Dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      bump_needed: ${{ steps.check.outputs.bump_needed }}
+      current_version: ${{ steps.check.outputs.current_version }}
+      new_version: ${{ steps.check.outputs.new_version }}
+      head_ref: ${{ github.head_ref }}
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Check if version bump is needed
+        id: check
+        run: |
+          # Get current version from Cargo.toml
+          CURRENT_VERSION=$(grep -E '^version\s*=' Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
+
+          # Fetch main to compare
+          git fetch origin main
+          
+          # Get the diff of Cargo.toml between main and this branch
+          DIFF=$(git diff origin/main -- Cargo.toml || true)
+          
+          # Check if version line was modified in this PR
+          if echo "$DIFF" | grep -q '^[+-]version\s*='; then
+            echo "Version was already modified in this PR - no bump needed"
+            echo "bump_needed=false" >> $GITHUB_OUTPUT
+            echo "new_version=" >> $GITHUB_OUTPUT
+          else
+            echo "Version not modified by Dependabot - bump needed"
+            echo "bump_needed=true" >> $GITHUB_OUTPUT
+            
+            # Calculate new patch version
+            MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT_VERSION" | cut -d. -f3)
+            NEW_PATCH=$((PATCH + 1))
+            NEW_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "Will bump to: $NEW_VERSION"
+          fi
+
+      - name: Summary
+        run: |
+          if [ "${{ steps.check.outputs.bump_needed }}" == "true" ]; then
+            echo "✅ Version bump needed: ${{ steps.check.outputs.current_version }} -> ${{ steps.check.outputs.new_version }}"
+          else
+            echo "ℹ️ No version bump needed"
+          fi

--- a/.github/workflows/dependabot-version-bump-check.yml
+++ b/.github/workflows/dependabot-version-bump-check.yml
@@ -68,6 +68,23 @@ jobs:
             echo "Will bump to: $NEW_VERSION"
           fi
 
+      - name: Save bump info as artifact
+        if: steps.check.outputs.bump_needed == 'true'
+        run: |
+          mkdir -p /tmp/bump-info
+          echo "bump_needed=${{ steps.check.outputs.bump_needed }}" > /tmp/bump-info/outputs.env
+          echo "current_version=${{ steps.check.outputs.current_version }}" >> /tmp/bump-info/outputs.env
+          echo "new_version=${{ steps.check.outputs.new_version }}" >> /tmp/bump-info/outputs.env
+          echo "head_ref=${{ github.head_ref }}" >> /tmp/bump-info/outputs.env
+
+      - name: Upload bump info artifact
+        if: steps.check.outputs.bump_needed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-bump-outputs
+          path: /tmp/bump-info/outputs.env
+          retention-days: 1
+
       - name: Summary
         run: |
           if [ "${{ steps.check.outputs.bump_needed }}" == "true" ]; then


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to automatically bump the app's version when Dependabot updates dependencies. This uses a two-workflow architecture for security: a check workflow detects if a bump is needed, and an apply workflow performs the actual commit with write permissions.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 81415d1: feat(ci): add Dependabot version bump workflow
- 8731ecc: fix(ci): upload artifact with bump info in check workflow
- 6bb90e8: fix(ci): download artifact and use env vars in apply workflow
- e7c33ce: fix(ci): always upload artifact in check workflow
- ea8e6bf: fix(ci): add dependabot actor check to apply workflow
- 4828259: fix(ci): security hardening and version detection improvements
- 755e2b7: fix(ci): add continue-on-error to artifact download

### Architecture

**Workflow 1: Check** (`dependabot-version-bump-check.yml`)
- Runs on `pull_request` trigger (read-only, safe)
- Only executes for Dependabot PRs (`github.actor == 'dependabot[bot]'`)
- Compares package version against main branch to detect if already modified
- Calculates new patch version if bump needed
- Uploads bump info as artifact (always, for apply workflow to consume)

**Workflow 2: Apply** (`dependabot-version-bump-apply.yml`)
- Runs on `workflow_run` trigger after check workflow completes
- Only executes if check was triggered by Dependabot
- Downloads artifact with bump info
- Applies version bump to Cargo.toml
- Runs `cargo check` to update Cargo.lock
- Commits changes back to PR branch

### Security Features

- **Two-workflow pattern**: Check runs in PR context (read-only), apply runs in base context (write permissions)
- **Artifact-based data passing**: Job outputs not propagated via workflow_run event
- **Environment variables**: All shell commands use `env:` blocks instead of direct `${{ }}` interpolation
- **Actor verification**: Both workflows verify `github.actor/login == 'dependabot[bot]'`
- **continue-on-error**: Artifact download gracefully handles missing artifacts

### Version Detection

- Compares package version from PR branch directly against main branch
- Avoids regex matching on diffs (which could match dependency version lines)
- Only bumps if package version equals main version (not already modified)

## Validation

- [x] Workflow files pass YAML syntax validation
- [x] Follows existing workflow conventions (blacksmith runners, caching)
- [x] Uses correct semantic versioning (patch bump for dependency updates)
- [x] Normal developer PRs show skipped jobs (filtered by actor check)
- [ ] When next Dependabot PR arrives, verify:
  - Check workflow triggers and uploads artifact
  - Apply workflow downloads artifact and applies bump
  - Version bump applies patch increment
  - `Cargo.lock` is updated via `cargo check`
  - Changes are committed back to the PR branch

## References

- Linear ticket: [ANNIE-140](https://linear.app/annie-mei/issue/ANNIE-140)

---

This PR description was written by fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo.