### PR TITLE
[ANNIE-144]/convert AniList and MAL request helpers to async reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.10.1"
+version = "2.10.2"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.10.1"
+version = "2.10.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ linkify = "0.10"
 log = "0.4.29"
 ngrammatic = "0.7.0"
 openssl = { version = "0.10.76", features = ["vendored"] }
-reqwest = { version = "0.13.2", features = ["blocking", "rustls"] }
+reqwest = { version = "0.13.2", features = ["rustls"] }
 redis = { version = "1.1.0", features = ["tls-native-tls"] }
 rspotify = { version = "0.16.0", default-features = false, features = [
   "client-ureq",

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -22,8 +22,7 @@ use serenity::{
     model::application::CommandOptionType,
 };
 
-use tokio::task;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("anime")
@@ -85,15 +84,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     info!("Got command 'anime' with search_term: {search_term}");
 
-    // Fetch anime data on a blocking thread (AniList uses blocking reqwest).
-    let anime_result: Option<Anime> =
-        match task::spawn_blocking(move || AniListSource.fetch_anime(&search_term)).await {
-            Ok(result) => result,
-            Err(e) => {
-                error!(error = %e, "spawn_blocking panicked while fetching anime");
-                None
-            }
-        };
+    let anime_result: Option<Anime> = AniListSource.fetch_anime(&search_term).await;
 
     // Block adult content in non-NSFW channels.
     if let Some(ref anime) = anime_result

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -22,8 +22,7 @@ use serenity::{
     model::application::CommandOptionType,
 };
 
-use tokio::task;
-use tracing::{error, info, instrument};
+use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("manga")
@@ -85,15 +84,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     info!("Got command 'manga' with search_term: {search_term}");
 
-    // Fetch manga data on a blocking thread (AniList uses blocking reqwest).
-    let manga_result: Option<Manga> =
-        match task::spawn_blocking(move || AniListSource.fetch_manga(&search_term)).await {
-            Ok(result) => result,
-            Err(e) => {
-                error!(error = %e, "spawn_blocking panicked while fetching manga");
-                None
-            }
-        };
+    let manga_result: Option<Manga> = AniListSource.fetch_manga(&search_term).await;
 
     // Block adult content in non-NSFW channels.
     if let Some(ref manga) = manga_result

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -18,6 +18,14 @@ use serenity::{
 use tokio::task;
 use tracing::{error, info, instrument};
 
+struct SongEmbedData {
+    title: String,
+    openings: String,
+    endings: String,
+    thumbnail: String,
+    mal_link: String,
+}
+
 pub fn register() -> CreateCommand {
     CreateCommand::new("songs")
         .description("Fetches the songs of an anime")
@@ -53,22 +61,33 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         return;
     }
 
-    let response = match task::spawn_blocking(move || SongFetcher(arg)).await {
-        Ok(result) => result,
-        Err(err) => {
-            error!(error = %err, "spawn_blocking panicked during song fetch");
-            let builder = EditInteractionResponse::new().content(
-                "An internal error occurred while fetching songs. Please try again later.",
-            );
-            let _ = interaction.edit_response(&ctx.http, builder).await;
-            return;
-        }
-    };
+    let response = SongFetcher(arg).await;
 
     let _songs_response = match response {
         SongFetchResult::Found(song_response) => {
-            let builder = EditInteractionResponse::new()
-                .embed(build_message_from_song_response(song_response));
+            let embed_data =
+                match task::spawn_blocking(move || build_message_from_song_response(song_response))
+                    .await
+                {
+                    Ok(data) => data,
+                    Err(err) => {
+                        error!(error = %err, "spawn_blocking panicked while building song embed");
+                        let builder = EditInteractionResponse::new().content(
+                        "An internal error occurred while fetching songs. Please try again later.",
+                    );
+                        let _ = interaction.edit_response(&ctx.http, builder).await;
+                        return;
+                    }
+                };
+
+            let builder = EditInteractionResponse::new().embed(
+                CreateEmbed::new()
+                    .title(embed_data.title)
+                    .field("Openings", embed_data.openings, false)
+                    .field("Endings", embed_data.endings, false)
+                    .thumbnail(embed_data.thumbnail)
+                    .field("\u{200b}", embed_data.mal_link, false),
+            );
             interaction.edit_response(&ctx.http, builder).await
         }
         SongFetchResult::AnimeNotFound => {
@@ -89,11 +108,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 }
 
 #[instrument(name = "command.songs.build_message", skip(mal_response))]
-fn build_message_from_song_response(mal_response: MalResponse) -> CreateEmbed {
-    CreateEmbed::new()
-        .title(mal_response.transform_title())
-        .field("Openings", mal_response.transform_openings(), false)
-        .field("Endings", mal_response.transform_endings(), false)
-        .thumbnail(mal_response.transform_thumbnail())
-        .field("\u{200b}", mal_response.transform_mal_link(), false)
+fn build_message_from_song_response(mal_response: MalResponse) -> SongEmbedData {
+    SongEmbedData {
+        title: mal_response.transform_title(),
+        openings: mal_response.transform_openings(),
+        endings: mal_response.transform_endings(),
+        thumbnail: mal_response.transform_thumbnail(),
+        mal_link: mal_response.transform_mal_link(),
+    }
 }

--- a/src/commands/songs/fetcher.rs
+++ b/src/commands/songs/fetcher.rs
@@ -17,8 +17,8 @@ pub enum SongFetchResult {
 }
 
 #[instrument(name = "command.songs.fetcher", skip(args))]
-pub fn fetcher(args: CommandDataOptionValue) -> SongFetchResult {
-    let anime_response: Option<Anime> = anime_fetcher(Type::Anime, args);
+pub async fn fetcher(args: CommandDataOptionValue) -> SongFetchResult {
+    let anime_response: Option<Anime> = anime_fetcher(Type::Anime, args).await;
     let Some(anime) = anime_response else {
         return SongFetchResult::AnimeNotFound;
     };
@@ -28,7 +28,7 @@ pub fn fetcher(args: CommandDataOptionValue) -> SongFetchResult {
         return SongFetchResult::AnimeNotFoundOnMal;
     };
 
-    let mal_fetcher_response = match my_anime_list::send_request(mal_id) {
+    let mal_fetcher_response = match my_anime_list::send_request(mal_id).await {
         Ok(response) => response,
         Err(err) => {
             error!(error = %err, mal_id = mal_id, "Failed to fetch MAL data for anime");

--- a/src/commands/traits.rs
+++ b/src/commands/traits.rs
@@ -17,6 +17,8 @@
 //! assert!(response.is_embed());
 //! ```
 
+use std::future::Future;
+
 use crate::models::{anilist_anime::Anime, anilist_manga::Manga};
 
 /// Abstraction over media-data retrieval (AniList today, pluggable tomorrow).
@@ -28,12 +30,12 @@ pub trait MediaDataSource: Send + Sync {
     /// Fetch anime data for the given search term (name **or** numeric ID).
     ///
     /// Returns `None` when no matching anime is found.
-    fn fetch_anime(&self, search_term: &str) -> Option<Anime>;
+    fn fetch_anime(&self, search_term: &str) -> impl Future<Output = Option<Anime>> + Send;
 
     /// Fetch manga data for the given search term (name **or** numeric ID).
     ///
     /// Returns `None` when no matching manga is found.
-    fn fetch_manga(&self, search_term: &str) -> Option<Manga>;
+    fn fetch_manga(&self, search_term: &str) -> impl Future<Output = Option<Manga>> + Send;
 }
 
 /// Production [`MediaDataSource`] backed by the AniList GraphQL API.
@@ -43,21 +45,21 @@ pub trait MediaDataSource: Send + Sync {
 pub struct AniListSource;
 
 impl MediaDataSource for AniListSource {
-    fn fetch_anime(&self, search_term: &str) -> Option<Anime> {
+    async fn fetch_anime(&self, search_term: &str) -> Option<Anime> {
         use crate::models::media_type::MediaType;
         use crate::utils::response_fetcher::fetcher;
         use serenity::all::CommandDataOptionValue;
 
         let arg = CommandDataOptionValue::String(search_term.to_string());
-        fetcher::<Anime>(MediaType::Anime, arg)
+        fetcher::<Anime>(MediaType::Anime, arg).await
     }
 
-    fn fetch_manga(&self, search_term: &str) -> Option<Manga> {
+    async fn fetch_manga(&self, search_term: &str) -> Option<Manga> {
         use crate::models::media_type::MediaType;
         use crate::utils::response_fetcher::fetcher;
         use serenity::all::CommandDataOptionValue;
 
         let arg = CommandDataOptionValue::String(search_term.to_string());
-        fetcher::<Manga>(MediaType::Manga, arg)
+        fetcher::<Manga>(MediaType::Manga, arg).await
     }
 }

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -40,6 +40,37 @@ pub trait Response {
     fn get_search_query(&self) -> String;
 }
 
+#[instrument(
+    name = "anilist.fetch_from_network_and_cache",
+    skip(search_query),
+    fields(cache_key = %cache_key, lookup_len = lookup_value.len())
+)]
+async fn fetch_from_network_and_cache(
+    search_query: String,
+    lookup_value: String,
+    cache_key: String,
+) -> Option<String> {
+    let response = match fetch_by_name(search_query, lookup_value).await {
+        Ok(data) => data,
+        Err(err) => {
+            error!(error = %err, "Failed to fetch AniList data by name");
+            return None;
+        }
+    };
+
+    let cache_key_for_write = cache_key.clone();
+    let response_to_cache = response.clone();
+    if let Err(err) = task::spawn_blocking(move || {
+        try_to_cache_response(&cache_key_for_write, &response_to_cache)
+    })
+    .await
+    {
+        error!(error = %err, cache_key = %cache_key, "Failed to cache AniList response");
+    }
+
+    Some(response)
+}
+
 #[instrument(name = "anilist.fetch", skip(response_config), fields(media_type = ?media_type))]
 pub async fn fetch<
     T: serde::de::DeserializeOwned + Transformers + std::fmt::Debug + std::clone::Clone,
@@ -69,67 +100,30 @@ pub async fn fetch<
         Argument::Search(value) => {
             let cache_key = format!("{}:{value}", media_type.as_ref());
             let cache_key_for_lookup = cache_key.clone();
+            let search_query = response_config.get_search_query();
+            let lookup_value = value.to_string();
 
-            let fetched_data = match task::spawn_blocking(move || {
-                check_cache(&cache_key_for_lookup)
-            })
-            .await
-            {
-                Ok(Ok(cached_value)) => {
-                    info!("Cache hit for {:#?}", cache_key);
-                    cached_value
-                }
-                Ok(Err(err)) => {
-                    info!("Cache miss for {:#?} with error {:#?}", cache_key, err);
-                    let response =
-                        match fetch_by_name(response_config.get_search_query(), value.to_string())
-                            .await
-                        {
-                            Ok(data) => data,
-                            Err(err) => {
-                                error!(error = %err, "Failed to fetch AniList data by name");
-                                return None;
-                            }
-                        };
-
-                    let cache_key_for_write = cache_key.clone();
-                    let response_to_cache = response.clone();
-                    if let Err(err) = task::spawn_blocking(move || {
-                        try_to_cache_response(&cache_key_for_write, &response_to_cache)
-                    })
-                    .await
-                    {
-                        error!(error = %err, "Failed to cache AniList response");
+            let fetched_data =
+                match task::spawn_blocking(move || check_cache(&cache_key_for_lookup)).await {
+                    Ok(Ok(cached_value)) => {
+                        info!("Cache hit for {:#?}", cache_key);
+                        cached_value
                     }
-
-                    response
-                }
-                Err(err) => {
-                    error!(error = %err, "Failed to read AniList cache");
-                    let response =
-                        match fetch_by_name(response_config.get_search_query(), value.to_string())
-                            .await
-                        {
-                            Ok(data) => data,
-                            Err(err) => {
-                                error!(error = %err, "Failed to fetch AniList data by name");
-                                return None;
-                            }
-                        };
-
-                    let cache_key_for_write = cache_key.clone();
-                    let response_to_cache = response.clone();
-                    if let Err(err) = task::spawn_blocking(move || {
-                        try_to_cache_response(&cache_key_for_write, &response_to_cache)
-                    })
-                    .await
-                    {
-                        error!(error = %err, "Failed to cache AniList response");
+                    Ok(Err(err)) => {
+                        info!("Cache miss for {:#?} with error {:#?}", cache_key, err);
+                        fetch_from_network_and_cache(
+                            search_query.clone(),
+                            lookup_value.clone(),
+                            cache_key.clone(),
+                        )
+                        .await?
                     }
-
-                    response
-                }
-            };
+                    Err(err) => {
+                        error!(error = %err, "Failed to read AniList cache");
+                        fetch_from_network_and_cache(search_query, lookup_value, cache_key.clone())
+                            .await?
+                    }
+                };
             let fetch_response: MediaResponse<T> = match serde_json::from_str(&fetched_data) {
                 Ok(response) => response,
                 Err(err) => {

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use tokio::task;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, instrument};
 
 pub struct AnimeConfig {
     argument: Argument,
@@ -40,6 +40,7 @@ pub trait Response {
     fn get_search_query(&self) -> String;
 }
 
+#[instrument(name = "anilist.fetch", skip(response_config), fields(media_type = ?media_type))]
 pub async fn fetch<
     T: serde::de::DeserializeOwned + Transformers + std::fmt::Debug + std::clone::Clone,
 >(

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -13,6 +13,7 @@ use crate::{
     },
 };
 
+use tokio::task;
 use tracing::{debug, error, info};
 
 pub struct AnimeConfig {
@@ -37,65 +38,108 @@ pub trait Response {
     fn get_argument(&self) -> &Argument;
     fn get_id_query(&self) -> String;
     fn get_search_query(&self) -> String;
+}
 
-    fn fetch<
-        T: serde::de::DeserializeOwned + Transformers + std::fmt::Debug + std::clone::Clone,
-    >(
-        &self,
-        media_type: Type,
-    ) -> Option<T> {
-        match self.get_argument() {
-            Argument::Id(value) => {
-                let fetched_data = match fetch_by_id(self.get_id_query(), *value) {
-                    Ok(data) => data,
-                    Err(err) => {
-                        error!(error = %err, id = *value, "Failed to fetch AniList data by id");
-                        return None;
+pub async fn fetch<
+    T: serde::de::DeserializeOwned + Transformers + std::fmt::Debug + std::clone::Clone,
+>(
+    response_config: &impl Response,
+    media_type: Type,
+) -> Option<T> {
+    match response_config.get_argument() {
+        Argument::Id(value) => {
+            let fetched_data = match fetch_by_id(response_config.get_id_query(), *value).await {
+                Ok(data) => data,
+                Err(err) => {
+                    error!(error = %err, id = *value, "Failed to fetch AniList data by id");
+                    return None;
+                }
+            };
+            let fetch_response: IdResponse<T> = match serde_json::from_str(&fetched_data) {
+                Ok(response) => response,
+                Err(err) => {
+                    error!(error = %err, "Failed to deserialize AniList id response");
+                    return None;
+                }
+            };
+            debug!("Deserialized response: {:#?}", fetch_response);
+            fetch_response.data.and_then(|data| data.media)
+        }
+        Argument::Search(value) => {
+            let cache_key = format!("{}:{value}", media_type.as_ref());
+            let cache_key_for_lookup = cache_key.clone();
+
+            let fetched_data = match task::spawn_blocking(move || {
+                check_cache(&cache_key_for_lookup)
+            })
+            .await
+            {
+                Ok(Ok(cached_value)) => {
+                    info!("Cache hit for {:#?}", cache_key);
+                    cached_value
+                }
+                Ok(Err(err)) => {
+                    info!("Cache miss for {:#?} with error {:#?}", cache_key, err);
+                    let response =
+                        match fetch_by_name(response_config.get_search_query(), value.to_string())
+                            .await
+                        {
+                            Ok(data) => data,
+                            Err(err) => {
+                                error!(error = %err, "Failed to fetch AniList data by name");
+                                return None;
+                            }
+                        };
+
+                    let cache_key_for_write = cache_key.clone();
+                    let response_to_cache = response.clone();
+                    if let Err(err) = task::spawn_blocking(move || {
+                        try_to_cache_response(&cache_key_for_write, &response_to_cache)
+                    })
+                    .await
+                    {
+                        error!(error = %err, "Failed to cache AniList response");
                     }
-                };
-                let fetch_response: IdResponse<T> = match serde_json::from_str(&fetched_data) {
-                    Ok(response) => response,
-                    Err(err) => {
-                        error!(error = %err, "Failed to deserialize AniList id response");
-                        return None;
+
+                    response
+                }
+                Err(err) => {
+                    error!(error = %err, "Failed to read AniList cache");
+                    let response =
+                        match fetch_by_name(response_config.get_search_query(), value.to_string())
+                            .await
+                        {
+                            Ok(data) => data,
+                            Err(err) => {
+                                error!(error = %err, "Failed to fetch AniList data by name");
+                                return None;
+                            }
+                        };
+
+                    let cache_key_for_write = cache_key.clone();
+                    let response_to_cache = response.clone();
+                    if let Err(err) = task::spawn_blocking(move || {
+                        try_to_cache_response(&cache_key_for_write, &response_to_cache)
+                    })
+                    .await
+                    {
+                        error!(error = %err, "Failed to cache AniList response");
                     }
-                };
-                debug!("Deserialized response: {:#?}", fetch_response);
-                fetch_response.data.and_then(|data| data.media)
-            }
-            Argument::Search(value) => {
-                let cache_key = format!("{}:{value}", media_type.as_ref());
-                let fetched_data = match check_cache(&cache_key) {
-                    Ok(value) => {
-                        info!("Cache hit for {:#?}", cache_key);
-                        value
-                    }
-                    Err(e) => {
-                        info!("Cache miss for {:#?} with error {:#?}", cache_key, e);
-                        let response =
-                            match fetch_by_name(self.get_search_query(), value.to_string()) {
-                                Ok(data) => data,
-                                Err(err) => {
-                                    error!(error = %err, "Failed to fetch AniList data by name");
-                                    return None;
-                                }
-                            };
-                        try_to_cache_response(&cache_key, &response);
-                        response
-                    }
-                };
-                let fetch_response: MediaResponse<T> = match serde_json::from_str(&fetched_data) {
-                    Ok(response) => response,
-                    Err(err) => {
-                        error!(error = %err, "Failed to deserialize AniList search response");
-                        return None;
-                    }
-                };
-                debug!("Deserialized response: {:#?}", fetch_response);
-                let result = fetch_response.fuzzy_match(value, media_type);
-                debug!("Fuzzy Response: {:#?}", result);
-                result
-            }
+
+                    response
+                }
+            };
+            let fetch_response: MediaResponse<T> = match serde_json::from_str(&fetched_data) {
+                Ok(response) => response,
+                Err(err) => {
+                    error!(error = %err, "Failed to deserialize AniList search response");
+                    return None;
+                }
+            };
+            debug!("Deserialized response: {:#?}", fetch_response);
+            let result = fetch_response.fuzzy_match(value, media_type);
+            debug!("Fuzzy Response: {:#?}", result);
+            result
         }
     }
 }

--- a/src/utils/fetch_by_arguments.rs
+++ b/src/utils/fetch_by_arguments.rs
@@ -5,9 +5,9 @@ use tracing::{info, instrument};
 use wana_kana::{ConvertJapanese, IsJapaneseStr};
 
 #[instrument(name = "anilist.fetch_by_id", skip(query), fields(id = id))]
-pub fn fetch_by_id(query: String, id: u32) -> Result<String, AniListRequestError> {
+pub async fn fetch_by_id(query: String, id: u32) -> Result<String, AniListRequestError> {
     let json = json!({"query": query, "variables": {"id":id}});
-    let result = send_request(json)?;
+    let result = send_request(json).await?;
 
     info!("Fetched By ID: {:#?}", id);
 
@@ -15,14 +15,14 @@ pub fn fetch_by_id(query: String, id: u32) -> Result<String, AniListRequestError
 }
 
 #[instrument(name = "anilist.fetch_by_name", skip(query), fields(name_len = name.len()))]
-pub fn fetch_by_name(query: String, name: String) -> Result<String, AniListRequestError> {
+pub async fn fetch_by_name(query: String, name: String) -> Result<String, AniListRequestError> {
     let searchable_name = if name.as_str().is_japanese() {
         name.to_romaji()
     } else {
         name.clone()
     };
     let json = json!({"query": query, "variables": {"search":searchable_name}});
-    let result = send_request(json)?;
+    let result = send_request(json).await?;
 
     info!("Fetched By Name: {:#?}", searchable_name);
 

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -135,14 +135,10 @@ async fn get_guild_anilist_data(
         request_body_len = body.to_string().len(),
         "Sending batch AniList media list query"
     );
-    let user_media_list_response = match task::spawn_blocking(move || send_request(body)).await {
-        Ok(Ok(response)) => response,
-        Ok(Err(err)) => {
-            error!(error = %err, "AniList batch media list request failed");
-            return HashMap::new();
-        }
+    let user_media_list_response = match send_request(body).await {
+        Ok(response) => response,
         Err(err) => {
-            error!(error = %err, "Failed to fetch guild AniList media data");
+            error!(error = %err, "AniList batch media list request failed");
             return HashMap::new();
         }
     };

--- a/src/utils/llm.rs
+++ b/src/utils/llm.rs
@@ -24,9 +24,10 @@
 
 use std::env;
 use std::fmt;
+use std::future::Future;
 use std::time::Duration;
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::{info, instrument};
 
@@ -160,14 +161,17 @@ pub trait LlmClient: Send + Sync {
     ///
     /// If the implementation has a system prompt configured, it is
     /// automatically prepended to the conversation.
-    fn chat(&self, user_message: &str) -> Result<String, LlmError>;
+    fn chat(&self, user_message: &str) -> impl Future<Output = Result<String, LlmError>> + Send;
 
     /// Send a full conversation (multiple messages) and return the
     /// assistant's reply.
     ///
     /// The caller has full control over the message list — no system
     /// prompt is automatically prepended.
-    fn chat_with_messages(&self, messages: &[ChatMessage]) -> Result<String, LlmError>;
+    fn chat_with_messages(
+        &self,
+        messages: &[ChatMessage],
+    ) -> impl Future<Output = Result<String, LlmError>> + Send;
 
     /// Return the model name this client is configured for.
     fn model(&self) -> &str;
@@ -313,7 +317,7 @@ impl GeminiClient {
             model = %self.config.model,
         )
     )]
-    fn send_chat_completion(
+    async fn send_chat_completion(
         &self,
         messages: &[ChatMessage],
     ) -> Result<ChatCompletionResponse, LlmError> {
@@ -335,11 +339,13 @@ impl GeminiClient {
             .header("Authorization", format!("Bearer {}", self.config.api_key))
             .body(body_json)
             .send()
+            .await
             .map_err(|e| LlmError::Request(e.to_string()))?;
 
         let status = response.status();
         let text = response
             .text()
+            .await
             .map_err(|e| LlmError::ResponseBody(e.to_string()))?;
 
         if !status.is_success() {
@@ -367,9 +373,9 @@ impl LlmClient for GeminiClient {
             has_system_prompt = self.config.system_prompt.is_some(),
         )
     )]
-    fn chat(&self, user_message: &str) -> Result<String, LlmError> {
+    async fn chat(&self, user_message: &str) -> Result<String, LlmError> {
         let messages = self.build_messages(user_message);
-        let response = self.send_chat_completion(&messages)?;
+        let response = self.send_chat_completion(&messages).await?;
 
         info!(usage = ?response.usage, "Chat completion received");
 
@@ -384,8 +390,8 @@ impl LlmClient for GeminiClient {
             message_count = messages.len(),
         )
     )]
-    fn chat_with_messages(&self, messages: &[ChatMessage]) -> Result<String, LlmError> {
-        let response = self.send_chat_completion(messages)?;
+    async fn chat_with_messages(&self, messages: &[ChatMessage]) -> Result<String, LlmError> {
+        let response = self.send_chat_completion(messages).await?;
 
         info!(usage = ?response.usage, "Chat completion received");
 

--- a/src/utils/requests/anilist.rs
+++ b/src/utils/requests/anilist.rs
@@ -1,6 +1,7 @@
+use std::sync::LazyLock;
 use std::time::Duration;
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 use serde_json::Value;
 use tracing::instrument;
 
@@ -38,16 +39,28 @@ impl std::error::Error for AniListRequestError {}
 
 const ANILIST_TIMEOUT_SECS: u64 = 10;
 
+static ANILIST_CLIENT: LazyLock<Result<Client, String>> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(ANILIST_TIMEOUT_SECS))
+        .build()
+        .map_err(|error| error.to_string())
+});
+
+#[instrument(name = "http.anilist.client")]
+fn get_client() -> Result<&'static Client, AniListRequestError> {
+    match &*ANILIST_CLIENT {
+        Ok(client) => Ok(client),
+        Err(error) => Err(AniListRequestError::ClientBuild(error.clone())),
+    }
+}
+
 #[instrument(
     name = "http.anilist.send_request",
     skip(json),
     fields(endpoint = "https://graphql.anilist.co/")
 )]
-pub fn send_request(json: Value) -> Result<String, AniListRequestError> {
-    let client = Client::builder()
-        .timeout(Duration::from_secs(ANILIST_TIMEOUT_SECS))
-        .build()
-        .map_err(|error| AniListRequestError::ClientBuild(error.to_string()))?;
+pub async fn send_request(json: Value) -> Result<String, AniListRequestError> {
+    let client = get_client()?;
 
     let response = client
         .post("https://graphql.anilist.co/")
@@ -55,11 +68,13 @@ pub fn send_request(json: Value) -> Result<String, AniListRequestError> {
         .header("Accept", "application/json")
         .body(json.to_string())
         .send()
+        .await
         .map_err(|error| AniListRequestError::RequestFailed(error.to_string()))?;
 
     let status = response.status();
     let body = response
         .text()
+        .await
         .map_err(|error| AniListRequestError::ResponseBodyReadFailed(error.to_string()))?;
 
     if !status.is_success() {

--- a/src/utils/requests/anilist.rs
+++ b/src/utils/requests/anilist.rs
@@ -46,7 +46,7 @@ static ANILIST_CLIENT: LazyLock<Result<Client, String>> = LazyLock::new(|| {
         .map_err(|error| error.to_string())
 });
 
-#[instrument(name = "http.anilist.client")]
+#[instrument(name = "http.anilist.client", level = "trace")]
 fn get_client() -> Result<&'static Client, AniListRequestError> {
     match &*ANILIST_CLIENT {
         Ok(client) => Ok(client),

--- a/src/utils/requests/my_anime_list.rs
+++ b/src/utils/requests/my_anime_list.rs
@@ -47,7 +47,7 @@ static MAL_CLIENT: LazyLock<Result<Client, String>> = LazyLock::new(|| {
         .map_err(|error| error.to_string())
 });
 
-#[instrument(name = "http.mal.client")]
+#[instrument(name = "http.mal.client", level = "trace")]
 fn get_client() -> Result<&'static Client, MalRequestError> {
     match &*MAL_CLIENT {
         Ok(client) => Ok(client),

--- a/src/utils/requests/my_anime_list.rs
+++ b/src/utils/requests/my_anime_list.rs
@@ -1,7 +1,8 @@
 use std::env;
+use std::sync::LazyLock;
 use std::time::Duration;
 
-use reqwest::blocking::Client;
+use reqwest::Client;
 use tracing::{info, instrument};
 
 use crate::utils::statics::MAL_CLIENT_ID;
@@ -39,6 +40,21 @@ const MY_ANIME_LIST_BASE: &str = "https://api.myanimelist.net/v2";
 const FIELDS_TO_FETCH: [&str; 3] = ["id", "opening_themes", "ending_themes"];
 const MAL_TIMEOUT_SECS: u64 = 10;
 
+static MAL_CLIENT: LazyLock<Result<Client, String>> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(MAL_TIMEOUT_SECS))
+        .build()
+        .map_err(|error| error.to_string())
+});
+
+#[instrument(name = "http.mal.client")]
+fn get_client() -> Result<&'static Client, MalRequestError> {
+    match &*MAL_CLIENT {
+        Ok(client) => Ok(client),
+        Err(error) => Err(MalRequestError::ClientBuild(error.clone())),
+    }
+}
+
 #[instrument(name = "http.mal.build_url", fields(mal_id = mal_id))]
 fn build_mal_url(mal_id: u32) -> String {
     let mal_url = format!(
@@ -51,23 +67,22 @@ fn build_mal_url(mal_id: u32) -> String {
 }
 
 #[instrument(name = "http.mal.send_request", skip_all, fields(mal_id = mal_id))]
-pub fn send_request(mal_id: u32) -> Result<String, MalRequestError> {
+pub async fn send_request(mal_id: u32) -> Result<String, MalRequestError> {
     let mal_client_id = env::var(MAL_CLIENT_ID).expect("Expected MAL_CLIENT_ID in the environment");
 
-    let client = Client::builder()
-        .timeout(Duration::from_secs(MAL_TIMEOUT_SECS))
-        .build()
-        .map_err(|error| MalRequestError::ClientBuild(error.to_string()))?;
+    let client = get_client()?;
 
     let response = client
         .get(build_mal_url(mal_id))
         .header("X-MAL-CLIENT-ID", mal_client_id)
         .send()
+        .await
         .map_err(|error| MalRequestError::RequestFailed(error.to_string()))?;
 
     let status = response.status();
     let body = response
         .text()
+        .await
         .map_err(|error| MalRequestError::ResponseBodyReadFailed(error.to_string()))?;
 
     if !status.is_success() {

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -1,5 +1,5 @@
 use crate::models::{
-    fetcher::{AnimeConfig, Argument, MangaConfig, Response},
+    fetcher::{AnimeConfig, Argument, MangaConfig, Response, fetch},
     media_type::MediaType as Type,
     transformers::Transformers,
 };
@@ -31,7 +31,7 @@ fn return_argument(arg: CommandDataOptionValue) -> Option<Argument> {
 }
 
 #[instrument(name = "fetcher.fetch", skip(arg), fields(media_type = ?media_type))]
-pub fn fetcher<
+pub async fn fetcher<
     T: serde::de::DeserializeOwned + Transformers + std::fmt::Debug + std::clone::Clone,
 >(
     media_type: Type,
@@ -43,11 +43,11 @@ pub fn fetcher<
     match media_type {
         Type::Anime => {
             let anime_response: AnimeConfig = Response::new(argument);
-            anime_response.fetch::<T>(media_type)
+            fetch::<T>(&anime_response, media_type).await
         }
         Type::Manga => {
             let manga_response: MangaConfig = Response::new(argument);
-            manga_response.fetch::<T>(media_type)
+            fetch::<T>(&manga_response, media_type).await
         }
     }
 }


### PR DESCRIPTION
## Summary
Migrate the AniList and MyAnimeList request helpers from blocking `reqwest` to async `reqwest`, thread the async boundary through the AniList lookup flow, and keep `spawn_blocking` only around the remaining sync Redis and Spotify work.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- c11f885e06e6a4d7c927c98da371ab8cb84d983e: migrate the shared reqwest clients to async usage and drop the blocking reqwest feature
- 00ac370ce40abe55dcac22c5ae16b358eb571732: make the AniList fetch pipeline async and await anime, manga, and guild lookup HTTP calls directly
- 229d8d4215500c0461e5e3367e7b7a7247270cee: convert the songs AniList and MAL fetch path to async while keeping Spotify embed-building work on a blocking boundary
- dba3ecaa1c4e62ff4757570b40a33127b5b4a529: bump the crate version to 2.10.2 and update the lockfile package version

### Notes
The `src/utils/llm.rs` client was also converted to async so the repository can remove reqwest's `blocking` feature cleanly.
Existing dead-code warnings in the currently unused LLM module still appear during validation, but `cargo clippy --all-targets --all-features` passes successfully.
The Spotify integration remains behind a blocking boundary because this ticket explicitly avoids rewriting that sync subsystem.

## Validation
- [x] `cargo fmt`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features`
- [ ] Manual Discord verification for `/anime`, `/manga`, `/songs`, and guild score lookups

## References
- Linear: ANNIE-144
- Notion: ANNIE-73 Async Reqwest Migration Plan
- Notion: Async Rules Of Thumb For Annie Mei

---

This PR description was written by GPT-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
