### PR TITLE
[ANNIE-146]/split-songs-fetch-pipeline-into-async-http-and-sync-spotify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.10.3"
+version = "2.10.4"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.10.3"
+version = "2.10.4"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -4,7 +4,10 @@ use crate::{
         songs::fetcher::{SongFetchResult, fetcher as SongFetcher},
     },
     models::mal_response::MalResponse,
-    utils::{privacy::configure_sentry_scope, statics::NOT_FOUND_ANIME},
+    utils::{
+        privacy::configure_sentry_scope, spotify::enrich_songs_with_spotify,
+        statics::NOT_FOUND_ANIME,
+    },
 };
 
 use serde_json::json;
@@ -17,14 +20,6 @@ use serenity::{
 
 use tokio::task;
 use tracing::{error, info, instrument};
-
-struct SongEmbedData {
-    title: String,
-    openings: String,
-    endings: String,
-    thumbnail: String,
-    mal_link: String,
-}
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("songs")
@@ -64,29 +59,42 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let response = SongFetcher(arg).await;
 
     let _songs_response = match response {
-        SongFetchResult::Found(song_response) => {
-            let embed_data =
-                match task::spawn_blocking(move || build_message_from_song_response(song_response))
-                    .await
-                {
-                    Ok(data) => data,
-                    Err(err) => {
-                        error!(error = %err, "spawn_blocking panicked while building song embed");
-                        let builder = EditInteractionResponse::new().content(
+        SongFetchResult::Found(mal_response) => {
+            // Pure parsing — no I/O, no spawn_blocking needed
+            let mut openings = mal_response.parse_openings();
+            let mut endings = mal_response.parse_endings();
+
+            // Narrow spawn_blocking: only the sync Spotify + Redis I/O
+            let (openings, endings) = match task::spawn_blocking(move || {
+                enrich_songs_with_spotify(&mut openings);
+                enrich_songs_with_spotify(&mut endings);
+                (openings, endings)
+            })
+            .await
+            {
+                Ok(result) => result,
+                Err(err) => {
+                    error!(error = %err, "spawn_blocking panicked during Spotify enrichment");
+                    let builder = EditInteractionResponse::new().content(
                         "An internal error occurred while fetching songs. Please try again later.",
                     );
-                        let _ = interaction.edit_response(&ctx.http, builder).await;
-                        return;
-                    }
-                };
+                    let _ = interaction.edit_response(&ctx.http, builder).await;
+                    return;
+                }
+            };
 
+            // Pure formatting — no I/O, no spawn_blocking needed
             let builder = EditInteractionResponse::new().embed(
                 CreateEmbed::new()
-                    .title(embed_data.title)
-                    .field("Openings", embed_data.openings, false)
-                    .field("Endings", embed_data.endings, false)
-                    .thumbnail(embed_data.thumbnail)
-                    .field("\u{200b}", embed_data.mal_link, false),
+                    .title(mal_response.transform_title())
+                    .field(
+                        "Openings",
+                        MalResponse::format_parsed_songs(&openings),
+                        false,
+                    )
+                    .field("Endings", MalResponse::format_parsed_songs(&endings), false)
+                    .thumbnail(mal_response.transform_thumbnail())
+                    .field("\u{200b}", mal_response.transform_mal_link(), false),
             );
             interaction.edit_response(&ctx.http, builder).await
         }
@@ -105,15 +113,4 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
             interaction.edit_response(&ctx.http, builder).await
         }
     };
-}
-
-#[instrument(name = "command.songs.build_message", skip(mal_response))]
-fn build_message_from_song_response(mal_response: MalResponse) -> SongEmbedData {
-    SongEmbedData {
-        title: mal_response.transform_title(),
-        openings: mal_response.transform_openings(),
-        endings: mal_response.transform_endings(),
-        thumbnail: mal_response.transform_thumbnail(),
-        mal_link: mal_response.transform_mal_link(),
-    }
 }

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -6,7 +6,7 @@ use crate::utils::{
 use std::{collections::HashSet, fmt::Write};
 
 use serde::Deserialize;
-use tracing::info;
+use tracing::{info, instrument};
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct MalResponse {
@@ -32,79 +32,118 @@ struct SongInfo {
     text: String,
 }
 
+/// A song parsed from a MAL response with metadata extracted from the raw text.
+/// The `spotify_url` field is left as `None` during parsing and filled in
+/// separately by the Spotify enrichment step.
+#[derive(Debug, Clone)]
+pub struct ParsedSong {
+    pub display_number: u32,
+    pub song_name: String,
+    pub romaji_name: String,
+    pub kana_name: Option<String>,
+    pub artist_names: Option<String>,
+    pub episode_numbers: Option<String>,
+    pub spotify_url: Option<String>,
+}
+
 impl MalResponse {
-    fn format_songs_for_display(songs: Vec<SongInfo>) -> String {
-        let mut return_string: Vec<String> = vec![];
-        let mut parsed_songs: HashSet<u32> = HashSet::new();
+    /// Parse opening themes into [`ParsedSong`] values without performing any I/O.
+    #[instrument(name = "mal_response.parse_openings", skip(self))]
+    pub fn parse_openings(&self) -> Vec<ParsedSong> {
+        Self::truncate_and_parse(self.opening_themes.clone())
+    }
+
+    /// Parse ending themes into [`ParsedSong`] values without performing any I/O.
+    #[instrument(name = "mal_response.parse_endings", skip(self))]
+    pub fn parse_endings(&self) -> Vec<ParsedSong> {
+        Self::truncate_and_parse(self.ending_themes.clone())
+    }
+
+    fn truncate_and_parse(songs: Option<Vec<SongInfo>>) -> Vec<ParsedSong> {
+        match songs {
+            None => vec![],
+            Some(mut songs_list) => {
+                // Only use first 10 entries, because discord hates large embeds
+                songs_list.truncate(10);
+                Self::parse_songs(songs_list)
+            }
+        }
+    }
+
+    fn parse_songs(songs: Vec<SongInfo>) -> Vec<ParsedSong> {
+        let mut result = vec![];
+        let mut seen_numbers: HashSet<u32> = HashSet::new();
+
         for (index, song) in songs.iter().enumerate() {
             let song_number = Self::get_song_number(&song.text);
 
-            if let Some(song_number) = song_number {
-                if parsed_songs.contains(&song_number) {
+            if let Some(num) = song_number {
+                if seen_numbers.contains(&num) {
                     continue;
-                } else {
-                    parsed_songs.insert(song_number);
                 }
+                seen_numbers.insert(num);
             }
+
             let song_name = Self::get_song_name(&song.text);
+            let romaji_name = Self::get_romaji_song_name(&song_name);
+            let kana_name = Self::get_kana_song_name(&song_name);
             let artist_names = Self::get_artist_names(&song.text);
             let episode_numbers = Self::get_episode_numbers(&song.text);
 
-            let mut song_string = "".to_string();
-
-            // Add song number if it exists else use index
-            write!(
-                song_string,
-                "{}. ",
-                song_number.unwrap_or_else(|| (index + 1_usize).try_into().unwrap())
-            )
-            .unwrap();
-
-            // Get Spotify URL
-            let spotify_url = match &artist_names {
-                Some(artist_names) => Self::fetch_spotify_url(
-                    Self::get_romaji_song_name(&song_name),
-                    Self::get_kana_song_name(&song_name),
-                    artist_names,
-                ),
-                None => None,
-            };
-
-            info!("Spotify Url: {:#?}", spotify_url);
-
-            // Add song name
-            match spotify_url {
-                Some(spotify_url) => {
-                    write!(song_string, "{}", linker(bold(song_name), spotify_url)).unwrap();
-                }
-                None => {
-                    write!(song_string, "{song_name}").unwrap();
-                }
-            }
-
-            // Add artist names if they exist
-            if let Some(artist_names) = artist_names {
-                write!(song_string, " by {}", artist_names).unwrap();
-            }
-
-            // Add episode numbers if they exist
-            if let Some(episode_numbers) = episode_numbers {
-                write!(song_string, " | {}", episode_numbers).unwrap();
-            }
-            return_string.push(song_string);
+            result.push(ParsedSong {
+                display_number: song_number.unwrap_or((index + 1) as u32),
+                song_name,
+                romaji_name,
+                kana_name,
+                artist_names,
+                episode_numbers,
+                spotify_url: None,
+            });
         }
-        return_string.join("\n")
+
+        result
     }
 
-    fn fetch_spotify_url(
-        romaji_name: String,
-        kana_name: Option<String>,
-        artist_name: &String,
-    ) -> Option<String> {
-        info!("Romaji Song Name: {:#?}", romaji_name);
-        info!("Kana Song Name: {:#?}", kana_name);
+    /// Format a slice of [`ParsedSong`] values into the Discord display string.
+    /// Spotify URLs, if present, are rendered as hyperlinks on the song name.
+    #[instrument(name = "mal_response.format_parsed_songs", skip(songs))]
+    pub fn format_parsed_songs(songs: &[ParsedSong]) -> String {
+        if songs.is_empty() {
+            return "No information available".to_string();
+        }
 
-        get_song_url(romaji_name, kana_name, artist_name.to_string())
+        let mut lines: Vec<String> = Vec::with_capacity(songs.len());
+
+        for song in songs {
+            let mut line = String::new();
+            write!(line, "{}. ", song.display_number).unwrap();
+
+            match &song.spotify_url {
+                Some(url) => {
+                    write!(
+                        line,
+                        "{}",
+                        linker(bold(song.song_name.clone()), url.clone())
+                    )
+                    .unwrap();
+                }
+                None => {
+                    write!(line, "{}", song.song_name).unwrap();
+                }
+            }
+
+            if let Some(ref artists) = song.artist_names {
+                write!(line, " by {}", artists).unwrap();
+            }
+
+            if let Some(ref episodes) = song.episode_numbers {
+                write!(line, " | {}", episodes).unwrap();
+            }
+
+            lines.push(line);
+        }
+
+        lines.join("\n")
     }
 
     fn get_artist_names(song: &str) -> Option<String> {
@@ -189,29 +228,39 @@ impl MalResponse {
         song[start_index + 1..end_index].parse::<u32>().ok()
     }
 
-    pub fn transform_endings(&self) -> String {
-        self.transform_songs(self.ending_themes.clone())
+    // --- Legacy wrappers (used by command.rs until the pipeline is updated) ---
+
+    pub fn transform_openings(&self) -> String {
+        let mut songs = self.parse_openings();
+        Self::enrich_and_format(&mut songs)
     }
+
+    pub fn transform_endings(&self) -> String {
+        let mut songs = self.parse_endings();
+        Self::enrich_and_format(&mut songs)
+    }
+
+    fn enrich_and_format(songs: &mut [ParsedSong]) -> String {
+        for song in songs.iter_mut() {
+            if let Some(ref artist) = song.artist_names {
+                info!("Romaji Song Name: {:#?}", song.romaji_name);
+                info!("Kana Song Name: {:#?}", song.kana_name);
+                song.spotify_url = get_song_url(
+                    song.romaji_name.clone(),
+                    song.kana_name.clone(),
+                    artist.clone(),
+                );
+                info!("Spotify Url: {:#?}", song.spotify_url);
+            }
+        }
+        Self::format_parsed_songs(songs)
+    }
+
+    // --- End legacy wrappers ---
 
     pub fn transform_mal_link(&self) -> String {
         let link = format!("https://www.myanimelist.net/anime/{}", self.id);
         linker("MyAnimeList".to_string(), link)
-    }
-
-    pub fn transform_openings(&self) -> String {
-        self.transform_songs(self.opening_themes.clone())
-    }
-
-    fn transform_songs(&self, songs: Option<Vec<SongInfo>>) -> String {
-        match songs {
-            None => "No information available".to_string(),
-            Some(mut songs_list) => {
-                // Only use first 10 entries, because discord hates large embeds
-                songs_list.truncate(10);
-                songs_list.shrink_to_fit();
-                Self::format_songs_for_display(songs_list)
-            }
-        }
     }
 
     pub fn transform_thumbnail(&self) -> String {

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -56,6 +56,7 @@ impl MalResponse {
         Self::truncate_and_parse(self.ending_themes.clone())
     }
 
+    #[instrument(name = "mal_response.truncate_and_parse", skip(songs))]
     fn truncate_and_parse(songs: Option<Vec<SongInfo>>) -> Vec<ParsedSong> {
         match songs {
             None => vec![],
@@ -67,6 +68,7 @@ impl MalResponse {
         }
     }
 
+    #[instrument(name = "mal_response.parse_songs", skip(songs), fields(count = songs.len()))]
     fn parse_songs(songs: Vec<SongInfo>) -> Vec<ParsedSong> {
         let mut result = vec![];
         let mut seen_numbers: HashSet<u32> = HashSet::new();

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -112,8 +112,7 @@ impl MalResponse {
         let mut lines: Vec<String> = Vec::with_capacity(songs.len());
 
         for song in songs {
-            let mut line = String::new();
-            write!(line, "{}. ", song.display_number).unwrap();
+            let mut line = format!("{}. ", song.display_number);
 
             match &song.spotify_url {
                 Some(url) => {

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -1,12 +1,9 @@
-use crate::utils::{
-    formatter::{bold, linker},
-    spotify::get_song_url,
-};
+use crate::utils::formatter::{bold, linker};
 
 use std::{collections::HashSet, fmt::Write};
 
 use serde::Deserialize;
-use tracing::{info, instrument};
+use tracing::instrument;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct MalResponse {
@@ -227,36 +224,6 @@ impl MalResponse {
 
         song[start_index + 1..end_index].parse::<u32>().ok()
     }
-
-    // --- Legacy wrappers (used by command.rs until the pipeline is updated) ---
-
-    pub fn transform_openings(&self) -> String {
-        let mut songs = self.parse_openings();
-        Self::enrich_and_format(&mut songs)
-    }
-
-    pub fn transform_endings(&self) -> String {
-        let mut songs = self.parse_endings();
-        Self::enrich_and_format(&mut songs)
-    }
-
-    fn enrich_and_format(songs: &mut [ParsedSong]) -> String {
-        for song in songs.iter_mut() {
-            if let Some(ref artist) = song.artist_names {
-                info!("Romaji Song Name: {:#?}", song.romaji_name);
-                info!("Kana Song Name: {:#?}", song.kana_name);
-                song.spotify_url = get_song_url(
-                    song.romaji_name.clone(),
-                    song.kana_name.clone(),
-                    artist.clone(),
-                );
-                info!("Spotify Url: {:#?}", song.spotify_url);
-            }
-        }
-        Self::format_parsed_songs(songs)
-    }
-
-    // --- End legacy wrappers ---
 
     pub fn transform_mal_link(&self) -> String {
         let link = format!("https://www.myanimelist.net/anime/{}", self.id);

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -1,6 +1,9 @@
-use crate::utils::{
-    redis::{check_cache, try_to_cache_response},
-    statics::{SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET},
+use crate::{
+    models::mal_response::ParsedSong,
+    utils::{
+        redis::{check_cache, try_to_cache_response},
+        statics::{SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET},
+    },
 };
 
 use rspotify::{
@@ -10,7 +13,7 @@ use rspotify::{
 };
 
 use std::env;
-use tracing::info;
+use tracing::{info, instrument};
 
 fn get_spotify_client() -> ClientCredsSpotify {
     let client_id =
@@ -114,5 +117,21 @@ fn get_url_from_search_result(search_result: SearchResult) -> Option<String> {
     } else {
         info!("Something else");
         None
+    }
+}
+
+/// Fill in `spotify_url` for each [`ParsedSong`] that has an artist.
+/// This performs synchronous Spotify + Redis I/O and is intended to run
+/// inside `spawn_blocking`.
+#[instrument(name = "spotify.enrich_songs", skip(songs), fields(count = songs.len()))]
+pub fn enrich_songs_with_spotify(songs: &mut [ParsedSong]) {
+    for song in songs.iter_mut() {
+        if let Some(ref artist) = song.artist_names {
+            song.spotify_url = get_song_url(
+                song.romaji_name.clone(),
+                song.kana_name.clone(),
+                artist.clone(),
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Refactor the `/songs` command pipeline so `spawn_blocking` only wraps the sync Spotify + Redis enrichment instead of the entire song-fetch workflow. Pure parsing and embed formatting now run directly in the async context, cleanly separating async HTTP boundaries (AniList, MAL) from the intentionally synchronous Spotify path.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore

## Changes

- c44b9665761f3d0875ad272e74550fda460dad5f: Extract `ParsedSong` struct and pure parsing/formatting methods from `MalResponse`, decoupling song text extraction from Spotify I/O
- 18b89335d445455257039f2b0222b5e1e2ea5500: Add `enrich_songs_with_spotify()` in `spotify.rs` as the explicit sync boundary for Spotify + Redis lookups
- 17fb615a9acf4ceea816f72be23707f2ac77ea0a: Rewire `command.rs` to a 3-stage pipeline (pure parse → narrow `spawn_blocking` for Spotify → pure format), remove legacy wrappers from `MalResponse`
- 66f6e9305a386489bc86cfeb41437e44d3cf14f7: Replace empty `String::new()` with `format!` initialization (DeepSource RS-W1079)
- f9cb21cc5bab84a27aa54a5fc06363d731665210: Bump version to 2.10.4

### Notes

This is Phase 3, Step 3 of the ANNIE-73 async reqwest migration plan. The `Async Rules Of Thumb` doc guided the boundary placement: "Prefer a narrow `spawn_blocking` around the actual sync dependency, not the whole workflow."

`MalResponse` no longer imports from `spotify.rs`, fully decoupling the model layer from external service I/O. The new `ParsedSong` struct acts as the data bridge between the parsing, enrichment, and formatting stages.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` — all 71 tests pass
- [x] Manual Discord QA: `/songs <anime>` returns the same embed shape for found, not-found, and error cases

## References

- [ANNIE-146](https://linear.app/annie-mei/issue/ANNIE-146)
- [ANNIE-73 Async Reqwest Migration Plan](https://www.notion.so/3400c6c7aa8b8115894ddbfb0926107b)
- [Async Rules Of Thumb For Annie Mei](https://www.notion.so/3400c6c7aa8b81aeba66d6ae2799b758)

---

This PR description was written by Claude Opus 4.6.