### PR TITLE
[ANNIE-148]/fix-stale-ssl-connections-in-r2d2-database-pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.10.7"
+version = "2.10.8"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.10.7"
+version = "2.10.8"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -7,6 +7,7 @@ use diesel::sql_query;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use serenity::{client::Context, prelude::TypeMapKey};
 use std::env;
+use std::time::Duration;
 use tracing::{error, info, instrument};
 
 pub type DbPool = Pool<ConnectionManager<PgConnection>>;
@@ -23,15 +24,20 @@ pub fn create_pool() -> DbPool {
     let database_url = env::var(DATABASE_URL).expect("DATABASE_URL must be set");
     let manager = ConnectionManager::<PgConnection>::new(database_url.clone());
 
-    Pool::builder().build(manager).unwrap_or_else(|error| {
-        let redacted_url = redact_database_url(&database_url);
-        error!(
-            error = %error,
-            database_url = %redacted_url,
-            "Failed to create database connection pool"
-        );
-        panic!("Error creating pool for {redacted_url}: {error}")
-    })
+    Pool::builder()
+        .test_on_check_out(true)
+        .max_lifetime(Some(Duration::from_secs(20 * 60)))
+        .idle_timeout(Some(Duration::from_secs(10 * 60)))
+        .build(manager)
+        .unwrap_or_else(|error| {
+            let redacted_url = redact_database_url(&database_url);
+            error!(
+                error = %error,
+                database_url = %redacted_url,
+                "Failed to create database connection pool"
+            );
+            panic!("Error creating pool for {redacted_url}: {error}")
+        })
 }
 
 #[instrument(name = "db.get_connection", skip(pool))]


### PR DESCRIPTION
## Summary

- Configure the r2d2 connection pool with health checks and lifetime limits to prevent stale SSL connections from causing errors after Neon cold-starts or proxy restarts
- Fixes Sentry issue [ANNIE-MEI-21](https://annie-mei.sentry.io/issues/ANNIE-MEI-21) — "SSL connection has been closed unexpectedly" (117 occurrences, regressed today)

## Type of Change

- [x] Bug fix

## Changes

- 03c2f2f8242d74f7ff196b581c1333bcc19e3d71: Add `test_on_check_out(true)`, `max_lifetime(20 min)`, and `idle_timeout(10 min)` to r2d2 pool builder in `src/utils/database.rs`
- 12489e3: Bump version to 2.10.8

### Notes

The root cause is that Neon's compute endpoint scales down after idle periods, severing all SSL connections. The r2d2 pool had no mechanism to detect or recycle dead connections — it would hand them out and fail on first use. The three new settings ensure:
- Connections are validated before checkout (`test_on_check_out`)
- Connections are recycled before they hit server-side timeouts (`max_lifetime`)
- Idle connections are cleaned up proactively (`idle_timeout`)

## Validation

- [x] `cargo check` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] `cargo fmt` applied
- [ ] Deploy and verify ANNIE-MEI-21 stops recurring in Sentry

## References

- Sentry: https://annie-mei.sentry.io/issues/ANNIE-MEI-21
- Linear: https://linear.app/annie-mei/issue/ANNIE-148/fix-stale-ssl-connections-in-r2d2-database-pool

---

This PR description was written by Claude Opus 4.6.