### PR TITLE
[ANNIE-42]/use-users-input-to-determine-the-primary-and-secondary-name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.10.11"
+version = "2.11.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.10.11"
+version = "2.11.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -217,4 +217,89 @@ mod tests {
 
         assert!(response.is_embed());
     }
+
+    /// Helper: build an `Anime` whose title fields are visibly distinct so
+    /// title/footer swaps can be observed in the embed JSON.
+    fn anime_with_distinct_titles() -> Anime {
+        serde_json::from_value(serde_json::json!({
+            "type": "ANIME",
+            "id": 16498,
+            "idMal": 16498,
+            "isAdult": false,
+            "title": {
+                "romaji": "Shingeki no Kyojin",
+                "english": "Attack on Titan",
+                "native": "進撃の巨人"
+            },
+            "synonyms": [],
+            "season": "SPRING",
+            "seasonYear": 2013,
+            "format": "TV",
+            "status": "FINISHED",
+            "episodes": 25,
+            "duration": 24,
+            "genres": ["Action"],
+            "source": "MANGA",
+            "coverImage": {
+                "extraLarge": "https://example.com/cover.jpg",
+                "large": null,
+                "medium": null,
+                "color": "#000000"
+            },
+            "averageScore": 84,
+            "studios": { "edges": [], "nodes": [] },
+            "siteUrl": "https://anilist.co/anime/16498",
+            "externalLinks": [],
+            "trailer": null,
+            "description": "",
+            "tags": []
+        }))
+        .expect("sample anime JSON should deserialize")
+    }
+
+    fn embed_title_and_footer(response: CommandResponse) -> (String, String) {
+        let embed = response.unwrap_embed();
+        let value = serde_json::to_value(&embed).expect("embed serializes");
+        let title = value["title"].as_str().unwrap_or_default().to_string();
+        let footer = value["footer"]["text"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        (title, footer)
+    }
+
+    #[test]
+    fn english_variant_puts_english_title_in_embed_and_romaji_in_footer() {
+        let response = handle_anime(
+            Some(anime_with_distinct_titles()),
+            None,
+            Some(TitleVariant::English),
+        );
+
+        let (title, footer) = embed_title_and_footer(response);
+        assert_eq!(title, "Attack on Titan");
+        assert_eq!(footer, "Shingeki No Kyojin");
+    }
+
+    #[test]
+    fn romaji_variant_puts_romaji_title_in_embed_and_english_in_footer() {
+        let response = handle_anime(
+            Some(anime_with_distinct_titles()),
+            None,
+            Some(TitleVariant::Romaji),
+        );
+
+        let (title, footer) = embed_title_and_footer(response);
+        assert_eq!(title, "Shingeki No Kyojin");
+        assert_eq!(footer, "Attack on Titan");
+    }
+
+    #[test]
+    fn no_variant_signal_preserves_legacy_romaji_title_english_footer() {
+        let response = handle_anime(Some(anime_with_distinct_titles()), None, None);
+
+        let (title, footer) = embed_title_and_footer(response);
+        assert_eq!(title, "Shingeki No Kyojin");
+        assert_eq!(footer, "Attack on Titan");
+    }
 }

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -5,7 +5,10 @@ use crate::{
         response::CommandResponse,
         traits::{AniListSource, MediaDataSource},
     },
-    models::{anilist_anime::Anime, transformers::Transformers, user_media_list::MediaListData},
+    models::{
+        anilist_anime::Anime, anilist_common::TitleVariant, transformers::Transformers,
+        user_media_list::MediaListData,
+    },
     utils::{
         channel::is_nsfw_channel,
         guild::{get_current_guild_members, get_guild_data_for_media},
@@ -50,7 +53,9 @@ pub fn register() -> CreateCommand {
 pub fn handle_anime(
     anime: Option<Anime>,
     guild_members_data: Option<HashMap<i64, MediaListData>>,
+    title_variant: Option<TitleVariant>,
 ) -> CommandResponse {
+    let _ = title_variant; // wired in next commit (transform_response_embed)
     match anime {
         None => CommandResponse::Content(NOT_FOUND_ANIME.to_string()),
         Some(anime_response) => {
@@ -84,7 +89,11 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     info!("Got command 'anime' with search_term: {search_term}");
 
-    let anime_result: Option<Anime> = AniListSource.fetch_anime(&search_term).await;
+    let fetch_result: Option<(Anime, TitleVariant)> = AniListSource.fetch_anime(&search_term).await;
+    let (anime_result, title_variant): (Option<Anime>, Option<TitleVariant>) = match fetch_result {
+        Some((anime, variant)) => (Some(anime), Some(variant)),
+        None => (None, None),
+    };
 
     // Block adult content in non-NSFW channels.
     if let Some(ref anime) = anime_result
@@ -114,7 +123,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
 
     // Delegate to the transport-agnostic core logic.
-    let response = handle_anime(anime_result, guild_members_data);
+    let response = handle_anime(anime_result, guild_members_data, title_variant);
 
     // Map the CommandResponse to the appropriate Discord API call.
     let _result = match response {
@@ -184,7 +193,7 @@ mod tests {
 
     #[test]
     fn anime_not_found_returns_content_with_message() {
-        let response = handle_anime(None, None);
+        let response = handle_anime(None, None, None);
 
         assert!(response.is_content(), "expected Content variant");
         assert_eq!(response.unwrap_content(), NOT_FOUND_ANIME);
@@ -192,7 +201,7 @@ mod tests {
 
     #[test]
     fn anime_success_returns_embed() {
-        let response = handle_anime(Some(sample_anime()), None);
+        let response = handle_anime(Some(sample_anime()), None, None);
 
         assert!(
             response.is_embed(),
@@ -205,7 +214,7 @@ mod tests {
 
     #[test]
     fn anime_success_with_no_guild_data_still_returns_embed() {
-        let response = handle_anime(Some(sample_anime()), None);
+        let response = handle_anime(Some(sample_anime()), None, None);
 
         assert!(response.is_embed());
     }

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -55,11 +55,10 @@ pub fn handle_anime(
     guild_members_data: Option<HashMap<i64, MediaListData>>,
     title_variant: Option<TitleVariant>,
 ) -> CommandResponse {
-    let _ = title_variant; // wired in next commit (transform_response_embed)
     match anime {
         None => CommandResponse::Content(NOT_FOUND_ANIME.to_string()),
         Some(anime_response) => {
-            let embed = anime_response.transform_response_embed(guild_members_data);
+            let embed = anime_response.transform_response_embed(guild_members_data, title_variant);
             CommandResponse::Embed(Box::new(embed))
         }
     }

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -5,7 +5,10 @@ use crate::{
         response::CommandResponse,
         traits::{AniListSource, MediaDataSource},
     },
-    models::{anilist_manga::Manga, transformers::Transformers, user_media_list::MediaListData},
+    models::{
+        anilist_common::TitleVariant, anilist_manga::Manga, transformers::Transformers,
+        user_media_list::MediaListData,
+    },
     utils::{
         channel::is_nsfw_channel,
         guild::{get_current_guild_members, get_guild_data_for_media},
@@ -50,7 +53,9 @@ pub fn register() -> CreateCommand {
 pub fn handle_manga(
     manga: Option<Manga>,
     guild_members_data: Option<HashMap<i64, MediaListData>>,
+    title_variant: Option<TitleVariant>,
 ) -> CommandResponse {
+    let _ = title_variant; // wired in next commit (transform_response_embed)
     match manga {
         None => CommandResponse::Content(NOT_FOUND_MANGA.to_string()),
         Some(manga_response) => {
@@ -84,7 +89,11 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     info!("Got command 'manga' with search_term: {search_term}");
 
-    let manga_result: Option<Manga> = AniListSource.fetch_manga(&search_term).await;
+    let fetch_result: Option<(Manga, TitleVariant)> = AniListSource.fetch_manga(&search_term).await;
+    let (manga_result, title_variant): (Option<Manga>, Option<TitleVariant>) = match fetch_result {
+        Some((manga, variant)) => (Some(manga), Some(variant)),
+        None => (None, None),
+    };
 
     // Block adult content in non-NSFW channels.
     if let Some(ref manga) = manga_result
@@ -114,7 +123,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
 
     // Delegate to the transport-agnostic core logic.
-    let response = handle_manga(manga_result, guild_members_data);
+    let response = handle_manga(manga_result, guild_members_data, title_variant);
 
     // Map the CommandResponse to the appropriate Discord API call.
     let _result = match response {
@@ -181,7 +190,7 @@ mod tests {
 
     #[test]
     fn manga_not_found_returns_content_with_message() {
-        let response = handle_manga(None, None);
+        let response = handle_manga(None, None, None);
 
         assert!(response.is_content(), "expected Content variant");
         assert_eq!(response.unwrap_content(), NOT_FOUND_MANGA);
@@ -189,7 +198,7 @@ mod tests {
 
     #[test]
     fn manga_success_returns_embed() {
-        let response = handle_manga(Some(sample_manga()), None);
+        let response = handle_manga(Some(sample_manga()), None, None);
 
         assert!(
             response.is_embed(),
@@ -200,7 +209,7 @@ mod tests {
 
     #[test]
     fn manga_success_with_no_guild_data_still_returns_embed() {
-        let response = handle_manga(Some(sample_manga()), None);
+        let response = handle_manga(Some(sample_manga()), None, None);
 
         assert!(response.is_embed());
     }

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -55,11 +55,10 @@ pub fn handle_manga(
     guild_members_data: Option<HashMap<i64, MediaListData>>,
     title_variant: Option<TitleVariant>,
 ) -> CommandResponse {
-    let _ = title_variant; // wired in next commit (transform_response_embed)
     match manga {
         None => CommandResponse::Content(NOT_FOUND_MANGA.to_string()),
         Some(manga_response) => {
-            let embed = manga_response.transform_response_embed(guild_members_data);
+            let embed = manga_response.transform_response_embed(guild_members_data, title_variant);
             CommandResponse::Embed(Box::new(embed))
         }
     }

--- a/src/commands/songs/fetcher.rs
+++ b/src/commands/songs/fetcher.rs
@@ -18,8 +18,8 @@ pub enum SongFetchResult {
 
 #[instrument(name = "command.songs.fetcher", skip(args))]
 pub async fn fetcher(args: CommandDataOptionValue) -> SongFetchResult {
-    let anime_response: Option<Anime> = anime_fetcher(Type::Anime, args).await;
-    let Some(anime) = anime_response else {
+    let anime_response = anime_fetcher::<Anime>(Type::Anime, args).await;
+    let Some((anime, _variant)) = anime_response else {
         return SongFetchResult::AnimeNotFound;
     };
 

--- a/src/commands/traits.rs
+++ b/src/commands/traits.rs
@@ -19,23 +19,33 @@
 
 use std::future::Future;
 
-use crate::models::{anilist_anime::Anime, anilist_manga::Manga};
+use crate::models::{anilist_anime::Anime, anilist_common::TitleVariant, anilist_manga::Manga};
 
 /// Abstraction over media-data retrieval (AniList today, pluggable tomorrow).
 ///
 /// Implement this trait for production (real API) and test (mocked data)
 /// variants. Command core-logic functions accept `&impl MediaDataSource` so
 /// they never touch the network directly.
+///
+/// Each fetch returns the matched media along with the [`TitleVariant`] that
+/// best matched the user's input, so handlers can pick the matching variant
+/// for the embed title (and demote the other to the footer).
 pub trait MediaDataSource: Send + Sync {
     /// Fetch anime data for the given search term (name **or** numeric ID).
     ///
     /// Returns `None` when no matching anime is found.
-    fn fetch_anime(&self, search_term: &str) -> impl Future<Output = Option<Anime>> + Send;
+    fn fetch_anime(
+        &self,
+        search_term: &str,
+    ) -> impl Future<Output = Option<(Anime, TitleVariant)>> + Send;
 
     /// Fetch manga data for the given search term (name **or** numeric ID).
     ///
     /// Returns `None` when no matching manga is found.
-    fn fetch_manga(&self, search_term: &str) -> impl Future<Output = Option<Manga>> + Send;
+    fn fetch_manga(
+        &self,
+        search_term: &str,
+    ) -> impl Future<Output = Option<(Manga, TitleVariant)>> + Send;
 }
 
 /// Production [`MediaDataSource`] backed by the AniList GraphQL API.
@@ -45,7 +55,7 @@ pub trait MediaDataSource: Send + Sync {
 pub struct AniListSource;
 
 impl MediaDataSource for AniListSource {
-    async fn fetch_anime(&self, search_term: &str) -> Option<Anime> {
+    async fn fetch_anime(&self, search_term: &str) -> Option<(Anime, TitleVariant)> {
         use crate::models::media_type::MediaType;
         use crate::utils::response_fetcher::fetcher;
         use serenity::all::CommandDataOptionValue;
@@ -54,7 +64,7 @@ impl MediaDataSource for AniListSource {
         fetcher::<Anime>(MediaType::Anime, arg).await
     }
 
-    async fn fetch_manga(&self, search_term: &str) -> Option<Manga> {
+    async fn fetch_manga(&self, search_term: &str) -> Option<(Manga, TitleVariant)> {
         use crate::models::media_type::MediaType;
         use crate::utils::response_fetcher::fetcher;
         use serenity::all::CommandDataOptionValue;

--- a/src/commands/traits.rs
+++ b/src/commands/traits.rs
@@ -8,12 +8,13 @@
 //! ```ignore
 //! use crate::commands::{anime::command::handle_anime, response::CommandResponse};
 //!
-//! // Not-found path — no anime, no guild data.
-//! let response = handle_anime(None, None);
+//! // Not-found path — no anime, no guild data, no variant signal.
+//! let response = handle_anime(None, None, None);
 //! assert!(response.is_content());
 //!
-//! // Success path — pass a pre-built Anime and optional guild data.
-//! let response = handle_anime(Some(sample_anime), Some(guild_data));
+//! // Success path — pass a pre-built Anime, optional guild data, and the
+//! // matched title variant (so the embed surfaces the user's typed variant).
+//! let response = handle_anime(Some(sample_anime), Some(guild_data), Some(title_variant));
 //! assert!(response.is_embed());
 //! ```
 

--- a/src/models/anilist_common.rs
+++ b/src/models/anilist_common.rs
@@ -7,6 +7,17 @@ pub struct Title {
     pub native: Option<String>,
 }
 
+/// Which title variant the user's search input best matched.
+///
+/// Used to decide which variant is surfaced as the embed title vs the footer,
+/// so the primary title mirrors what the user typed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TitleVariant {
+    English,
+    Romaji,
+    Native,
+}
+
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CoverImage {

--- a/src/models/anilist_common.rs
+++ b/src/models/anilist_common.rs
@@ -15,6 +15,9 @@ pub struct Title {
 pub enum TitleVariant {
     English,
     Romaji,
+    // Reserved for future native-input detection; today the fuzzy matcher
+    // only scores against english/romaji, so this variant is never produced.
+    #[allow(dead_code)]
     Native,
 }
 

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -4,8 +4,9 @@ use crate::{
         manga::queries::{FETCH_MANGA, FETCH_MANGA_BY_ID},
     },
     models::{
-        id_response::FetchResponse as IdResponse, media_response::FetchResponse as MediaResponse,
-        media_type::MediaType as Type, transformers::Transformers,
+        anilist_common::TitleVariant, id_response::FetchResponse as IdResponse,
+        media_response::FetchResponse as MediaResponse, media_type::MediaType as Type,
+        transformers::Transformers,
     },
     utils::{
         fetch_by_arguments::{fetch_by_id, fetch_by_name},
@@ -88,7 +89,7 @@ pub async fn fetch<
 >(
     response_config: &impl Response,
     media_type: Type,
-) -> Option<T> {
+) -> Option<(T, TitleVariant)> {
     match response_config.get_argument() {
         Argument::Id(value) => {
             let fetched_data = match fetch_by_id(response_config.get_id_query(), *value).await {
@@ -106,7 +107,13 @@ pub async fn fetch<
                 }
             };
             debug!("Deserialized response: {:#?}", fetch_response);
-            fetch_response.data.and_then(|data| data.media)
+            // ID lookups bypass fuzzy matching, so we have no signal about
+            // which variant the user prefers — default to Romaji to preserve
+            // the existing primary-title behaviour.
+            fetch_response
+                .data
+                .and_then(|data| data.media)
+                .map(|media| (media, TitleVariant::Romaji))
         }
         Argument::Search(value) => {
             let cache_key = format!("{}:{value}", media_type.as_ref());

--- a/src/models/media_response.rs
+++ b/src/models/media_response.rs
@@ -104,6 +104,10 @@ impl<T: Transformers + std::clone::Clone> FetchResponse<T> {
 
         let english_score = top_english_title_match.result.similarity;
         let romaji_score = top_romaji_title_match.result.similarity;
+        // On exact ties (including the common case where both variants share
+        // the same string for the same entry), prefer English. AniList lists
+        // English first in its UI, so this matches user expectations and keeps
+        // the prior default behaviour.
         let (top_match, top_variant) = if english_score < romaji_score {
             (top_romaji_title_match, TitleVariant::Romaji)
         } else {

--- a/src/models/media_response.rs
+++ b/src/models/media_response.rs
@@ -1,5 +1,5 @@
 use crate::{
-    models::{media_type::MediaType, transformers::Transformers},
+    models::{anilist_common::TitleVariant, media_type::MediaType, transformers::Transformers},
     utils::fuzzy::{fuzzy_matcher, fuzzy_matcher_synonyms},
 };
 
@@ -63,7 +63,11 @@ impl<T: Transformers + std::clone::Clone> FetchResponse<T> {
             .collect()
     }
 
-    pub fn fuzzy_match(&self, user_input: &str, media_type: MediaType) -> Option<T> {
+    pub fn fuzzy_match(
+        &self,
+        user_input: &str,
+        media_type: MediaType,
+    ) -> Option<(T, TitleVariant)> {
         let no_result = &self.no_results();
 
         if *no_result {
@@ -100,10 +104,10 @@ impl<T: Transformers + std::clone::Clone> FetchResponse<T> {
 
         let english_score = top_english_title_match.result.similarity;
         let romaji_score = top_romaji_title_match.result.similarity;
-        let top_match = if english_score < romaji_score {
-            top_romaji_title_match
+        let (top_match, top_variant) = if english_score < romaji_score {
+            (top_romaji_title_match, TitleVariant::Romaji)
         } else {
-            top_english_title_match
+            (top_english_title_match, TitleVariant::English)
         };
 
         if !need_to_match_synonyms {
@@ -112,7 +116,7 @@ impl<T: Transformers + std::clone::Clone> FetchResponse<T> {
                 media_list[top_match.index].get_english_title(),
                 top_match.index
             );
-            Some(media_list[top_match.index].clone())
+            Some((media_list[top_match.index].clone(), top_variant))
         } else {
             let synonyms: Vec<Vec<String>> = media_list
                 .iter()
@@ -125,10 +129,12 @@ impl<T: Transformers + std::clone::Clone> FetchResponse<T> {
                         if media_list.is_empty() {
                             None
                         } else {
-                            Some(media_list[0].clone())
+                            // No clean variant signal — preserve current default
+                            // (Romaji as primary title) for ambiguous fallbacks.
+                            Some((media_list[0].clone(), TitleVariant::Romaji))
                         }
                     }
-                    _ => Some(media_list[top_match.index].clone()),
+                    _ => Some((media_list[top_match.index].clone(), top_variant)),
                 }
             } else {
                 info!(
@@ -136,7 +142,10 @@ impl<T: Transformers + std::clone::Clone> FetchResponse<T> {
                     media_list[top_synonym_match.index].get_romaji_title(),
                     top_synonym_match.index
                 );
-                Some(media_list[top_synonym_match.index].clone())
+                Some((
+                    media_list[top_synonym_match.index].clone(),
+                    TitleVariant::Romaji,
+                ))
             }
         }
     }

--- a/src/models/media_response.rs
+++ b/src/models/media_response.rs
@@ -150,3 +150,77 @@ impl<T: Transformers + std::clone::Clone> FetchResponse<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::anilist_anime::Anime;
+
+    fn anime_response_json(english: &str, romaji: &str) -> serde_json::Value {
+        serde_json::json!({
+            "data": {
+                "Page": {
+                    "media": [{
+                        "type": "ANIME",
+                        "id": 1,
+                        "idMal": 1,
+                        "isAdult": false,
+                        "title": {
+                            "romaji": romaji,
+                            "english": english,
+                            "native": "ネイティブ"
+                        },
+                        "synonyms": [],
+                        "season": "FALL",
+                        "seasonYear": 2024,
+                        "format": "TV",
+                        "status": "RELEASING",
+                        "episodes": null,
+                        "duration": 24,
+                        "genres": [],
+                        "source": "MANGA",
+                        "coverImage": {
+                            "extraLarge": "https://example.com/cover.jpg",
+                            "large": null,
+                            "medium": null,
+                            "color": "#000000"
+                        },
+                        "averageScore": 80,
+                        "studios": { "edges": [], "nodes": [] },
+                        "siteUrl": "https://anilist.co/anime/1",
+                        "externalLinks": [],
+                        "trailer": null,
+                        "description": "",
+                        "tags": []
+                    }]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn fuzzy_match_returns_english_variant_when_user_types_english_title() {
+        let payload = anime_response_json("Attack on Titan", "Shingeki no Kyojin");
+        let response: FetchResponse<Anime> =
+            serde_json::from_value(payload).expect("payload deserializes");
+
+        let (_, variant) = response
+            .fuzzy_match("Attack on Titan", MediaType::Anime)
+            .expect("expected a match");
+
+        assert_eq!(variant, TitleVariant::English);
+    }
+
+    #[test]
+    fn fuzzy_match_returns_romaji_variant_when_user_types_romaji_title() {
+        let payload = anime_response_json("Attack on Titan", "Shingeki no Kyojin");
+        let response: FetchResponse<Anime> =
+            serde_json::from_value(payload).expect("payload deserializes");
+
+        let (_, variant) = response
+            .fuzzy_match("Shingeki no Kyojin", MediaType::Anime)
+            .expect("expected a match");
+
+        assert_eq!(variant, TitleVariant::Romaji);
+    }
+}

--- a/src/models/transformers.rs
+++ b/src/models/transformers.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     models::{
-        anilist_common::{CoverImage, Tag},
+        anilist_common::{CoverImage, Tag, TitleVariant},
         user_media_list::MediaListData,
     },
     utils::{formatter::*, statics::EMPTY_STR},
@@ -64,6 +64,17 @@ pub trait Transformers {
             },
         };
         titlecase(&return_title)
+    }
+    fn transform_native_title(&self) -> String {
+        // Native titles are typically Japanese, so titlecase would be wrong.
+        // Fall back to romaji → english when native is missing.
+        match self.get_native_title() {
+            Some(title) => title,
+            None => match self.get_romaji_title() {
+                Some(title) => titlecase(&title),
+                None => titlecase(&self.get_english_title().unwrap_or_default()),
+            },
+        }
     }
 
     fn transform_format(&self) -> String {
@@ -168,16 +179,35 @@ pub trait Transformers {
     fn transform_response_embed(
         &self,
         guild_members_data: Option<HashMap<i64, MediaListData>>,
+        title_variant: Option<TitleVariant>,
     ) -> CreateEmbed {
         let is_anime = self.get_type() == "anime";
+
+        // Surface whichever variant the user typed as the primary title;
+        // park the other one in the footer. Default (no signal) keeps the
+        // long-standing Romaji-as-title behaviour.
+        let (primary_title, footer_title) = match title_variant {
+            Some(TitleVariant::English) => (
+                self.transform_english_title(),
+                self.transform_romaji_title(),
+            ),
+            Some(TitleVariant::Native) => {
+                (self.transform_native_title(), self.transform_romaji_title())
+            }
+            Some(TitleVariant::Romaji) | None => (
+                self.transform_romaji_title(),
+                self.transform_english_title(),
+            ),
+        };
+
         let mut embed = CreateEmbed::new()
             // General Embed Fields
             .color(self.transform_color())
-            .title(self.transform_romaji_title())
+            .title(primary_title)
             .description(self.transform_description_and_mal_link())
             .url(self.transform_anilist())
             .thumbnail(self.transform_thumbnail())
-            .footer(CreateEmbedFooter::new(self.transform_english_title()))
+            .footer(CreateEmbedFooter::new(footer_title))
             // self Data Fields
             // First line after MAL link
             .fields(vec![

--- a/src/models/transformers.rs
+++ b/src/models/transformers.rs
@@ -191,6 +191,10 @@ pub trait Transformers {
                 self.transform_english_title(),
                 self.transform_romaji_title(),
             ),
+            // Native primary pairs with Romaji in the footer: Romaji is the
+            // direct transliteration, so it acts as a pronunciation aid for
+            // the Native script. English is intentionally omitted here — it
+            // is the variant least related to a native-script search.
             Some(TitleVariant::Native) => {
                 (self.transform_native_title(), self.transform_romaji_title())
             }

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -1,4 +1,5 @@
 use crate::models::{
+    anilist_common::TitleVariant,
     fetcher::{AnimeConfig, Argument, MangaConfig, Response, fetch},
     media_type::MediaType as Type,
     transformers::Transformers,
@@ -36,7 +37,7 @@ pub async fn fetcher<
 >(
     media_type: Type,
     arg: CommandDataOptionValue,
-) -> Option<T> {
+) -> Option<(T, TitleVariant)> {
     info!("Fetcher found arg: {:#?}", arg);
     let argument = return_argument(arg)?;
 


### PR DESCRIPTION
## Summary

Make the embed title mirror the variant the user typed: searching the English title surfaces the English title (with Romaji in the footer); searching the Romaji title surfaces Romaji (with English in the footer). Previously the title was always Romaji and the footer always English, regardless of input.

Closes [ANNIE-42](https://linear.app/annie-mei/issue/ANNIE-42/use-users-input-to-determine-the-primary-and-secondary-name-variant).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 6bee75b27c55078784f9943384fa42d81f04a639: introduce a shared `TitleVariant` enum (English / Romaji / Native) representing which variant best matched the user's search.
- 4101a76ae2c0251e37ac73d9fbfa1ad5e0cdda16: thread `TitleVariant` through `FetchResponse::fuzzy_match` → `fetcher` / `response_fetcher` → `MediaDataSource` trait → `handle_anime` / `handle_manga`. ID lookups and synonym fallbacks default to Romaji to preserve existing behaviour; `/songs` discards the variant since it only needs the MAL ID.
- 6e9d3fe8a19c6e5cf183cc220c595c6028a79dfe: `transform_response_embed` now picks title vs footer based on the variant, with a new `transform_native_title` helper (no titlecase, since native titles are typically Japanese). Default (no signal) keeps the legacy Romaji-as-title / English-as-footer behaviour.
- 8c5146f2b30bedc2cec952d1eb95111df15475fa: add tests covering both variant detection (`fuzzy_match`) and the title/footer swap at the handler boundary; bump to 2.11.0 (minor — new feature). `TitleVariant::Native` is `#[allow(dead_code)]` since native-input detection isn't wired today.

### Notes

- `fuzzy_match` only scores against english/romaji titles; native-input detection isn't implemented (would need Japanese-aware matching). The enum carries a `Native` arm for forward-compatibility.
- Backward compatible: ID lookups, synonym-only matches, and any other "no clean signal" path falls back to the original Romaji-title / English-footer layout.

## Validation
- [x] `cargo fmt`
- [x] `cargo clippy` (no new warnings beyond pre-existing dead-code)
- [x] `cargo test` (80 passed, 5 new)
- [ ] Manual Discord QA: search an anime by its English title and confirm the title shows English with Romaji in the footer; repeat with Romaji input and confirm the swap.

## References

- Linear: [ANNIE-42](https://linear.app/annie-mei/issue/ANNIE-42/use-users-input-to-determine-the-primary-and-secondary-name-variant)

---

This PR description was written by Claude Opus 4.7.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
