### PR TITLE
[ANNIE-103]/enable sentry release tracking with github commit integration

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Determine Sentry release
         id: sentry-release-meta
         run: |
-          version="$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)"
+          version="$(awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ { print $2; exit }' Cargo.toml)"
           release="annie-mei@${version}"
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"
@@ -57,13 +57,19 @@ jobs:
             echo "::error::Git tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${version}"
             exit 1
           fi
+      - name: Install sentry-cli
+        env:
+          SENTRY_CLI_URL: https://github.com/getsentry/sentry-cli/releases/download/3.4.0/sentry-cli-Linux-aarch64
+          SENTRY_CLI_SHA256: 1273fe22639e394e0c8d2bd097da13b25139e75e977c5ce44c6f54130664ea45
+        run: |
+          curl -fsSL "$SENTRY_CLI_URL" -o /usr/local/bin/sentry-cli
+          echo "$SENTRY_CLI_SHA256  /usr/local/bin/sentry-cli" | sha256sum --check --strict
+          chmod +x /usr/local/bin/sentry-cli
       - name: Create Sentry release
         if: startsWith(github.ref, 'refs/tags/')
         id: sentry-release
         continue-on-error: true
         run: |
-          curl -sL https://sentry.io/get-cli/ | bash
-
           if ! sentry-cli releases info "$SENTRY_RELEASE" >/dev/null 2>&1; then
             sentry-cli releases new -p "$SENTRY_PROJECT" "$SENTRY_RELEASE"
           fi
@@ -81,9 +87,7 @@ jobs:
       - name: Upload debug symbols to Sentry
         id: sentry-upload
         continue-on-error: true
-        run: |
-          curl -sL https://sentry.io/get-cli/ | bash
-          sentry-cli debug-files upload --include-sources target/release/
+        run: sentry-cli debug-files upload --include-sources target/release/
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,18 +69,16 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         id: sentry-release
         continue-on-error: true
-        run: |
-          if ! sentry-cli releases info "$SENTRY_RELEASE" >/dev/null 2>&1; then
-            sentry-cli releases new -p "$SENTRY_PROJECT" "$SENTRY_RELEASE"
-          fi
-
-          sentry-cli releases set-commits "$SENTRY_RELEASE" --auto --ignore-missing
-          sentry-cli releases finalize "$SENTRY_RELEASE"
+        uses: getsentry/action-release@dab6548b3c03c4717878099e43782cf5be654289 # v3.5.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_RELEASE: ${{ steps.sentry-release-meta.outputs.release }}
+        with:
+          release: ${{ steps.sentry-release-meta.outputs.release }}
+          set_commits: auto
+          ignore_missing: true
+          disable_telemetry: true
       - name: Warn on Sentry release failure
         if: steps.sentry-release.outcome == 'failure'
         run: echo "::warning::Sentry release creation failed — commit tracking and release resolution may be incomplete"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+          fetch-depth: 0
       - name: Install Rust
         run: |
           toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
@@ -43,6 +44,40 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       - name: Build
         run: cargo build --release
+      - name: Determine Sentry release
+        id: sentry-release-meta
+        run: |
+          version="$(awk -F'"' '/^version = / { print $2; exit }' Cargo.toml)"
+          release="annie-mei@${version}"
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release=${release}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${GITHUB_REF}" == refs/tags/* && "${GITHUB_REF_NAME#v}" != "$version" ]]; then
+            echo "::error::Git tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${version}"
+            exit 1
+          fi
+      - name: Create Sentry release
+        if: startsWith(github.ref, 'refs/tags/')
+        id: sentry-release
+        continue-on-error: true
+        run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+
+          if ! sentry-cli releases info "$SENTRY_RELEASE" >/dev/null 2>&1; then
+            sentry-cli releases new -p "$SENTRY_PROJECT" "$SENTRY_RELEASE"
+          fi
+
+          sentry-cli releases set-commits "$SENTRY_RELEASE" --auto --ignore-missing
+          sentry-cli releases finalize "$SENTRY_RELEASE"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_RELEASE: ${{ steps.sentry-release-meta.outputs.release }}
+      - name: Warn on Sentry release failure
+        if: steps.sentry-release.outcome == 'failure'
+        run: echo "::warning::Sentry release creation failed — commit tracking and release resolution may be incomplete"
       - name: Upload debug symbols to Sentry
         id: sentry-upload
         continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.11.1"
+version = "2.11.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"


### PR DESCRIPTION
## Summary

Enable Sentry release tracking for tagged deploys so Sentry releases are created with the same `annie-mei@<version>` identifier the Rust SDK reports at runtime, GitHub commits are associated with those releases, and native debug files continue to be uploaded for symbolication. Also bump the app version to `2.11.2` so the next tagged release aligns with the new automation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- 2e6c26303fd7820b6400a570b342cd6216ac2d8d: add full-history checkout, derive the runtime-aligned Sentry release name from Cargo.toml, and guard tagged builds against tag/version mismatches
- 6aa65c54852a8291f82a07e864ff92c414722de4: bump the packaged application version to 2.11.2 so the next runtime release name matches release automation
- 2c7b3312eb617736b763b5b041fe674d02124966: replace `curl | bash` with a pinned, SHA256-verified `sentry-cli` install and reuse it for native debug file upload
- 128dafad71dae5856948c23c31b5f1e12cae3442: switch Sentry release creation and commit association to the official pinned `getsentry/action-release` GitHub Action

### Notes

- Release names are derived from Cargo.toml as `annie-mei@<version>` to match the Rust SDK’s `sentry::release_name!()` output.
- Tagged builds now fail fast when `github.ref_name` and the Cargo package version diverge.
- Release creation and debug-file upload remain non-blocking for deployment and emit GitHub Actions warnings on failure.
- The workflow now follows Sentry’s GitHub Actions guidance for release management while keeping a separate verified CLI path for Rust native debug files, which the action does not replace.
- The Sentry-side GitHub repository integration for `annie-mei/annie-mei` was confirmed in the Sentry UI, but end-to-end commit population still needs the next tagged release run.

### High-risk resources

- GitHub Actions release and Oracle Cloud deployment workflow
- Sentry release automation, commit association, and debug-file upload for the annie-mei project

## Validation
- [x] cargo check
- [x] cargo clippy
- [x] cargo fmt --check
- [x] Workflow YAML parse check for `.github/workflows/build-release.yml`
- [ ] Trigger a `v2.11.2` tag build and verify the `annie-mei@2.11.2` release shows associated commits in Sentry

## References

- Linear: https://linear.app/annie-mei/issue/ANNIE-103/enable-sentry-release-tracking-with-github-commit-integration
- Sentry docs: https://docs.sentry.io/product/releases/setup/release-automation/github-actions/

---

This PR description was written by OpenAI GPT-5.
