### PR TITLE
[ANNIE-44]/Remove unused externalLinks from manga queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.11.9"
+version = "2.11.10"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.11.9"
+version = "2.11.10"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -179,7 +179,6 @@ mod tests {
                 "nodes": [{ "name": { "full": "Eiichiro Oda" } }]
             },
             "siteUrl": "https://anilist.co/manga/30013",
-            "externalLinks": [],
             "description": "<p>Gol D. Roger was known as the Pirate King.</p>",
             "tags": [{ "name": "Shounen" }]
         }))

--- a/src/commands/manga/queries.rs
+++ b/src/commands/manga/queries.rs
@@ -48,10 +48,6 @@ query ($id: Int) {
       }
     }
     siteUrl
-    externalLinks {
-      url
-      type
-    }
     description
     tags {
       name
@@ -118,10 +114,6 @@ query ($page: Int, $perPage: Int, $search: String) {
         }
       }
       siteUrl
-      externalLinks {
-        url
-        type
-      }
       description
       tags {
         name

--- a/src/models/anilist_manga.rs
+++ b/src/models/anilist_manga.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::{
-        anilist_common::{CoverImage, ExternalLinks, Tag, Title},
+        anilist_common::{CoverImage, Tag, Title},
         transformers::Transformers,
     },
     utils::{
@@ -36,8 +36,6 @@ pub struct Manga {
     average_score: Option<u32>,
     staff: Option<Staff>,
     site_url: String,
-    #[allow(dead_code)]
-    external_links: Option<Vec<ExternalLinks>>,
     description: Option<String>,
     tags: Vec<Tag>,
 }
@@ -357,7 +355,6 @@ mod tests {
             "averageScore": null,
             "staff": null,
             "siteUrl": "https://anilist.co/manga/1",
-            "externalLinks": null,
             "description": null,
             "tags": []
         }))


### PR DESCRIPTION
## Summary

Drop the unused `externalLinks` field from the manga AniList queries and the `Manga` model. The field was dead code (resolves ANNIE-44 by deciding to remove rather than use it), so this trims the GraphQL payload and the model surface.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- f00a9ab14b9743669a0b9bf4e2b6dbd57edaed5d: remove externalLinks selection from FETCH_MANGA_BY_ID and FETCH_MANGA queries, drop the dead `external_links` field and `ExternalLinks` import from `Manga`, clean up the field from manga test fixtures, and bump the patch version to 2.11.10

### Notes

Anime queries/model still use `externalLinks`; this change only touches manga.

## Validation
- [x] `cargo check`
- [x] `cargo test manga` (5 passed)

---

This PR description was written by Claude Sonnet 4.5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
