### PR TITLE
[ANNIE-17]/support character api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.11.10"
+version = "2.12.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.11.10"
+version = "2.12.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 
 ## Features
 
-- Fetch detailed anime/manga information from AniList
+- Fetch detailed anime/manga/character information from AniList
 - Look up opening and ending theme songs with Spotify links
 - Link your AniList account with a secure OAuth flow to show guild members' scores
 - Check your currently linked AniList account
@@ -26,6 +26,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 | `/whoami` | Show your linked AniList username and profile link |
 | `/anime <search>` | Look up anime by name or AniList ID |
 | `/manga <search>` | Look up manga by name or AniList ID |
+| `/character search:<term or id> spoilers:<allow\|disallow>` | Look up characters by name or AniList ID |
 | `/songs <search>` | Find theme songs for an anime |
 
 ### Search Tips

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -83,8 +83,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
     let search_term = search_term.clone();
 
-    let arg_str = format!("{:?}", search_term);
-    configure_sentry_scope("Anime", user.id.get(), Some(json!(arg_str)));
+    configure_sentry_scope("Anime", user.id.get(), Some(json!(search_term.clone())));
 
     info!("Got command 'anime' with search_term: {search_term}");
 

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -23,9 +23,11 @@ use serenity::{
 };
 use tracing::{info, instrument};
 
-const ALLOW_SPOILERS_SUBCOMMAND: &str = "allow";
-const DISALLOW_SPOILERS_SUBCOMMAND: &str = "disallow";
+const LOOKUP_SUBCOMMAND: &str = "lookup";
 const SEARCH_OPTION: &str = "search";
+const SPOILERS_OPTION: &str = "spoilers";
+const ALLOW_SPOILERS: &str = "allow";
+const DISALLOW_SPOILERS: &str = "disallow";
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("character")
@@ -33,8 +35,8 @@ pub fn register() -> CreateCommand {
         .add_option(
             CreateCommandOption::new(
                 CommandOptionType::SubCommand,
-                DISALLOW_SPOILERS_SUBCOMMAND,
-                "Search without matching spoiler aliases",
+                LOOKUP_SUBCOMMAND,
+                "Look up a character",
             )
             .add_sub_option(
                 CreateCommandOption::new(
@@ -43,20 +45,15 @@ pub fn register() -> CreateCommand {
                     "AniList character ID or search term",
                 )
                 .required(true),
-            ),
-        )
-        .add_option(
-            CreateCommandOption::new(
-                CommandOptionType::SubCommand,
-                ALLOW_SPOILERS_SUBCOMMAND,
-                "Search and allow matching spoiler aliases",
             )
             .add_sub_option(
                 CreateCommandOption::new(
                     CommandOptionType::String,
-                    SEARCH_OPTION,
-                    "AniList character ID or search term",
+                    SPOILERS_OPTION,
+                    "Whether to include spoiler aliases and spoiler description content",
                 )
+                .add_string_choice("Allow", ALLOW_SPOILERS)
+                .add_string_choice("Disallow", DISALLOW_SPOILERS)
                 .required(true),
             ),
         )
@@ -67,16 +64,26 @@ fn parse_character_options(options: &[CommandDataOption]) -> Option<(String, boo
 
     match &option.value {
         CommandDataOptionValue::SubCommand(sub_options) => {
-            let allow_spoilers = match option.name.as_str() {
-                ALLOW_SPOILERS_SUBCOMMAND => true,
-                DISALLOW_SPOILERS_SUBCOMMAND => false,
-                _ => return None,
-            };
+            if option.name != LOOKUP_SUBCOMMAND {
+                return None;
+            }
+
             let search_term = sub_options
                 .iter()
                 .find(|sub_option| sub_option.name == SEARCH_OPTION)
                 .and_then(|sub_option| match &sub_option.value {
                     CommandDataOptionValue::String(search_term) => Some(search_term.clone()),
+                    _ => None,
+                })?;
+            let allow_spoilers = sub_options
+                .iter()
+                .find(|sub_option| sub_option.name == SPOILERS_OPTION)
+                .and_then(|sub_option| match &sub_option.value {
+                    CommandDataOptionValue::String(value) => match value.as_str() {
+                        ALLOW_SPOILERS => Some(true),
+                        DISALLOW_SPOILERS => Some(false),
+                        _ => None,
+                    },
                     _ => None,
                 })?;
 
@@ -87,11 +94,15 @@ fn parse_character_options(options: &[CommandDataOption]) -> Option<(String, boo
     }
 }
 
-pub fn handle_character(character: Option<Character>, allow_adult_media: bool) -> CommandResponse {
+pub fn handle_character(
+    character: Option<Character>,
+    allow_adult_media: bool,
+    allow_spoilers: bool,
+) -> CommandResponse {
     match character {
         None => CommandResponse::Content(NOT_FOUND_CHARACTER.to_string()),
         Some(character_response) => CommandResponse::Embed(Box::new(
-            character_response.transform_response_embed(allow_adult_media),
+            character_response.transform_response_embed(allow_adult_media, allow_spoilers),
         )),
     }
 }
@@ -138,7 +149,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         return;
     }
 
-    let response = handle_character(character_result, allow_adult_media);
+    let response = handle_character(character_result, allow_adult_media, allow_spoilers);
 
     let _result = match response {
         CommandResponse::Content(text) => {
@@ -187,7 +198,7 @@ mod tests {
 
     #[test]
     fn character_not_found_returns_content_with_message() {
-        let response = handle_character(None, false);
+        let response = handle_character(None, false, false);
 
         assert!(response.is_content(), "expected Content variant");
         assert_eq!(response.unwrap_content(), NOT_FOUND_CHARACTER);
@@ -195,7 +206,7 @@ mod tests {
 
     #[test]
     fn character_success_returns_embed() {
-        let response = handle_character(Some(sample_character()), false);
+        let response = handle_character(Some(sample_character()), false, false);
 
         assert!(
             response.is_embed(),
@@ -205,14 +216,18 @@ mod tests {
     }
 
     #[test]
-    fn parses_disallow_spoilers_subcommand() {
+    fn parses_lookup_with_disallowed_spoilers() {
         let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
-            "name": "disallow",
+            "name": "lookup",
             "type": 1,
             "options": [{
                 "name": "search",
                 "type": 3,
                 "value": "Lust"
+            }, {
+                "name": "spoilers",
+                "type": 3,
+                "value": "disallow"
             }]
         }]))
         .expect("options deserialize");
@@ -224,14 +239,18 @@ mod tests {
     }
 
     #[test]
-    fn parses_allow_spoilers_subcommand() {
+    fn parses_lookup_with_allowed_spoilers() {
         let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
-            "name": "allow",
+            "name": "lookup",
             "type": 1,
             "options": [{
                 "name": "search",
                 "type": 3,
                 "value": "Joy Boy"
+            }, {
+                "name": "spoilers",
+                "type": 3,
+                "value": "allow"
             }]
         }]))
         .expect("options deserialize");

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -4,7 +4,11 @@ use crate::{
         traits::{AniListSource, CharacterDataSource},
     },
     models::anilist_character::Character,
-    utils::{privacy::configure_sentry_scope, statics::NOT_FOUND_CHARACTER},
+    utils::{
+        channel::is_nsfw_channel,
+        privacy::configure_sentry_scope,
+        statics::{NOT_FOUND_CHARACTER, NSFW_NOT_ALLOWED},
+    },
 };
 
 use serde_json::json;
@@ -60,6 +64,16 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     info!("Got command 'character' with search_term: {search_term}");
 
     let character_result = AniListSource.fetch_character(&search_term).await;
+
+    if let Some(ref character) = character_result
+        && character.media_is_all_adult()
+        && !is_nsfw_channel(ctx, interaction.channel_id).await
+    {
+        let builder = EditInteractionResponse::new().content(NSFW_NOT_ALLOWED);
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
+
     let response = handle_character(character_result);
 
     let _result = match response {

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -13,24 +13,78 @@ use crate::{
 
 use serde_json::json;
 use serenity::{
-    all::{CommandInteraction, CreateCommandOption, EditInteractionResponse},
+    all::{
+        CommandDataOption, CommandDataOptionValue, CommandInteraction, CreateCommandOption,
+        EditInteractionResponse,
+    },
     builder::CreateCommand,
     client::Context,
     model::application::CommandOptionType,
 };
 use tracing::{info, instrument};
 
+const ALLOW_SPOILERS_SUBCOMMAND: &str = "allow";
+const DISALLOW_SPOILERS_SUBCOMMAND: &str = "disallow";
+const SEARCH_OPTION: &str = "search";
+
 pub fn register() -> CreateCommand {
     CreateCommand::new("character")
         .description("Fetches the details for an AniList character")
         .add_option(
             CreateCommandOption::new(
-                CommandOptionType::String,
-                "search",
-                "AniList character ID or search term",
+                CommandOptionType::SubCommand,
+                DISALLOW_SPOILERS_SUBCOMMAND,
+                "Search without matching spoiler aliases",
             )
-            .required(true),
+            .add_sub_option(
+                CreateCommandOption::new(
+                    CommandOptionType::String,
+                    SEARCH_OPTION,
+                    "AniList character ID or search term",
+                )
+                .required(true),
+            ),
         )
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::SubCommand,
+                ALLOW_SPOILERS_SUBCOMMAND,
+                "Search and allow matching spoiler aliases",
+            )
+            .add_sub_option(
+                CreateCommandOption::new(
+                    CommandOptionType::String,
+                    SEARCH_OPTION,
+                    "AniList character ID or search term",
+                )
+                .required(true),
+            ),
+        )
+}
+
+fn parse_character_options(options: &[CommandDataOption]) -> Option<(String, bool)> {
+    let option = options.first()?;
+
+    match &option.value {
+        CommandDataOptionValue::SubCommand(sub_options) => {
+            let allow_spoilers = match option.name.as_str() {
+                ALLOW_SPOILERS_SUBCOMMAND => true,
+                DISALLOW_SPOILERS_SUBCOMMAND => false,
+                _ => return None,
+            };
+            let search_term = sub_options
+                .iter()
+                .find(|sub_option| sub_option.name == SEARCH_OPTION)
+                .and_then(|sub_option| match &sub_option.value {
+                    CommandDataOptionValue::String(search_term) => Some(search_term.clone()),
+                    _ => None,
+                })?;
+
+            Some((search_term, allow_spoilers))
+        }
+        CommandDataOptionValue::String(search_term) => Some((search_term.clone(), false)),
+        _ => None,
+    }
 }
 
 pub fn handle_character(character: Option<Character>, allow_adult_media: bool) -> CommandResponse {
@@ -48,22 +102,24 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let user = &interaction.user;
 
-    let Some(serenity::all::CommandDataOptionValue::String(search_term)) =
-        interaction.data.options.first().map(|opt| &opt.value)
+    let Some((search_term, allow_spoilers)) = parse_character_options(&interaction.data.options)
     else {
         let builder = EditInteractionResponse::new()
             .content("Missing or invalid `search` option — please provide a character name or ID.");
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
-    let search_term = search_term.clone();
 
     let arg_str = format!("{:?}", search_term);
     configure_sentry_scope("Character", user.id.get(), Some(json!(arg_str)));
 
-    info!("Got command 'character' with search_term: {search_term}");
+    info!(
+        "Got command 'character' with search_term: {search_term}, allow_spoilers: {allow_spoilers}"
+    );
 
-    let character_result = AniListSource.fetch_character(&search_term).await;
+    let character_result = AniListSource
+        .fetch_character(&search_term, allow_spoilers)
+        .await;
     let allow_adult_media = if character_result
         .as_ref()
         .is_some_and(Character::has_adult_media)
@@ -146,5 +202,43 @@ mod tests {
             "expected Embed variant for a successful lookup"
         );
         let _embed = response.unwrap_embed();
+    }
+
+    #[test]
+    fn parses_disallow_spoilers_subcommand() {
+        let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
+            "name": "disallow",
+            "type": 1,
+            "options": [{
+                "name": "search",
+                "type": 3,
+                "value": "Lust"
+            }]
+        }]))
+        .expect("options deserialize");
+
+        assert_eq!(
+            parse_character_options(&options),
+            Some(("Lust".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn parses_allow_spoilers_subcommand() {
+        let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
+            "name": "allow",
+            "type": 1,
+            "options": [{
+                "name": "search",
+                "type": 3,
+                "value": "Joy Boy"
+            }]
+        }]))
+        .expect("options deserialize");
+
+        assert_eq!(
+            parse_character_options(&options),
+            Some(("Joy Boy".to_string(), true))
+        );
     }
 }

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -23,7 +23,6 @@ use serenity::{
 };
 use tracing::{info, instrument};
 
-const LOOKUP_SUBCOMMAND: &str = "lookup";
 const SEARCH_OPTION: &str = "search";
 const SPOILERS_OPTION: &str = "spoilers";
 const ALLOW_SPOILERS: &str = "allow";
@@ -34,64 +33,45 @@ pub fn register() -> CreateCommand {
         .description("Fetches the details for an AniList character")
         .add_option(
             CreateCommandOption::new(
-                CommandOptionType::SubCommand,
-                LOOKUP_SUBCOMMAND,
-                "Look up a character",
+                CommandOptionType::String,
+                SEARCH_OPTION,
+                "AniList character ID or search term",
             )
-            .add_sub_option(
-                CreateCommandOption::new(
-                    CommandOptionType::String,
-                    SEARCH_OPTION,
-                    "AniList character ID or search term",
-                )
-                .required(true),
+            .required(true),
+        )
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::String,
+                SPOILERS_OPTION,
+                "Whether to include spoiler aliases and spoiler description content",
             )
-            .add_sub_option(
-                CreateCommandOption::new(
-                    CommandOptionType::String,
-                    SPOILERS_OPTION,
-                    "Whether to include spoiler aliases and spoiler description content",
-                )
-                .add_string_choice("Allow", ALLOW_SPOILERS)
-                .add_string_choice("Disallow", DISALLOW_SPOILERS)
-                .required(true),
-            ),
+            .add_string_choice("Allow", ALLOW_SPOILERS)
+            .add_string_choice("Disallow", DISALLOW_SPOILERS)
+            .required(true),
         )
 }
 
 fn parse_character_options(options: &[CommandDataOption]) -> Option<(String, bool)> {
-    let option = options.first()?;
+    let search_term = options
+        .iter()
+        .find(|option| option.name == SEARCH_OPTION)
+        .and_then(|option| match &option.value {
+            CommandDataOptionValue::String(search_term) => Some(search_term.clone()),
+            _ => None,
+        })?;
+    let allow_spoilers = options
+        .iter()
+        .find(|option| option.name == SPOILERS_OPTION)
+        .and_then(|option| match &option.value {
+            CommandDataOptionValue::String(value) => match value.as_str() {
+                ALLOW_SPOILERS => Some(true),
+                DISALLOW_SPOILERS => Some(false),
+                _ => None,
+            },
+            _ => None,
+        })?;
 
-    match &option.value {
-        CommandDataOptionValue::SubCommand(sub_options) => {
-            if option.name != LOOKUP_SUBCOMMAND {
-                return None;
-            }
-
-            let search_term = sub_options
-                .iter()
-                .find(|sub_option| sub_option.name == SEARCH_OPTION)
-                .and_then(|sub_option| match &sub_option.value {
-                    CommandDataOptionValue::String(search_term) => Some(search_term.clone()),
-                    _ => None,
-                })?;
-            let allow_spoilers = sub_options
-                .iter()
-                .find(|sub_option| sub_option.name == SPOILERS_OPTION)
-                .and_then(|sub_option| match &sub_option.value {
-                    CommandDataOptionValue::String(value) => match value.as_str() {
-                        ALLOW_SPOILERS => Some(true),
-                        DISALLOW_SPOILERS => Some(false),
-                        _ => None,
-                    },
-                    _ => None,
-                })?;
-
-            Some((search_term, allow_spoilers))
-        }
-        CommandDataOptionValue::String(search_term) => Some((search_term.clone(), false)),
-        _ => None,
-    }
+    Some((search_term, allow_spoilers))
 }
 
 pub fn handle_character(
@@ -216,19 +196,15 @@ mod tests {
     }
 
     #[test]
-    fn parses_lookup_with_disallowed_spoilers() {
+    fn parses_disallowed_spoilers_option() {
         let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
-            "name": "lookup",
-            "type": 1,
-            "options": [{
-                "name": "search",
-                "type": 3,
-                "value": "Lust"
-            }, {
-                "name": "spoilers",
-                "type": 3,
-                "value": "disallow"
-            }]
+            "name": "search",
+            "type": 3,
+            "value": "Lust"
+        }, {
+            "name": "spoilers",
+            "type": 3,
+            "value": "disallow"
         }]))
         .expect("options deserialize");
 
@@ -239,19 +215,15 @@ mod tests {
     }
 
     #[test]
-    fn parses_lookup_with_allowed_spoilers() {
+    fn parses_allowed_spoilers_option() {
         let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
-            "name": "lookup",
-            "type": 1,
-            "options": [{
-                "name": "search",
-                "type": 3,
-                "value": "Joy Boy"
-            }, {
-                "name": "spoilers",
-                "type": 3,
-                "value": "allow"
-            }]
+            "name": "search",
+            "type": 3,
+            "value": "Joy Boy"
+        }, {
+            "name": "spoilers",
+            "type": 3,
+            "value": "allow"
         }]))
         .expect("options deserialize");
 

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -33,12 +33,12 @@ pub fn register() -> CreateCommand {
         )
 }
 
-pub fn handle_character(character: Option<Character>) -> CommandResponse {
+pub fn handle_character(character: Option<Character>, allow_adult_media: bool) -> CommandResponse {
     match character {
         None => CommandResponse::Content(NOT_FOUND_CHARACTER.to_string()),
-        Some(character_response) => {
-            CommandResponse::Embed(Box::new(character_response.transform_response_embed()))
-        }
+        Some(character_response) => CommandResponse::Embed(Box::new(
+            character_response.transform_response_embed(allow_adult_media),
+        )),
     }
 }
 
@@ -64,17 +64,25 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     info!("Got command 'character' with search_term: {search_term}");
 
     let character_result = AniListSource.fetch_character(&search_term).await;
+    let allow_adult_media = if character_result
+        .as_ref()
+        .is_some_and(Character::has_adult_media)
+    {
+        is_nsfw_channel(ctx, interaction.channel_id).await
+    } else {
+        false
+    };
 
     if let Some(ref character) = character_result
         && character.media_is_all_adult()
-        && !is_nsfw_channel(ctx, interaction.channel_id).await
+        && !allow_adult_media
     {
         let builder = EditInteractionResponse::new().content(NSFW_NOT_ALLOWED);
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     }
 
-    let response = handle_character(character_result);
+    let response = handle_character(character_result, allow_adult_media);
 
     let _result = match response {
         CommandResponse::Content(text) => {
@@ -123,7 +131,7 @@ mod tests {
 
     #[test]
     fn character_not_found_returns_content_with_message() {
-        let response = handle_character(None);
+        let response = handle_character(None, false);
 
         assert!(response.is_content(), "expected Content variant");
         assert_eq!(response.unwrap_content(), NOT_FOUND_CHARACTER);
@@ -131,7 +139,7 @@ mod tests {
 
     #[test]
     fn character_success_returns_embed() {
-        let response = handle_character(Some(sample_character()));
+        let response = handle_character(Some(sample_character()), false);
 
         assert!(
             response.is_embed(),

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -101,8 +101,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         return;
     };
 
-    let arg_str = format!("{:?}", search_term);
-    configure_sentry_scope("Character", user.id.get(), Some(json!(arg_str)));
+    configure_sentry_scope("Character", user.id.get(), Some(json!(search_term.clone())));
 
     info!(
         "Got command 'character' with search_term: {search_term}, allow_spoilers: {allow_spoilers}"

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -1,0 +1,128 @@
+use crate::{
+    commands::{
+        response::CommandResponse,
+        traits::{AniListSource, CharacterDataSource},
+    },
+    models::anilist_character::Character,
+    utils::{privacy::configure_sentry_scope, statics::NOT_FOUND_CHARACTER},
+};
+
+use serde_json::json;
+use serenity::{
+    all::{CommandInteraction, CreateCommandOption, EditInteractionResponse},
+    builder::CreateCommand,
+    client::Context,
+    model::application::CommandOptionType,
+};
+use tracing::{info, instrument};
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("character")
+        .description("Fetches the details for an AniList character")
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::String,
+                "search",
+                "AniList character ID or search term",
+            )
+            .required(true),
+        )
+}
+
+pub fn handle_character(character: Option<Character>) -> CommandResponse {
+    match character {
+        None => CommandResponse::Content(NOT_FOUND_CHARACTER.to_string()),
+        Some(character_response) => {
+            CommandResponse::Embed(Box::new(character_response.transform_response_embed()))
+        }
+    }
+}
+
+#[instrument(name = "command.character.run", skip(ctx, interaction))]
+pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
+    let _ = interaction.defer(&ctx.http).await;
+
+    let user = &interaction.user;
+
+    let Some(serenity::all::CommandDataOptionValue::String(search_term)) =
+        interaction.data.options.first().map(|opt| &opt.value)
+    else {
+        let builder = EditInteractionResponse::new()
+            .content("Missing or invalid `search` option — please provide a character name or ID.");
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    };
+    let search_term = search_term.clone();
+
+    let arg_str = format!("{:?}", search_term);
+    configure_sentry_scope("Character", user.id.get(), Some(json!(arg_str)));
+
+    info!("Got command 'character' with search_term: {search_term}");
+
+    let character_result = AniListSource.fetch_character(&search_term).await;
+    let response = handle_character(character_result);
+
+    let _result = match response {
+        CommandResponse::Content(text) => {
+            let builder = EditInteractionResponse::new().content(text);
+            interaction.edit_response(&ctx.http, builder).await
+        }
+        CommandResponse::Embed(embed) => {
+            let builder = EditInteractionResponse::new().embed(*embed);
+            interaction.edit_response(&ctx.http, builder).await
+        }
+        CommandResponse::Message(text) => {
+            let builder = EditInteractionResponse::new().content(text);
+            interaction.edit_response(&ctx.http, builder).await
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_character() -> Character {
+        serde_json::from_value(serde_json::json!({
+            "id": 40,
+            "name": {
+                "full": "Lelouch Lamperouge",
+                "native": "ルルーシュ・ランペルージ",
+                "alternative": [],
+                "userPreferred": "Lelouch Lamperouge"
+            },
+            "image": {
+                "large": "https://example.com/large.jpg",
+                "medium": null
+            },
+            "description": "<p>A former prince.</p>",
+            "gender": "Male",
+            "dateOfBirth": { "year": null, "month": 12, "day": 5 },
+            "age": "17",
+            "bloodType": "A",
+            "favourites": 1000,
+            "siteUrl": "https://anilist.co/character/40",
+            "media": { "nodes": [] }
+        }))
+        .expect("sample character JSON should deserialize")
+    }
+
+    #[test]
+    fn character_not_found_returns_content_with_message() {
+        let response = handle_character(None);
+
+        assert!(response.is_content(), "expected Content variant");
+        assert_eq!(response.unwrap_content(), NOT_FOUND_CHARACTER);
+    }
+
+    #[test]
+    fn character_success_returns_embed() {
+        let response = handle_character(Some(sample_character()));
+
+        assert!(
+            response.is_embed(),
+            "expected Embed variant for a successful lookup"
+        );
+        let _embed = response.unwrap_embed();
+    }
+}

--- a/src/commands/character/mod.rs
+++ b/src/commands/character/mod.rs
@@ -1,0 +1,1 @@
+pub mod queries;

--- a/src/commands/character/mod.rs
+++ b/src/commands/character/mod.rs
@@ -1,1 +1,2 @@
+pub mod command;
 pub mod queries;

--- a/src/commands/character/queries.rs
+++ b/src/commands/character/queries.rs
@@ -6,6 +6,7 @@ query ($id: Int) {
       full
       native
       alternative
+      alternativeSpoiler
       userPreferred
     }
     image {
@@ -48,6 +49,7 @@ query ($search: String) {
         full
         native
         alternative
+        alternativeSpoiler
         userPreferred
       }
       image {

--- a/src/commands/character/queries.rs
+++ b/src/commands/character/queries.rs
@@ -1,0 +1,83 @@
+pub const FETCH_CHARACTER_BY_ID: &str = "
+query ($id: Int) {
+  Character(id: $id) {
+    id
+    name {
+      full
+      native
+      alternative
+      userPreferred
+    }
+    image {
+      large
+      medium
+    }
+    description(asHtml: true)
+    gender
+    dateOfBirth {
+      year
+      month
+      day
+    }
+    age
+    bloodType
+    favourites
+    siteUrl
+    media(page: 1, perPage: 5, sort: POPULARITY_DESC) {
+      nodes {
+        id
+        type
+        title {
+          romaji
+          english
+        }
+        siteUrl
+        isAdult
+      }
+    }
+  }
+}
+";
+
+pub const FETCH_CHARACTER: &str = "
+query ($search: String) {
+  Page(page: 1, perPage: 10) {
+    characters(search: $search) {
+      id
+      name {
+        full
+        native
+        alternative
+        userPreferred
+      }
+      image {
+        large
+        medium
+      }
+      description(asHtml: true)
+      gender
+      dateOfBirth {
+        year
+        month
+        day
+      }
+      age
+      bloodType
+      favourites
+      siteUrl
+      media(page: 1, perPage: 5, sort: POPULARITY_DESC) {
+        nodes {
+          id
+          type
+          title {
+            romaji
+            english
+          }
+          siteUrl
+          isAdult
+        }
+      }
+    }
+  }
+}
+";

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -24,16 +24,16 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
         .colour(0x00ff00)
         .title(format!("{} • Annie Mei Help", user.name))
         .description(
-            "I can help you look up anime and manga details, theme songs, and show what guild members are watching or reading.",
+            "I can help you look up anime, manga, and character details, theme songs, and show what guild members are watching or reading.",
         )
         .field(
             "Get started",
-            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime` or `/manga` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it",
+            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime`, `/manga`, or `/character` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it",
             false,
         )
         .field(
             "Commands",
-            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
+            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/character search:<term or id> spoilers:<allow|disallow>` - character details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
             false,
         )
         .field(

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -83,8 +83,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
     let search_term = search_term.clone();
 
-    let arg_str = format!("{:?}", search_term);
-    configure_sentry_scope("Manga", user.id.get(), Some(json!(arg_str)));
+    configure_sentry_scope("Manga", user.id.get(), Some(json!(search_term.clone())));
 
     info!("Got command 'manga' with search_term: {search_term}");
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod anime;
+pub mod character;
 pub mod help;
 pub mod input_validation;
 pub mod manga;

--- a/src/commands/traits.rs
+++ b/src/commands/traits.rs
@@ -56,7 +56,11 @@ pub trait CharacterDataSource: Send + Sync {
     /// Fetch character data for the given search term (name **or** numeric ID).
     ///
     /// Returns `None` when no matching character is found.
-    fn fetch_character(&self, search_term: &str) -> impl Future<Output = Option<Character>> + Send;
+    fn fetch_character(
+        &self,
+        search_term: &str,
+        allow_spoilers: bool,
+    ) -> impl Future<Output = Option<Character>> + Send;
 }
 
 /// Production [`MediaDataSource`] backed by the AniList GraphQL API.
@@ -86,11 +90,11 @@ impl MediaDataSource for AniListSource {
 }
 
 impl CharacterDataSource for AniListSource {
-    async fn fetch_character(&self, search_term: &str) -> Option<Character> {
+    async fn fetch_character(&self, search_term: &str, allow_spoilers: bool) -> Option<Character> {
         use crate::utils::response_fetcher::character_fetcher;
         use serenity::all::CommandDataOptionValue;
 
         let arg = CommandDataOptionValue::String(search_term.to_string());
-        character_fetcher(arg).await
+        character_fetcher(arg, allow_spoilers).await
     }
 }

--- a/src/commands/traits.rs
+++ b/src/commands/traits.rs
@@ -20,7 +20,10 @@
 
 use std::future::Future;
 
-use crate::models::{anilist_anime::Anime, anilist_common::TitleVariant, anilist_manga::Manga};
+use crate::models::{
+    anilist_anime::Anime, anilist_character::Character, anilist_common::TitleVariant,
+    anilist_manga::Manga,
+};
 
 /// Abstraction over media-data retrieval (AniList today, pluggable tomorrow).
 ///
@@ -49,6 +52,13 @@ pub trait MediaDataSource: Send + Sync {
     ) -> impl Future<Output = Option<(Manga, TitleVariant)>> + Send;
 }
 
+pub trait CharacterDataSource: Send + Sync {
+    /// Fetch character data for the given search term (name **or** numeric ID).
+    ///
+    /// Returns `None` when no matching character is found.
+    fn fetch_character(&self, search_term: &str) -> impl Future<Output = Option<Character>> + Send;
+}
+
 /// Production [`MediaDataSource`] backed by the AniList GraphQL API.
 ///
 /// This delegates to the existing [`crate::utils::response_fetcher::fetcher`]
@@ -72,5 +82,15 @@ impl MediaDataSource for AniListSource {
 
         let arg = CommandDataOptionValue::String(search_term.to_string());
         fetcher::<Manga>(MediaType::Manga, arg).await
+    }
+}
+
+impl CharacterDataSource for AniListSource {
+    async fn fetch_character(&self, search_term: &str) -> Option<Character> {
+        use crate::utils::response_fetcher::character_fetcher;
+        use serenity::all::CommandDataOptionValue;
+
+        let arg = CommandDataOptionValue::String(search_term.to_string());
+        character_fetcher(arg).await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ impl EventHandler for Handler {
                     "songs" => commands::songs::command::run(&ctx, &mut command).await,
                     "manga" => commands::manga::command::run(&ctx, &mut command).await,
                     "anime" => commands::anime::command::run(&ctx, &mut command).await,
+                    "character" => commands::character::command::run(&ctx, &mut command).await,
                     "register" => commands::register::command::run(&ctx, &command).await,
                     "whoami" => commands::whoami::run(&ctx, &mut command).await,
                     _ => {
@@ -98,6 +99,7 @@ impl EventHandler for Handler {
             commands::songs::command::register(),
             commands::manga::command::register(),
             commands::anime::command::register(),
+            commands::character::command::register(),
             commands::register::command::register(),
             commands::whoami::register(),
         ];

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -1,0 +1,321 @@
+use crate::utils::{
+    formatter::{code, linker, titlecase},
+    statics::EMPTY_STR,
+};
+
+use html2md::parse_html;
+use serde::Deserialize;
+use serenity::all::{CreateEmbed, CreateEmbedFooter};
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Character {
+    #[allow(dead_code)]
+    id: u32,
+    name: CharacterName,
+    image: Option<CharacterImage>,
+    description: Option<String>,
+    gender: Option<String>,
+    date_of_birth: Option<CharacterDate>,
+    age: Option<String>,
+    blood_type: Option<String>,
+    favourites: Option<u32>,
+    site_url: String,
+    media: Option<CharacterMediaConnection>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterName {
+    pub full: Option<String>,
+    pub native: Option<String>,
+    pub alternative: Option<Vec<String>>,
+    pub user_preferred: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CharacterImage {
+    pub large: Option<String>,
+    pub medium: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CharacterDate {
+    year: Option<u32>,
+    month: Option<u32>,
+    day: Option<u32>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CharacterMediaConnection {
+    nodes: Option<Vec<CharacterMedia>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterMedia {
+    #[allow(dead_code)]
+    id: u32,
+    #[serde(rename = "type")]
+    media_type: Option<String>,
+    title: CharacterMediaTitle,
+    site_url: Option<String>,
+    is_adult: Option<bool>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct CharacterMediaTitle {
+    romaji: Option<String>,
+    english: Option<String>,
+}
+
+impl CharacterName {
+    pub fn search_name(&self) -> String {
+        self.user_preferred
+            .as_deref()
+            .or(self.full.as_deref())
+            .or(self.native.as_deref())
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    pub fn search_aliases(&self) -> Vec<String> {
+        let mut aliases = Vec::new();
+
+        if let Some(full) = &self.full {
+            aliases.push(full.clone());
+        }
+
+        if let Some(native) = &self.native {
+            aliases.push(native.clone());
+        }
+
+        if let Some(alternative) = &self.alternative {
+            aliases.extend(alternative.clone());
+        }
+
+        aliases
+    }
+
+    pub fn has_alias(&self, alias: &str) -> bool {
+        self.search_aliases()
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(alias))
+    }
+}
+
+impl Character {
+    pub fn name(&self) -> &CharacterName {
+        &self.name
+    }
+
+    pub fn transform_name(&self) -> String {
+        self.name
+            .user_preferred
+            .as_deref()
+            .or(self.name.full.as_deref())
+            .or(self.name.native.as_deref())
+            .map(titlecase)
+            .unwrap_or_else(|| EMPTY_STR.to_string())
+    }
+
+    pub fn transform_footer_name(&self) -> String {
+        self.name
+            .native
+            .as_deref()
+            .filter(|native| *native != self.transform_name())
+            .map(ToString::to_string)
+            .or_else(|| {
+                self.name
+                    .alternative
+                    .as_ref()
+                    .and_then(|alternative| alternative.first())
+                    .map(|name| titlecase(name))
+            })
+            .unwrap_or_else(|| EMPTY_STR.to_string())
+    }
+
+    pub fn transform_thumbnail(&self) -> String {
+        self.image
+            .as_ref()
+            .and_then(|image| image.large.as_deref().or(image.medium.as_deref()))
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    pub fn transform_description(&self) -> String {
+        parse_html(
+            self.description
+                .as_deref()
+                .unwrap_or("<i>No Description Yet</i>"),
+        )
+    }
+
+    pub fn transform_gender(&self) -> String {
+        self.gender
+            .as_deref()
+            .map(titlecase)
+            .unwrap_or_else(|| EMPTY_STR.to_string())
+    }
+
+    pub fn transform_birthday(&self) -> String {
+        let Some(date) = &self.date_of_birth else {
+            return EMPTY_STR.to_string();
+        };
+
+        match (date.year, date.month, date.day) {
+            (Some(year), Some(month), Some(day)) => format!("{year:04}-{month:02}-{day:02}"),
+            (None, Some(month), Some(day)) => format!("{month:02}-{day:02}"),
+            (Some(year), Some(month), None) => format!("{year:04}-{month:02}"),
+            (Some(year), None, None) => year.to_string(),
+            _ => EMPTY_STR.to_string(),
+        }
+    }
+
+    pub fn transform_age(&self) -> String {
+        self.age.clone().unwrap_or_else(|| EMPTY_STR.to_string())
+    }
+
+    pub fn transform_blood_type(&self) -> String {
+        self.blood_type
+            .clone()
+            .unwrap_or_else(|| EMPTY_STR.to_string())
+    }
+
+    pub fn transform_favourites(&self) -> String {
+        self.favourites
+            .map(|favourites| favourites.to_string())
+            .unwrap_or_else(|| EMPTY_STR.to_string())
+    }
+
+    pub fn transform_media(&self) -> String {
+        let Some(media) = &self.media else {
+            return EMPTY_STR.to_string();
+        };
+        let Some(nodes) = &media.nodes else {
+            return EMPTY_STR.to_string();
+        };
+
+        let appearances = nodes
+            .iter()
+            .filter(|media| !media.is_adult.unwrap_or(false))
+            .filter_map(|media| {
+                let title = media
+                    .title
+                    .english
+                    .as_deref()
+                    .or(media.title.romaji.as_deref())?;
+                let formatted_title = titlecase(title);
+                let media_type = media
+                    .media_type
+                    .as_deref()
+                    .map(titlecase)
+                    .unwrap_or_else(|| EMPTY_STR.to_string());
+
+                match media.site_url.as_deref() {
+                    Some(url) => Some(format!(
+                        "{} {}",
+                        code(&media_type),
+                        linker(&formatted_title, url)
+                    )),
+                    None => Some(format!("{} {}", code(&media_type), formatted_title)),
+                }
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        if appearances.is_empty() {
+            EMPTY_STR.to_string()
+        } else {
+            appearances
+        }
+    }
+
+    pub fn transform_response_embed(&self) -> CreateEmbed {
+        CreateEmbed::new()
+            .color(0x00_68_A8)
+            .title(self.transform_name())
+            .description(self.transform_description())
+            .url(&self.site_url)
+            .thumbnail(self.transform_thumbnail())
+            .footer(CreateEmbedFooter::new(self.transform_footer_name()))
+            .fields(vec![
+                ("Gender", self.transform_gender(), true),
+                ("Age", self.transform_age(), true),
+                ("Birthday", self.transform_birthday(), true),
+            ])
+            .fields(vec![
+                ("Blood Type", self.transform_blood_type(), true),
+                ("Favourites", self.transform_favourites(), true),
+            ])
+            .field("Appears In", self.transform_media(), false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Character;
+
+    fn sample_character() -> Character {
+        serde_json::from_value(serde_json::json!({
+            "id": 40,
+            "name": {
+                "full": "Lelouch Lamperouge",
+                "native": "ルルーシュ・ランペルージ",
+                "alternative": ["Lelouch vi Britannia"],
+                "userPreferred": "Lelouch Lamperouge"
+            },
+            "image": {
+                "large": "https://example.com/large.jpg",
+                "medium": "https://example.com/medium.jpg"
+            },
+            "description": "<p>A former prince.</p>",
+            "gender": "Male",
+            "dateOfBirth": { "year": null, "month": 12, "day": 5 },
+            "age": "17",
+            "bloodType": "A",
+            "favourites": 1000,
+            "siteUrl": "https://anilist.co/character/40",
+            "media": {
+                "nodes": [{
+                    "id": 1575,
+                    "type": "ANIME",
+                    "title": {
+                        "romaji": "Code Geass: Hangyaku no Lelouch",
+                        "english": "Code Geass: Lelouch of the Rebellion"
+                    },
+                    "siteUrl": "https://anilist.co/anime/1575",
+                    "isAdult": false
+                }]
+            }
+        }))
+        .expect("sample character JSON should deserialize")
+    }
+
+    #[test]
+    fn transforms_name_from_user_preferred() {
+        assert_eq!(sample_character().transform_name(), "Lelouch Lamperouge");
+    }
+
+    #[test]
+    fn transforms_partial_birthday() {
+        assert_eq!(sample_character().transform_birthday(), "12-05");
+    }
+
+    #[test]
+    fn transforms_media_appearances() {
+        let appearances = sample_character().transform_media();
+
+        assert!(appearances.contains("Code Geass: Lelouch of the Rebellion"));
+        assert!(appearances.contains("https://anilist.co/anime/1575"));
+    }
+
+    #[test]
+    fn success_embed_serializes() {
+        let embed = sample_character().transform_response_embed();
+        let value = serde_json::to_value(&embed).expect("embed serializes");
+
+        assert_eq!(value["title"], "Lelouch Lamperouge");
+        assert_eq!(value["url"], "https://anilist.co/character/40");
+    }
+}

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -137,12 +137,12 @@ impl Character {
             .unwrap_or_else(|| EMPTY_STR.to_string())
     }
 
-    pub fn transform_thumbnail(&self) -> String {
+    pub fn transform_thumbnail(&self) -> Option<String> {
         self.image
             .as_ref()
             .and_then(|image| image.large.as_deref().or(image.medium.as_deref()))
-            .unwrap_or_default()
-            .to_string()
+            .filter(|url| !url.trim().is_empty())
+            .map(ToString::to_string)
     }
 
     pub fn transform_description(&self) -> String {
@@ -258,12 +258,11 @@ impl Character {
     }
 
     pub fn transform_response_embed(&self, allow_adult_media: bool) -> CreateEmbed {
-        CreateEmbed::new()
+        let embed = CreateEmbed::new()
             .color(0x00_68_A8)
             .title(self.transform_name())
             .description(self.transform_description())
             .url(&self.site_url)
-            .thumbnail(self.transform_thumbnail())
             .footer(CreateEmbedFooter::new(self.transform_footer_name()))
             .fields(vec![
                 ("Gender", self.transform_gender(), true),
@@ -274,7 +273,12 @@ impl Character {
                 ("Blood Type", self.transform_blood_type(), true),
                 ("Favourites", self.transform_favourites(), true),
             ])
-            .field("Appears In", self.transform_media(allow_adult_media), false)
+            .field("Appears In", self.transform_media(allow_adult_media), false);
+
+        match self.transform_thumbnail() {
+            Some(thumbnail) => embed.thumbnail(thumbnail),
+            None => embed,
+        }
     }
 }
 
@@ -432,11 +436,41 @@ mod tests {
     }
 
     #[test]
+    fn transform_thumbnail_ignores_missing_image_urls() {
+        let character: Character = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "name": {
+                "full": "No Image",
+                "native": null,
+                "alternative": [],
+                "userPreferred": "No Image"
+            },
+            "image": { "large": "", "medium": null },
+            "description": null,
+            "gender": null,
+            "dateOfBirth": null,
+            "age": null,
+            "bloodType": null,
+            "favourites": null,
+            "siteUrl": "https://anilist.co/character/1",
+            "media": { "nodes": [] }
+        }))
+        .expect("sample character JSON should deserialize");
+
+        let embed = character.transform_response_embed(false);
+        let value = serde_json::to_value(&embed).expect("embed serializes");
+
+        assert!(character.transform_thumbnail().is_none());
+        assert!(value.get("thumbnail").is_none());
+    }
+
+    #[test]
     fn success_embed_serializes() {
         let embed = sample_character().transform_response_embed(false);
         let value = serde_json::to_value(&embed).expect("embed serializes");
 
         assert_eq!(value["title"], "Lelouch Lamperouge");
         assert_eq!(value["url"], "https://anilist.co/character/40");
+        assert_eq!(value["thumbnail"]["url"], "https://example.com/large.jpg");
     }
 }

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -33,6 +33,7 @@ pub struct CharacterName {
     pub full: Option<String>,
     pub native: Option<String>,
     pub alternative: Option<Vec<String>>,
+    pub alternative_spoiler: Option<Vec<String>>,
     pub user_preferred: Option<String>,
 }
 
@@ -82,7 +83,7 @@ impl CharacterName {
             .to_string()
     }
 
-    pub fn search_aliases(&self) -> Vec<String> {
+    pub fn search_aliases(&self, allow_spoilers: bool) -> Vec<String> {
         let mut aliases = Vec::new();
 
         if let Some(full) = &self.full {
@@ -97,13 +98,25 @@ impl CharacterName {
             aliases.extend(alternative.clone());
         }
 
+        if allow_spoilers && let Some(alternative_spoiler) = &self.alternative_spoiler {
+            aliases.extend(alternative_spoiler.clone());
+        }
+
         aliases
     }
 
-    pub fn has_alias(&self, alias: &str) -> bool {
-        self.search_aliases()
+    pub fn has_alias(&self, alias: &str, allow_spoilers: bool) -> bool {
+        self.search_aliases(allow_spoilers)
             .iter()
             .any(|candidate| candidate.eq_ignore_ascii_case(alias))
+    }
+
+    pub fn has_spoiler_alias(&self, alias: &str) -> bool {
+        self.alternative_spoiler.as_ref().is_some_and(|aliases| {
+            aliases
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(alias))
+        })
     }
 }
 
@@ -293,6 +306,7 @@ mod tests {
                 "full": "Lelouch Lamperouge",
                 "native": "ルルーシュ・ランペルージ",
                 "alternative": ["Lelouch vi Britannia"],
+                "alternativeSpoiler": ["Lelouch vi Britannia the 99th Emperor"],
                 "userPreferred": "Lelouch Lamperouge"
             },
             "image": {
@@ -338,6 +352,22 @@ mod tests {
 
         assert!(appearances.contains("Code Geass: Lelouch of the Rebellion"));
         assert!(appearances.contains("https://anilist.co/anime/1575"));
+    }
+
+    #[test]
+    fn spoiler_aliases_require_explicit_allowance() {
+        let character = sample_character();
+
+        assert!(
+            !character
+                .name()
+                .has_alias("Lelouch vi Britannia the 99th Emperor", false)
+        );
+        assert!(
+            character
+                .name()
+                .has_alias("Lelouch vi Britannia the 99th Emperor", true)
+        );
     }
 
     #[test]

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -321,6 +321,7 @@ fn strip_spoiler_html(html: &str) -> String {
         output.push_str(&remaining[..open_start]);
 
         let Some(open_end_offset) = remaining[class_index..].find('>') else {
+            remaining = &remaining[open_start..];
             break;
         };
         let mut cursor = class_index + open_end_offset + 1;
@@ -556,6 +557,35 @@ mod tests {
         assert!(disallowed.contains("Visible text."));
         assert!(!disallowed.contains("Hidden spoiler."));
         assert!(allowed.contains("Hidden spoiler."));
+    }
+
+    #[test]
+    fn transform_description_does_not_duplicate_malformed_spoiler_prefix() {
+        let character: Character = serde_json::from_value(serde_json::json!({
+            "id": 650,
+            "name": {
+                "full": "Lust",
+                "native": null,
+                "alternative": [],
+                "alternativeSpoiler": [],
+                "userPreferred": "Lust"
+            },
+            "image": null,
+            "description": "Visible <span class='markdown_spoiler'",
+            "gender": null,
+            "dateOfBirth": null,
+            "age": null,
+            "bloodType": null,
+            "favourites": null,
+            "siteUrl": "https://anilist.co/character/650",
+            "media": { "nodes": [] }
+        }))
+        .expect("sample character JSON should deserialize");
+
+        let description = character.transform_description(false);
+
+        assert!(description.starts_with("Visible"));
+        assert!(!description.contains("Visible Visible"));
     }
 
     #[test]

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -115,8 +115,7 @@ impl Character {
             .as_deref()
             .or(self.name.full.as_deref())
             .or(self.name.native.as_deref())
-            .map(titlecase)
-            .unwrap_or_else(|| EMPTY_STR.to_string())
+            .map_or_else(|| EMPTY_STR.to_string(), titlecase)
     }
 
     pub fn transform_footer_name(&self) -> String {
@@ -154,8 +153,7 @@ impl Character {
     pub fn transform_gender(&self) -> String {
         self.gender
             .as_deref()
-            .map(titlecase)
-            .unwrap_or_else(|| EMPTY_STR.to_string())
+            .map_or_else(|| EMPTY_STR.to_string(), titlecase)
     }
 
     pub fn transform_birthday(&self) -> String {
@@ -183,9 +181,18 @@ impl Character {
     }
 
     pub fn transform_favourites(&self) -> String {
-        self.favourites
-            .map(|favourites| favourites.to_string())
-            .unwrap_or_else(|| EMPTY_STR.to_string())
+        self.favourites.map_or_else(
+            || EMPTY_STR.to_string(),
+            |favourites| favourites.to_string(),
+        )
+    }
+
+    pub fn media_is_all_adult(&self) -> bool {
+        let Some(nodes) = self.media.as_ref().and_then(|media| media.nodes.as_ref()) else {
+            return false;
+        };
+
+        !nodes.is_empty() && nodes.iter().all(|media| media.is_adult.unwrap_or(false))
     }
 
     pub fn transform_media(&self) -> String {
@@ -209,8 +216,7 @@ impl Character {
                 let media_type = media
                     .media_type
                     .as_deref()
-                    .map(titlecase)
-                    .unwrap_or_else(|| EMPTY_STR.to_string());
+                    .map_or_else(|| EMPTY_STR.to_string(), titlecase);
 
                 match media.site_url.as_deref() {
                     Some(url) => Some(format!(
@@ -308,6 +314,39 @@ mod tests {
 
         assert!(appearances.contains("Code Geass: Lelouch of the Rebellion"));
         assert!(appearances.contains("https://anilist.co/anime/1575"));
+    }
+
+    #[test]
+    fn media_is_all_adult_requires_only_adult_appearances() {
+        let character: Character = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "name": {
+                "full": "Adult Character",
+                "native": null,
+                "alternative": [],
+                "userPreferred": "Adult Character"
+            },
+            "image": null,
+            "description": null,
+            "gender": null,
+            "dateOfBirth": null,
+            "age": null,
+            "bloodType": null,
+            "favourites": null,
+            "siteUrl": "https://anilist.co/character/1",
+            "media": {
+                "nodes": [{
+                    "id": 1,
+                    "type": "MANGA",
+                    "title": { "romaji": "Adult Manga", "english": null },
+                    "siteUrl": "https://anilist.co/manga/1",
+                    "isAdult": true
+                }]
+            }
+        }))
+        .expect("sample character JSON should deserialize");
+
+        assert!(character.media_is_all_adult());
     }
 
     #[test]

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -308,7 +308,7 @@ impl Character {
 }
 
 fn strip_spoiler_html(html: &str) -> String {
-    let mut output = String::new();
+    let mut output = String::default();
     let mut remaining = html;
 
     while let Some(class_index) = remaining.find(MARKDOWN_SPOILER_CLASS) {

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -9,6 +9,9 @@ use serenity::all::{CreateEmbed, CreateEmbedFooter};
 
 const DISCORD_EMBED_DESCRIPTION_LIMIT: usize = 4096;
 const DESCRIPTION_ELLIPSIS: &str = "...";
+const MARKDOWN_SPOILER_CLASS: &str = "markdown_spoiler";
+const SPAN_OPEN: &str = "<span";
+const SPAN_CLOSE: &str = "</span>";
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -153,17 +156,22 @@ impl Character {
     pub fn transform_thumbnail(&self) -> Option<String> {
         self.image
             .as_ref()
-            .and_then(|image| image.large.as_deref().or(image.medium.as_deref()))
+            .and_then(|image| image.medium.as_deref().or(image.large.as_deref()))
             .filter(|url| !url.trim().is_empty())
             .map(ToString::to_string)
     }
 
-    pub fn transform_description(&self) -> String {
-        let description = parse_html(
-            self.description
-                .as_deref()
-                .unwrap_or("<i>No Description Yet</i>"),
-        );
+    pub fn transform_description(&self, allow_spoilers: bool) -> String {
+        let description_html = self
+            .description
+            .as_deref()
+            .unwrap_or("<i>No Description Yet</i>");
+        let filtered_description = if allow_spoilers {
+            description_html.to_string()
+        } else {
+            strip_spoiler_html(description_html)
+        };
+        let description = parse_html(&filtered_description);
 
         if description.chars().count() <= DISCORD_EMBED_DESCRIPTION_LIMIT {
             return description;
@@ -270,11 +278,15 @@ impl Character {
         }
     }
 
-    pub fn transform_response_embed(&self, allow_adult_media: bool) -> CreateEmbed {
+    pub fn transform_response_embed(
+        &self,
+        allow_adult_media: bool,
+        allow_spoilers: bool,
+    ) -> CreateEmbed {
         let embed = CreateEmbed::new()
             .color(0x00_68_A8)
             .title(self.transform_name())
-            .description(self.transform_description())
+            .description(self.transform_description(allow_spoilers))
             .url(&self.site_url)
             .footer(CreateEmbedFooter::new(self.transform_footer_name()))
             .fields(vec![
@@ -293,6 +305,56 @@ impl Character {
             None => embed,
         }
     }
+}
+
+fn strip_spoiler_html(html: &str) -> String {
+    let mut output = String::new();
+    let mut remaining = html;
+
+    while let Some(class_index) = remaining.find(MARKDOWN_SPOILER_CLASS) {
+        let Some(open_start) = remaining[..class_index].rfind(SPAN_OPEN) else {
+            output.push_str(&remaining[..class_index + MARKDOWN_SPOILER_CLASS.len()]);
+            remaining = &remaining[class_index + MARKDOWN_SPOILER_CLASS.len()..];
+            continue;
+        };
+
+        output.push_str(&remaining[..open_start]);
+
+        let Some(open_end_offset) = remaining[class_index..].find('>') else {
+            break;
+        };
+        let mut cursor = class_index + open_end_offset + 1;
+        let mut span_depth = 1;
+
+        while span_depth > 0 {
+            let next_open = remaining[cursor..]
+                .find(SPAN_OPEN)
+                .map(|offset| cursor + offset);
+            let next_close = remaining[cursor..]
+                .find(SPAN_CLOSE)
+                .map(|offset| cursor + offset);
+
+            match (next_open, next_close) {
+                (Some(open), Some(close)) if open < close => {
+                    span_depth += 1;
+                    cursor = open + SPAN_OPEN.len();
+                }
+                (_, Some(close)) => {
+                    span_depth -= 1;
+                    cursor = close + SPAN_CLOSE.len();
+                }
+                _ => {
+                    cursor = remaining.len();
+                    break;
+                }
+            }
+        }
+
+        remaining = &remaining[cursor..];
+    }
+
+    output.push_str(remaining);
+    output
 }
 
 #[cfg(test)]
@@ -459,10 +521,41 @@ mod tests {
         }))
         .expect("sample character JSON should deserialize");
 
-        let description = character.transform_description();
+        let description = character.transform_description(true);
 
         assert_eq!(description.chars().count(), DISCORD_EMBED_DESCRIPTION_LIMIT);
         assert!(description.ends_with(DESCRIPTION_ELLIPSIS));
+    }
+
+    #[test]
+    fn transform_description_filters_spoiler_html_when_disallowed() {
+        let character: Character = serde_json::from_value(serde_json::json!({
+            "id": 650,
+            "name": {
+                "full": "Lust",
+                "native": null,
+                "alternative": [],
+                "alternativeSpoiler": [],
+                "userPreferred": "Lust"
+            },
+            "image": null,
+            "description": "<p>Visible text.</p><p><span class='markdown_spoiler'><span>Hidden spoiler.</span></span></p>",
+            "gender": null,
+            "dateOfBirth": null,
+            "age": null,
+            "bloodType": null,
+            "favourites": null,
+            "siteUrl": "https://anilist.co/character/650",
+            "media": { "nodes": [] }
+        }))
+        .expect("sample character JSON should deserialize");
+
+        let disallowed = character.transform_description(false);
+        let allowed = character.transform_description(true);
+
+        assert!(disallowed.contains("Visible text."));
+        assert!(!disallowed.contains("Hidden spoiler."));
+        assert!(allowed.contains("Hidden spoiler."));
     }
 
     #[test]
@@ -487,7 +580,7 @@ mod tests {
         }))
         .expect("sample character JSON should deserialize");
 
-        let embed = character.transform_response_embed(false);
+        let embed = character.transform_response_embed(false, false);
         let value = serde_json::to_value(&embed).expect("embed serializes");
 
         assert!(character.transform_thumbnail().is_none());
@@ -496,11 +589,11 @@ mod tests {
 
     #[test]
     fn success_embed_serializes() {
-        let embed = sample_character().transform_response_embed(false);
+        let embed = sample_character().transform_response_embed(false, false);
         let value = serde_json::to_value(&embed).expect("embed serializes");
 
         assert_eq!(value["title"], "Lelouch Lamperouge");
         assert_eq!(value["url"], "https://anilist.co/character/40");
-        assert_eq!(value["thumbnail"]["url"], "https://example.com/large.jpg");
+        assert_eq!(value["thumbnail"]["url"], "https://example.com/medium.jpg");
     }
 }

--- a/src/models/anilist_character.rs
+++ b/src/models/anilist_character.rs
@@ -7,6 +7,9 @@ use html2md::parse_html;
 use serde::Deserialize;
 use serenity::all::{CreateEmbed, CreateEmbedFooter};
 
+const DISCORD_EMBED_DESCRIPTION_LIMIT: usize = 4096;
+const DESCRIPTION_ELLIPSIS: &str = "...";
+
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Character {
@@ -143,11 +146,21 @@ impl Character {
     }
 
     pub fn transform_description(&self) -> String {
-        parse_html(
+        let description = parse_html(
             self.description
                 .as_deref()
                 .unwrap_or("<i>No Description Yet</i>"),
-        )
+        );
+
+        if description.chars().count() <= DISCORD_EMBED_DESCRIPTION_LIMIT {
+            return description;
+        }
+
+        description
+            .chars()
+            .take(DISCORD_EMBED_DESCRIPTION_LIMIT - DESCRIPTION_ELLIPSIS.len())
+            .chain(DESCRIPTION_ELLIPSIS.chars())
+            .collect()
     }
 
     pub fn transform_gender(&self) -> String {
@@ -195,7 +208,14 @@ impl Character {
         !nodes.is_empty() && nodes.iter().all(|media| media.is_adult.unwrap_or(false))
     }
 
-    pub fn transform_media(&self) -> String {
+    pub fn has_adult_media(&self) -> bool {
+        self.media
+            .as_ref()
+            .and_then(|media| media.nodes.as_ref())
+            .is_some_and(|nodes| nodes.iter().any(|media| media.is_adult.unwrap_or(false)))
+    }
+
+    pub fn transform_media(&self, allow_adult: bool) -> String {
         let Some(media) = &self.media else {
             return EMPTY_STR.to_string();
         };
@@ -205,7 +225,7 @@ impl Character {
 
         let appearances = nodes
             .iter()
-            .filter(|media| !media.is_adult.unwrap_or(false))
+            .filter(|media| allow_adult || !media.is_adult.unwrap_or(false))
             .filter_map(|media| {
                 let title = media
                     .title
@@ -237,7 +257,7 @@ impl Character {
         }
     }
 
-    pub fn transform_response_embed(&self) -> CreateEmbed {
+    pub fn transform_response_embed(&self, allow_adult_media: bool) -> CreateEmbed {
         CreateEmbed::new()
             .color(0x00_68_A8)
             .title(self.transform_name())
@@ -254,13 +274,13 @@ impl Character {
                 ("Blood Type", self.transform_blood_type(), true),
                 ("Favourites", self.transform_favourites(), true),
             ])
-            .field("Appears In", self.transform_media(), false)
+            .field("Appears In", self.transform_media(allow_adult_media), false)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Character;
+    use super::{Character, DESCRIPTION_ELLIPSIS, DISCORD_EMBED_DESCRIPTION_LIMIT, EMPTY_STR};
 
     fn sample_character() -> Character {
         serde_json::from_value(serde_json::json!({
@@ -310,7 +330,7 @@ mod tests {
 
     #[test]
     fn transforms_media_appearances() {
-        let appearances = sample_character().transform_media();
+        let appearances = sample_character().transform_media(false);
 
         assert!(appearances.contains("Code Geass: Lelouch of the Rebellion"));
         assert!(appearances.contains("https://anilist.co/anime/1575"));
@@ -350,8 +370,70 @@ mod tests {
     }
 
     #[test]
+    fn transform_media_includes_adult_appearances_when_allowed() {
+        let character: Character = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "name": {
+                "full": "Adult Character",
+                "native": null,
+                "alternative": [],
+                "userPreferred": "Adult Character"
+            },
+            "image": null,
+            "description": null,
+            "gender": null,
+            "dateOfBirth": null,
+            "age": null,
+            "bloodType": null,
+            "favourites": null,
+            "siteUrl": "https://anilist.co/character/1",
+            "media": {
+                "nodes": [{
+                    "id": 1,
+                    "type": "MANGA",
+                    "title": { "romaji": "Adult Manga", "english": null },
+                    "siteUrl": "https://anilist.co/manga/1",
+                    "isAdult": true
+                }]
+            }
+        }))
+        .expect("sample character JSON should deserialize");
+
+        assert_eq!(character.transform_media(false), EMPTY_STR);
+        assert!(character.transform_media(true).contains("Adult Manga"));
+    }
+
+    #[test]
+    fn transform_description_respects_discord_embed_limit() {
+        let character: Character = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "name": {
+                "full": "Long Bio",
+                "native": null,
+                "alternative": [],
+                "userPreferred": "Long Bio"
+            },
+            "image": null,
+            "description": "a".repeat(5000),
+            "gender": null,
+            "dateOfBirth": null,
+            "age": null,
+            "bloodType": null,
+            "favourites": null,
+            "siteUrl": "https://anilist.co/character/1",
+            "media": { "nodes": [] }
+        }))
+        .expect("sample character JSON should deserialize");
+
+        let description = character.transform_description();
+
+        assert_eq!(description.chars().count(), DISCORD_EMBED_DESCRIPTION_LIMIT);
+        assert!(description.ends_with(DESCRIPTION_ELLIPSIS));
+    }
+
+    #[test]
     fn success_embed_serializes() {
-        let embed = sample_character().transform_response_embed();
+        let embed = sample_character().transform_response_embed(false);
         let value = serde_json::to_value(&embed).expect("embed serializes");
 
         assert_eq!(value["title"], "Lelouch Lamperouge");

--- a/src/models/character_id_response.rs
+++ b/src/models/character_id_response.rs
@@ -1,0 +1,12 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct FetchResponse<T> {
+    pub data: Option<FetchData<T>>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct FetchData<T> {
+    #[serde(rename = "Character")]
+    pub character: Option<T>,
+}

--- a/src/models/character_response.rs
+++ b/src/models/character_response.rs
@@ -1,0 +1,138 @@
+use crate::{models::anilist_character::Character, utils::fuzzy::fuzzy_matcher};
+
+use serde::Deserialize;
+use tracing::{debug, info};
+
+#[derive(Deserialize, Debug)]
+pub struct FetchResponse {
+    pub data: Option<Page>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Page {
+    #[serde(rename = "Page")]
+    pub page: Option<PageData>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PageData {
+    pub characters: Option<Vec<Character>>,
+}
+
+impl FetchResponse {
+    pub fn characters(&self) -> Option<&[Character]> {
+        self.data.as_ref()?.page.as_ref()?.characters.as_deref()
+    }
+
+    pub fn fuzzy_match(&self, user_input: &str) -> Option<Character> {
+        let characters = self.characters()?;
+        if characters.is_empty() {
+            return None;
+        }
+
+        let name = user_input.to_lowercase();
+        let preferred_names: Vec<String> = characters
+            .iter()
+            .map(|character| character.name().search_name())
+            .collect();
+        let top_name_match = fuzzy_matcher(&name, preferred_names, 0.5).unwrap_or_default();
+
+        if top_name_match.index != usize::MAX && top_name_match.result.similarity >= 0.85 {
+            info!(
+                "Character name match says: {:#?} at Index: {:#?}",
+                characters[top_name_match.index].name().search_name(),
+                top_name_match.index
+            );
+            return Some(characters[top_name_match.index].clone());
+        }
+
+        let alternative_names: Vec<String> = characters
+            .iter()
+            .flat_map(|character| character.name().search_aliases())
+            .collect();
+        let top_alternative_match =
+            fuzzy_matcher(&name, alternative_names, 1.0).unwrap_or_default();
+
+        if top_alternative_match.index != usize::MAX {
+            let matched_alias = top_alternative_match.result.text;
+            debug!("Character alias match says: {matched_alias:#?}");
+            return characters
+                .iter()
+                .find(|character| character.name().has_alias(&matched_alias))
+                .cloned();
+        }
+
+        match top_name_match.index {
+            usize::MAX => characters.first().cloned(),
+            index => characters.get(index).cloned(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FetchResponse;
+
+    fn character_response_json() -> serde_json::Value {
+        serde_json::json!({
+            "data": {
+                "Page": {
+                    "characters": [
+                        {
+                            "id": 1,
+                            "name": {
+                                "full": "Monkey D. Luffy",
+                                "native": "モンキー・D・ルフィ",
+                                "alternative": ["Straw Hat Luffy"],
+                                "userPreferred": "Monkey D. Luffy"
+                            },
+                            "image": { "large": null, "medium": null },
+                            "description": null,
+                            "gender": null,
+                            "dateOfBirth": null,
+                            "age": null,
+                            "bloodType": null,
+                            "favourites": null,
+                            "siteUrl": "https://anilist.co/character/1",
+                            "media": { "nodes": [] }
+                        }
+                    ]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn empty_response_returns_none() {
+        let response: FetchResponse = serde_json::from_value(serde_json::json!({
+            "data": { "Page": { "characters": [] } }
+        }))
+        .expect("payload deserializes");
+
+        assert!(response.fuzzy_match("luffy").is_none());
+    }
+
+    #[test]
+    fn fuzzy_match_returns_name_match() {
+        let response: FetchResponse =
+            serde_json::from_value(character_response_json()).expect("payload deserializes");
+
+        let character = response
+            .fuzzy_match("Monkey D. Luffy")
+            .expect("expected a match");
+
+        assert_eq!(character.transform_name(), "Monkey D. Luffy");
+    }
+
+    #[test]
+    fn fuzzy_match_returns_alternative_name_match() {
+        let response: FetchResponse =
+            serde_json::from_value(character_response_json()).expect("payload deserializes");
+
+        let character = response
+            .fuzzy_match("Straw Hat Luffy")
+            .expect("expected a match");
+
+        assert_eq!(character.transform_name(), "Monkey D. Luffy");
+    }
+}

--- a/src/models/character_response.rs
+++ b/src/models/character_response.rs
@@ -24,7 +24,7 @@ impl FetchResponse {
         self.data.as_ref()?.page.as_ref()?.characters.as_deref()
     }
 
-    pub fn fuzzy_match(&self, user_input: &str) -> Option<Character> {
+    pub fn fuzzy_match(&self, user_input: &str, allow_spoilers: bool) -> Option<Character> {
         let characters = self.characters()?;
         if characters.is_empty() {
             return None;
@@ -48,7 +48,7 @@ impl FetchResponse {
 
         let alternative_names: Vec<String> = characters
             .iter()
-            .flat_map(|character| character.name().search_aliases())
+            .flat_map(|character| character.name().search_aliases(allow_spoilers))
             .collect();
         let top_alternative_match =
             fuzzy_matcher(&name, alternative_names, 1.0).unwrap_or_default();
@@ -58,8 +58,17 @@ impl FetchResponse {
             debug!("Character alias match says: {matched_alias:#?}");
             return characters
                 .iter()
-                .find(|character| character.name().has_alias(&matched_alias))
+                .find(|character| character.name().has_alias(&matched_alias, allow_spoilers))
                 .cloned();
+        }
+
+        if !allow_spoilers
+            && characters
+                .iter()
+                .any(|character| character.name().has_spoiler_alias(user_input))
+        {
+            info!("Character spoiler alias matched while spoilers are disallowed");
+            return None;
         }
 
         match top_name_match.index {
@@ -84,6 +93,7 @@ mod tests {
                                 "full": "Monkey D. Luffy",
                                 "native": "モンキー・D・ルフィ",
                                 "alternative": ["Straw Hat Luffy"],
+                                "alternativeSpoiler": ["Joy Boy"],
                                 "userPreferred": "Monkey D. Luffy"
                             },
                             "image": { "large": null, "medium": null },
@@ -109,7 +119,7 @@ mod tests {
         }))
         .expect("payload deserializes");
 
-        assert!(response.fuzzy_match("luffy").is_none());
+        assert!(response.fuzzy_match("luffy", false).is_none());
     }
 
     #[test]
@@ -118,7 +128,7 @@ mod tests {
             serde_json::from_value(character_response_json()).expect("payload deserializes");
 
         let character = response
-            .fuzzy_match("Monkey D. Luffy")
+            .fuzzy_match("Monkey D. Luffy", false)
             .expect("expected a match");
 
         assert_eq!(character.transform_name(), "Monkey D. Luffy");
@@ -130,8 +140,22 @@ mod tests {
             serde_json::from_value(character_response_json()).expect("payload deserializes");
 
         let character = response
-            .fuzzy_match("Straw Hat Luffy")
+            .fuzzy_match("Straw Hat Luffy", false)
             .expect("expected a match");
+
+        assert_eq!(character.transform_name(), "Monkey D. Luffy");
+    }
+
+    #[test]
+    fn fuzzy_match_requires_spoiler_allowance_for_spoiler_aliases() {
+        let response: FetchResponse =
+            serde_json::from_value(character_response_json()).expect("payload deserializes");
+
+        assert!(response.fuzzy_match("Joy Boy", false).is_none());
+
+        let character = response
+            .fuzzy_match("Joy Boy", true)
+            .expect("expected a spoiler alias match");
 
         assert_eq!(character.transform_name(), "Monkey D. Luffy");
     }

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -170,7 +170,10 @@ pub async fn fetch<
 }
 
 #[instrument(name = "anilist.fetch_character", skip(response_config))]
-pub async fn fetch_character(response_config: &impl Response) -> Option<Character> {
+pub async fn fetch_character(
+    response_config: &impl Response,
+    allow_spoilers: bool,
+) -> Option<Character> {
     match response_config.get_argument() {
         Argument::Id(value) => {
             let fetched_data = match fetch_by_id(response_config.get_id_query(), *value).await {
@@ -192,7 +195,7 @@ pub async fn fetch_character(response_config: &impl Response) -> Option<Characte
             fetch_response.data.and_then(|data| data.character)
         }
         Argument::Search(value) => {
-            let cache_key = format!("character:{value}");
+            let cache_key = format!("character:v2:{value}");
             let cache_key_for_lookup = cache_key.clone();
             let search_query = response_config.get_search_query();
             let lookup_value = value.to_string();
@@ -232,7 +235,7 @@ pub async fn fetch_character(response_config: &impl Response) -> Option<Characte
                 "Deserialized character search response: {:#?}",
                 fetch_response
             );
-            fetch_response.fuzzy_match(value)
+            fetch_response.fuzzy_match(value, allow_spoilers)
         }
     }
 }

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -12,7 +12,7 @@ use crate::{
         media_type::MediaType as Type, transformers::Transformers,
     },
     utils::{
-        fetch_by_arguments::{fetch_by_id, fetch_by_name},
+        fetch_by_arguments::{fetch_by_id, fetch_by_name, fetch_by_raw_name},
         redis::{check_cache, try_to_cache_response},
     },
 };
@@ -65,6 +65,37 @@ async fn fetch_from_network_and_cache(
         Ok(data) => data,
         Err(err) => {
             error!(error = %err, "Failed to fetch AniList data by name");
+            return None;
+        }
+    };
+
+    let cache_key_for_write = cache_key.clone();
+    let response_to_cache = response.clone();
+    if let Err(err) = task::spawn_blocking(move || {
+        write_cached_anilist_response(cache_key_for_write, response_to_cache)
+    })
+    .await
+    {
+        error!(error = %err, cache_key = %cache_key, "Failed to cache AniList response");
+    }
+
+    Some(response)
+}
+
+#[instrument(
+    name = "anilist.fetch_raw_from_network_and_cache",
+    skip(search_query),
+    fields(cache_key = %cache_key, lookup_len = lookup_value.len())
+)]
+async fn fetch_raw_from_network_and_cache(
+    search_query: String,
+    lookup_value: String,
+    cache_key: String,
+) -> Option<String> {
+    let response = match fetch_by_raw_name(search_query, lookup_value).await {
+        Ok(data) => data,
+        Err(err) => {
+            error!(error = %err, "Failed to fetch AniList data by raw name");
             return None;
         }
     };
@@ -211,7 +242,7 @@ pub async fn fetch_character(
                 }
                 Ok(Err(err)) => {
                     info!("Cache miss for {:#?} with error {:#?}", cache_key, err);
-                    fetch_from_network_and_cache(
+                    fetch_raw_from_network_and_cache(
                         search_query.clone(),
                         lookup_value.clone(),
                         cache_key.clone(),
@@ -220,7 +251,7 @@ pub async fn fetch_character(
                 }
                 Err(err) => {
                     error!(error = %err, "Failed to read AniList character cache");
-                    fetch_from_network_and_cache(search_query, lookup_value, cache_key.clone())
+                    fetch_raw_from_network_and_cache(search_query, lookup_value, cache_key.clone())
                         .await?
                 }
             };

--- a/src/models/fetcher.rs
+++ b/src/models/fetcher.rs
@@ -1,12 +1,15 @@
 use crate::{
     commands::{
         anime::queries::{FETCH_ANIME, FETCH_ANIME_BY_ID},
+        character::queries::{FETCH_CHARACTER, FETCH_CHARACTER_BY_ID},
         manga::queries::{FETCH_MANGA, FETCH_MANGA_BY_ID},
     },
     models::{
-        anilist_common::TitleVariant, id_response::FetchResponse as IdResponse,
-        media_response::FetchResponse as MediaResponse, media_type::MediaType as Type,
-        transformers::Transformers,
+        anilist_character::Character, anilist_common::TitleVariant,
+        character_id_response::FetchResponse as CharacterIdResponse,
+        character_response::FetchResponse as CharacterResponse,
+        id_response::FetchResponse as IdResponse, media_response::FetchResponse as MediaResponse,
+        media_type::MediaType as Type, transformers::Transformers,
     },
     utils::{
         fetch_by_arguments::{fetch_by_id, fetch_by_name},
@@ -25,6 +28,12 @@ pub struct AnimeConfig {
 }
 
 pub struct MangaConfig {
+    argument: Argument,
+    id_query: String,
+    search_query: String,
+}
+
+pub struct CharacterConfig {
     argument: Argument,
     id_query: String,
     search_query: String,
@@ -160,6 +169,74 @@ pub async fn fetch<
     }
 }
 
+#[instrument(name = "anilist.fetch_character", skip(response_config))]
+pub async fn fetch_character(response_config: &impl Response) -> Option<Character> {
+    match response_config.get_argument() {
+        Argument::Id(value) => {
+            let fetched_data = match fetch_by_id(response_config.get_id_query(), *value).await {
+                Ok(data) => data,
+                Err(err) => {
+                    error!(error = %err, id = *value, "Failed to fetch AniList character data by id");
+                    return None;
+                }
+            };
+            let fetch_response: CharacterIdResponse<Character> =
+                match serde_json::from_str(&fetched_data) {
+                    Ok(response) => response,
+                    Err(err) => {
+                        error!(error = %err, "Failed to deserialize AniList character id response");
+                        return None;
+                    }
+                };
+            debug!("Deserialized character id response: {:#?}", fetch_response);
+            fetch_response.data.and_then(|data| data.character)
+        }
+        Argument::Search(value) => {
+            let cache_key = format!("character:{value}");
+            let cache_key_for_lookup = cache_key.clone();
+            let search_query = response_config.get_search_query();
+            let lookup_value = value.to_string();
+
+            let fetched_data = match task::spawn_blocking(move || {
+                read_cached_anilist_response(cache_key_for_lookup)
+            })
+            .await
+            {
+                Ok(Ok(cached_value)) => {
+                    info!("Cache hit for {:#?}", cache_key);
+                    cached_value
+                }
+                Ok(Err(err)) => {
+                    info!("Cache miss for {:#?} with error {:#?}", cache_key, err);
+                    fetch_from_network_and_cache(
+                        search_query.clone(),
+                        lookup_value.clone(),
+                        cache_key.clone(),
+                    )
+                    .await?
+                }
+                Err(err) => {
+                    error!(error = %err, "Failed to read AniList character cache");
+                    fetch_from_network_and_cache(search_query, lookup_value, cache_key.clone())
+                        .await?
+                }
+            };
+            let fetch_response: CharacterResponse = match serde_json::from_str(&fetched_data) {
+                Ok(response) => response,
+                Err(err) => {
+                    error!(error = %err, "Failed to deserialize AniList character search response");
+                    return None;
+                }
+            };
+            debug!(
+                "Deserialized character search response: {:#?}",
+                fetch_response
+            );
+            fetch_response.fuzzy_match(value)
+        }
+    }
+}
+
 impl Response for AnimeConfig {
     fn new(argument: Argument) -> AnimeConfig {
         AnimeConfig {
@@ -188,6 +265,28 @@ impl Response for MangaConfig {
             argument,
             id_query: FETCH_MANGA_BY_ID.to_string(),
             search_query: FETCH_MANGA.to_string(),
+        }
+    }
+
+    fn get_argument(&self) -> &Argument {
+        &self.argument
+    }
+
+    fn get_id_query(&self) -> String {
+        self.id_query.to_owned()
+    }
+
+    fn get_search_query(&self) -> String {
+        self.search_query.to_owned()
+    }
+}
+
+impl Response for CharacterConfig {
+    fn new(argument: Argument) -> CharacterConfig {
+        CharacterConfig {
+            argument,
+            id_query: FETCH_CHARACTER_BY_ID.to_string(),
+            search_query: FETCH_CHARACTER.to_string(),
         }
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,9 @@
 pub mod anilist_anime;
+pub mod anilist_character;
 pub mod anilist_common;
 pub mod anilist_manga;
+pub mod character_id_response;
+pub mod character_response;
 pub mod db;
 pub mod fetcher;
 pub mod id_response;

--- a/src/utils/fetch_by_arguments.rs
+++ b/src/utils/fetch_by_arguments.rs
@@ -28,3 +28,13 @@ pub async fn fetch_by_name(query: String, name: String) -> Result<String, AniLis
 
     Ok(result)
 }
+
+#[instrument(name = "anilist.fetch_by_raw_name", skip(query), fields(name_len = name.len()))]
+pub async fn fetch_by_raw_name(query: String, name: String) -> Result<String, AniListRequestError> {
+    let json = json!({"query": query, "variables": {"search": name}});
+    let result = send_request(json).await?;
+
+    info!("Fetched By Raw Name");
+
+    Ok(result)
+}

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -57,9 +57,12 @@ pub async fn fetcher<
 }
 
 #[instrument(name = "fetcher.fetch_character", skip(arg))]
-pub async fn character_fetcher(arg: CommandDataOptionValue) -> Option<Character> {
+pub async fn character_fetcher(
+    arg: CommandDataOptionValue,
+    allow_spoilers: bool,
+) -> Option<Character> {
     info!("Character fetcher found arg: {:#?}", arg);
     let argument = return_argument(arg)?;
     let character_response: CharacterConfig = Response::new(argument);
-    fetch_character(&character_response).await
+    fetch_character(&character_response, allow_spoilers).await
 }

--- a/src/utils/response_fetcher.rs
+++ b/src/utils/response_fetcher.rs
@@ -1,6 +1,9 @@
 use crate::models::{
+    anilist_character::Character,
     anilist_common::TitleVariant,
-    fetcher::{AnimeConfig, Argument, MangaConfig, Response, fetch},
+    fetcher::{
+        AnimeConfig, Argument, CharacterConfig, MangaConfig, Response, fetch, fetch_character,
+    },
     media_type::MediaType as Type,
     transformers::Transformers,
 };
@@ -51,4 +54,12 @@ pub async fn fetcher<
             fetch::<T>(&manga_response, media_type).await
         }
     }
+}
+
+#[instrument(name = "fetcher.fetch_character", skip(arg))]
+pub async fn character_fetcher(arg: CommandDataOptionValue) -> Option<Character> {
+    info!("Character fetcher found arg: {:#?}", arg);
+    let argument = return_argument(arg)?;
+    let character_response: CharacterConfig = Response::new(argument);
+    fetch_character(&character_response).await
 }

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -1,5 +1,6 @@
 pub const NOT_FOUND_ANIME: &str = "No such anime";
 pub const NOT_FOUND_MANGA: &str = "No such manga";
+pub const NOT_FOUND_CHARACTER: &str = "No such character";
 pub const NSFW_NOT_ALLOWED: &str =
     "This content is age-restricted and can only be viewed in NSFW channels";
 pub const EMPTY_STR: &str = "-";


### PR DESCRIPTION
## Summary

Adds AniList character lookup support through a new `/character` slash command.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 249819e9d7d7e3a05b2b723013c6fba292162cd8: add AniList character GraphQL queries, response wrappers, model transforms, and character fuzzy matching tests
- f28bc9bbf49151fad87c20efee8844c4871a7e77: add character fetch configuration, cache-backed lookup path, and AniList data-source support
- 9d81d461d68e5773c245bb923dd10ca669c1d3a0: wire the `/character` slash command into registration/dispatch and bump the crate version to 2.12.0

### Notes

Character embeds include profile metadata, birthday, favorites, description, thumbnail, and top non-adult media appearances.

## Validation
- [x] `cargo fmt --manifest-path /project/workspace/annie-mei/Cargo.toml -- --check`
- [x] `cargo test --manifest-path /project/workspace/annie-mei/Cargo.toml`
- [x] `cargo clippy --manifest-path /project/workspace/annie-mei/Cargo.toml --all-targets --all-features`

## References

- ANNIE-17

---

This PR description was written by GPT-5.5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
