### PR TITLE
[ANNIE-152]/add ToS and privacy policy

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -68,9 +68,9 @@ Annie Mei does not sell personal information. Information is shared only as need
 
 ## Your choices and deletion requests
 
-You can avoid optional AniList account processing by not using `/register`. If you have linked an AniList account, you may revoke access from AniList where supported.
+You can avoid optional AniList account processing by not using `/register`. If you have linked an AniList account, you can use `/unregister confirmation:Confirm unlink` in Discord to unlink your AniList account from Annie Mei's bot features. You may also revoke Annie Mei's access from AniList where supported.
 
-To request deletion of stored Annie Mei account-link data, open an issue at:
+Unlinking in Discord may not remove every record held by the companion auth service, such as OAuth credential records or operational backups. To request deletion of any remaining stored Annie Mei account-link data, open an issue at:
 
 https://github.com/annie-mei/annie-mei/issues
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -27,7 +27,7 @@ AniList linking is optional. Commands that do not require an AniList link can st
 
 ### Logs, diagnostics, and error reports
 
-Annie Mei may collect operational logs, diagnostics, and error reports to keep the service reliable and investigate failures. Where practical, Discord user IDs are hashed or fingerprinted before being sent to logs or Sentry. Error reports may include command names, high-level execution context, and sanitized error details. Secrets and credential-bearing URLs are intended to be redacted before logging.
+Annie Mei may collect operational logs, diagnostics, and error reports to keep the service reliable and investigate failures. Discord user IDs are hashed or fingerprinted before being attached to application logs or Sentry diagnostics. Error reports may include command names, high-level execution context, and sanitized error details. Credential-bearing URLs are redacted before being sent to application logs or Sentry.
 
 ### Cache and infrastructure data
 
@@ -74,11 +74,11 @@ To request deletion of stored Annie Mei account-link data, open an issue at:
 
 https://github.com/annie-mei/annie-mei/issues
 
-Include enough information to identify the Discord account or server involved. Do not post secrets, OAuth tokens, or other sensitive information in public issues.
+Do not include your numeric Discord ID, OAuth tokens, secrets, or other sensitive information in a public issue. Ask for private deletion support and the maintainer will coordinate a private way to verify the account involved.
 
 ## Security
 
-Annie Mei uses technical measures intended to protect stored data, including secret-managed OAuth configuration, hashed or fingerprinted identifiers in diagnostics where practical, and redaction of credential-bearing URLs. No system is perfectly secure, and Annie Mei cannot guarantee absolute security.
+Annie Mei uses technical measures intended to protect stored data, including secret-managed OAuth configuration, hashed or fingerprinted identifiers in diagnostics, and redaction of credential-bearing URLs before application logging or Sentry reporting. No system is perfectly secure, and Annie Mei cannot guarantee absolute security.
 
 ## Children's privacy
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,95 @@
+# Annie Mei Privacy Policy
+
+Effective date: 2026-04-27
+
+This Privacy Policy explains what information Annie Mei collects, how it is used, and how you can request deletion. Annie Mei is a Discord bot with a companion AniList OAuth service.
+
+## Information Annie Mei processes
+
+### Discord information
+
+When you use Annie Mei in Discord, the bot receives information Discord provides for the interaction, such as:
+
+- Your Discord user ID.
+- The server, channel, and interaction context needed to respond to commands.
+- Slash command names and command inputs, such as anime, manga, character, or song search terms.
+
+### AniList account linking information
+
+If you choose to link your AniList account with `/register`, Annie Mei and its auth service process and store information needed to maintain that link, including:
+
+- Your Discord user ID.
+- Your AniList user ID and AniList username.
+- AniList OAuth access tokens, refresh tokens when provided, token expiry timestamps, and relink status metadata.
+- Temporary OAuth session state used to protect the login flow.
+
+AniList linking is optional. Commands that do not require an AniList link can still be used without linking an account.
+
+### Logs, diagnostics, and error reports
+
+Annie Mei may collect operational logs, diagnostics, and error reports to keep the service reliable and investigate failures. Where practical, Discord user IDs are hashed or fingerprinted before being sent to logs or Sentry. Error reports may include command names, high-level execution context, and sanitized error details. Secrets and credential-bearing URLs are intended to be redacted before logging.
+
+### Cache and infrastructure data
+
+Annie Mei may cache API responses or derived data in Redis to improve performance and reduce third-party API usage. The bot also stores application data in Postgres and uses managed infrastructure providers to operate the service.
+
+## How information is used
+
+Annie Mei uses the information above to:
+
+- Respond to Discord slash commands.
+- Link Discord users to AniList accounts when requested.
+- Fetch anime, manga, character, user list, and theme song information.
+- Display linked-account context such as AniList usernames or scores where supported.
+- Prevent OAuth replay or misuse.
+- Debug errors, monitor reliability, and protect the service from abuse.
+
+## Third-party services
+
+Annie Mei uses third-party services to operate and provide features, including:
+
+- Discord for bot interactions.
+- AniList for anime, manga, character, user, and OAuth data.
+- MyAnimeList and Spotify for theme song metadata and links.
+- Sentry for error reporting and diagnostics.
+- Postgres hosting, Redis hosting, secret management, and deployment providers for infrastructure operations.
+
+These services process data under their own terms and privacy policies.
+
+## Data sharing
+
+Annie Mei does not sell personal information. Information is shared only as needed to operate the bot, provide requested features, comply with legal obligations, protect the service, or use the third-party providers listed above.
+
+## Data retention
+
+- AniList OAuth session state is temporary and expires after a short period.
+- AniList account link records are kept until they are no longer needed to provide the linked-account feature or until deletion is requested.
+- Logs, diagnostics, caches, and backups may be retained for operational, security, and reliability purposes and then deleted or rotated according to provider and maintainer practices.
+
+## Your choices and deletion requests
+
+You can avoid optional AniList account processing by not using `/register`. If you have linked an AniList account, you may revoke access from AniList where supported.
+
+To request deletion of stored Annie Mei account-link data, open an issue at:
+
+https://github.com/annie-mei/annie-mei/issues
+
+Include enough information to identify the Discord account or server involved. Do not post secrets, OAuth tokens, or other sensitive information in public issues.
+
+## Security
+
+Annie Mei uses technical measures intended to protect stored data, including secret-managed OAuth configuration, hashed or fingerprinted identifiers in diagnostics where practical, and redaction of credential-bearing URLs. No system is perfectly secure, and Annie Mei cannot guarantee absolute security.
+
+## Children's privacy
+
+Annie Mei is intended for users who are allowed to use Discord under Discord's own terms. Annie Mei is not directed at children below the age permitted by Discord.
+
+## Changes to this policy
+
+This policy may be updated from time to time. Continued use of Annie Mei after changes are published means you accept the updated policy.
+
+## Contact
+
+For privacy questions, support, or deletion requests, open an issue at:
+
+https://github.com/annie-mei/annie-mei/issues

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -68,9 +68,9 @@ Annie Mei does not sell personal information. Information is shared only as need
 
 ## Your choices and deletion requests
 
-You can avoid optional AniList account processing by not using `/register`. If you have linked an AniList account, you can use `/unregister confirmation:Confirm unlink` in Discord to unlink your AniList account from Annie Mei's bot features. You may also revoke Annie Mei's access from AniList where supported.
+You can avoid optional AniList account processing by not using `/register`. If you have linked an AniList account, you can use `/unregister confirmation:Confirm unlink` in Discord to unlink your AniList account from Annie Mei's bot features and delete active stored AniList OAuth credentials associated with your Discord account. You may also revoke Annie Mei's access from AniList where supported.
 
-Unlinking in Discord may not remove every record held by the companion auth service, such as OAuth credential records or operational backups. To request deletion of any remaining stored Annie Mei account-link data, open an issue at:
+Unlinking in Discord may not remove retained operational logs, diagnostics, caches, or backups. To request deletion of any remaining stored Annie Mei account-link data, open an issue at:
 
 https://github.com/annie-mei/annie-mei/issues
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 
 | Component | Service |
 |-----------|---------|
-| Database | Neon (PostgreSQL) |
+| Database | Supabase (PostgreSQL) |
 | Cache | Upstash (Redis) |
 | Secrets | Doppler |
+
+## Legal
+
+- [Terms of Service](TERMS_OF_SERVICE.md)
+- [Privacy Policy](PRIVACY_POLICY.md)

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -25,7 +25,7 @@ You agree not to:
 
 ## Account linking
 
-AniList account linking is optional. If you link an AniList account, Annie Mei's auth service stores the information needed to maintain that link and perform authorized AniList requests. You may revoke Annie Mei's access from AniList where supported, and you may request deletion of stored link data as described in the Privacy Policy.
+AniList account linking is optional. If you link an AniList account, Annie Mei's auth service stores the information needed to maintain that link and perform authorized AniList requests. You may use `/unregister confirmation:Confirm unlink` in Discord to unlink your AniList account from Annie Mei's bot features, revoke Annie Mei's access from AniList where supported, and request deletion of remaining stored link data as described in the Privacy Policy.
 
 ## Third-party services and content
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,0 +1,58 @@
+# Annie Mei Terms of Service
+
+Effective date: 2026-04-27
+
+These Terms of Service govern your use of Annie Mei, a Discord bot that provides anime, manga, character, and theme song information and optional AniList account linking.
+
+By adding Annie Mei to a Discord server or using its commands, you agree to these terms.
+
+## Service description
+
+Annie Mei provides Discord slash commands for looking up information from third-party services including AniList, MyAnimeList, and Spotify. Annie Mei may also let you link an AniList account so the bot can show account-specific information, such as guild member scores, when you use supported commands.
+
+## Eligibility
+
+You must comply with Discord's Terms of Service and Community Guidelines when using Annie Mei. If you use AniList, MyAnimeList, Spotify, or other third-party services through Annie Mei, you are also responsible for complying with those services' terms.
+
+## Acceptable use
+
+You agree not to:
+
+- Use Annie Mei for harassment, abuse, spam, or other activity that violates Discord rules or applicable law.
+- Attempt to exploit, disrupt, overload, reverse engineer, or gain unauthorized access to Annie Mei or its infrastructure.
+- Use Annie Mei to scrape, mirror, or bulk collect third-party data in a way that violates third-party terms or rate limits.
+- Misrepresent Annie Mei as being endorsed by Discord, AniList, MyAnimeList, Spotify, or any other third party.
+
+## Account linking
+
+AniList account linking is optional. If you link an AniList account, Annie Mei's auth service stores the information needed to maintain that link and perform authorized AniList requests. You may revoke Annie Mei's access from AniList where supported, and you may request deletion of stored link data as described in the Privacy Policy.
+
+## Third-party services and content
+
+Annie Mei depends on third-party APIs and content. Search results, titles, images, links, scores, and music metadata may come from AniList, MyAnimeList, Spotify, Discord, or other third parties. Annie Mei does not control those services and is not responsible for their availability, accuracy, content, or policies.
+
+## Availability and changes
+
+Annie Mei is provided on a best-effort basis. The service may be unavailable, rate limited, changed, or discontinued at any time. Features may be added, modified, or removed without notice.
+
+## Disclaimer
+
+Annie Mei is provided "as is" and "as available," without warranties of any kind. To the maximum extent permitted by law, the maintainers disclaim all warranties, including implied warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+## Limitation of liability
+
+To the maximum extent permitted by law, Annie Mei's maintainers will not be liable for indirect, incidental, special, consequential, exemplary, or punitive damages, or for loss of data, profits, goodwill, or service availability arising from your use of Annie Mei.
+
+## Termination
+
+The maintainers may block access to Annie Mei, remove the bot from servers, or disable features for any user or server that violates these terms, creates operational risk, or harms other users or services.
+
+## Changes to these terms
+
+These terms may be updated from time to time. Continued use of Annie Mei after changes are published means you accept the updated terms.
+
+## Contact
+
+For questions, support, or data requests, open an issue at:
+
+https://github.com/annie-mei/annie-mei/issues

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -25,7 +25,7 @@ You agree not to:
 
 ## Account linking
 
-AniList account linking is optional. If you link an AniList account, Annie Mei's auth service stores the information needed to maintain that link and perform authorized AniList requests. You may use `/unregister confirmation:Confirm unlink` in Discord to unlink your AniList account from Annie Mei's bot features, revoke Annie Mei's access from AniList where supported, and request deletion of remaining stored link data as described in the Privacy Policy.
+AniList account linking is optional. If you link an AniList account, Annie Mei's auth service stores the information needed to maintain that link and perform authorized AniList requests. You may use `/unregister confirmation:Confirm unlink` in Discord to unlink your AniList account from Annie Mei's bot features and delete active stored AniList OAuth credentials associated with your Discord account. You may also revoke Annie Mei's access from AniList where supported and request deletion of remaining stored link data as described in the Privacy Policy.
 
 ## Third-party services and content
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -56,3 +56,5 @@ These terms may be updated from time to time. Continued use of Annie Mei after c
 For questions, support, or data requests, open an issue at:
 
 https://github.com/annie-mei/annie-mei/issues
+
+Do not include your numeric Discord ID, OAuth tokens, secrets, or other sensitive information in a public issue. Ask for private support when a request requires account-specific verification.


### PR DESCRIPTION
## Summary

Add public Terms of Service and Privacy Policy documents for Annie Mei's Discord application verification requirements.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore

## Changes

- 93b9d7e98ca03eaebfe8b4b205cb42bb78daa6d7: add Terms of Service and Privacy Policy documents, link them from the README, and update the documented database provider to Supabase.

### Notes

- The Privacy Policy covers the sibling auth service's AniList OAuth data handling, including OAuth credentials, temporary sessions, and diagnostic fingerprinting.

## Validation

- [x] Reviewed generated Markdown documents locally.
- [x] Verified branch status with `git status --short --branch`.

---

This PR description was written by OpenAI GPT-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
