### PR TITLE
[ANNIE-153]/add unregister command to unlink AniList account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.12.0"
+version = "2.13.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 | `/help` | Shows available commands |
 | `/ping` | Bot health check |
 | `/register` | Start or refresh the secure AniList OAuth linking flow |
-| `/unregister` | Unlink your AniList account |
+| `/unregister confirmation:<confirm\|cancel>` | Unlink your AniList account after confirmation |
 | `/whoami` | Show your linked AniList username and profile link |
 | `/anime <search>` | Look up anime by name or AniList ID |
 | `/manga <search>` | Look up manga by name or AniList ID |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 - Fetch detailed anime/manga/character information from AniList
 - Look up opening and ending theme songs with Spotify links
 - Link your AniList account with a secure OAuth flow to show guild members' scores
-- Check your currently linked AniList account
+- Check or unlink your currently linked AniList account
 - Full Japanese kana support for searches
 
 ## Commands
@@ -23,6 +23,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 | `/help` | Shows available commands |
 | `/ping` | Bot health check |
 | `/register` | Start or refresh the secure AniList OAuth linking flow |
+| `/unregister` | Unlink your AniList account |
 | `/whoami` | Show your linked AniList username and profile link |
 | `/anime <search>` | Look up anime by name or AniList ID |
 | `/manga <search>` | Look up manga by name or AniList ID |

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -28,17 +28,17 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
         )
         .field(
             "Get started",
-            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime`, `/manga`, or `/character` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it, or `/unregister` to unlink it",
+            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime`, `/manga`, or `/character` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it, or `/unregister confirmation:Confirm unlink` to unlink it",
             false,
         )
         .field(
             "Commands",
-            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/character search:<term or id> spoilers:<allow|disallow>` - character details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/unregister` - unlink your AniList account\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
+            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/character search:<term or id> spoilers:<allow|disallow>` - character details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/unregister confirmation:<confirm|cancel>` - unlink your AniList account after confirmation\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
             false,
         )
         .field(
             "Tips",
-            "You can search with full names, short names, or AniList IDs. If the AniList link page expires or fails, or if you need to reconnect your AniList account later, run `/register` again to get a fresh secure link. Use `/unregister` when you want Annie Mei to forget your linked AniList account.",
+            "You can search with full names, short names, or AniList IDs. If the AniList link page expires or fails, or if you need to reconnect your AniList account later, run `/register` again to get a fresh secure link. Use `/unregister confirmation:Confirm unlink` when you want Annie Mei to forget your linked AniList account.",
             false,
         )
         .footer(CreateEmbedFooter::new("Annie Mei"))

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -28,17 +28,17 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
         )
         .field(
             "Get started",
-            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime`, `/manga`, or `/character` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it",
+            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime`, `/manga`, or `/character` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it, or `/unregister` to unlink it",
             false,
         )
         .field(
             "Commands",
-            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/character search:<term or id> spoilers:<allow|disallow>` - character details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
+            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/character search:<term or id> spoilers:<allow|disallow>` - character details\n`/songs search:<term or id>` - OP/ED songs + links\n`/register` - open the AniList OAuth link or relink flow\n`/unregister` - unlink your AniList account\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
             false,
         )
         .field(
             "Tips",
-            "You can search with full names, short names, or AniList IDs. If the AniList link page expires or fails, or if you need to reconnect your AniList account later, run `/register` again to get a fresh secure link.",
+            "You can search with full names, short names, or AniList IDs. If the AniList link page expires or fails, or if you need to reconnect your AniList account later, run `/register` again to get a fresh secure link. Use `/unregister` when you want Annie Mei to forget your linked AniList account.",
             false,
         )
         .footer(CreateEmbedFooter::new("Annie Mei"))

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod register;
 pub mod response;
 pub mod songs;
 pub mod traits;
+pub mod unregister;
 pub mod whoami;

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -8,22 +8,56 @@ use crate::{
 };
 
 use serenity::{
-    all::{CommandInteraction, EditInteractionResponse},
+    all::{
+        CommandDataOption, CommandDataOptionValue, CommandInteraction, CreateCommandOption,
+        EditInteractionResponse,
+    },
     builder::CreateCommand,
     client::Context,
+    model::application::CommandOptionType,
 };
 use tokio::task;
 use tracing::{error, instrument};
+
+const CONFIRMATION_OPTION: &str = "confirmation";
+const CONFIRM_UNREGISTER: &str = "confirm";
+const CANCEL_UNREGISTER: &str = "cancel";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnregisterOutcome {
     Unlinked { username: String },
     NotLinked,
+    Cancelled,
     Failed,
 }
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("unregister").description("Unlink your AniList account from Annie Mei")
+    CreateCommand::new("unregister")
+        .description("Unlink your AniList account from Annie Mei")
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::String,
+                CONFIRMATION_OPTION,
+                "Confirm whether to unlink your AniList account",
+            )
+            .add_string_choice("Confirm unlink", CONFIRM_UNREGISTER)
+            .add_string_choice("Cancel", CANCEL_UNREGISTER)
+            .required(true),
+        )
+}
+
+fn parse_unregister_confirmation(options: &[CommandDataOption]) -> Option<bool> {
+    options
+        .iter()
+        .find(|option| option.name == CONFIRMATION_OPTION)
+        .and_then(|option| match &option.value {
+            CommandDataOptionValue::String(value) => match value.as_str() {
+                CONFIRM_UNREGISTER => Some(true),
+                CANCEL_UNREGISTER => Some(false),
+                _ => None,
+            },
+            _ => None,
+        })
 }
 
 #[instrument(name = "command.unregister.handle")]
@@ -35,6 +69,9 @@ pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
         UnregisterOutcome::NotLinked => CommandResponse::Content(
             "You do not have a linked AniList account. Run `/register` if you want to link one."
                 .to_string(),
+        ),
+        UnregisterOutcome::Cancelled => CommandResponse::Content(
+            "Cancelled. Your AniList account link was not changed.".to_string(),
         ),
         UnregisterOutcome::Failed => CommandResponse::Content(
             "I hit an internal error while unlinking your AniList account. Please try again later."
@@ -58,6 +95,23 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let user = &interaction.user;
     configure_sentry_scope("Unregister", user.id.get(), None);
+
+    let Some(confirmed) = parse_unregister_confirmation(&interaction.data.options) else {
+        let builder = EditInteractionResponse::new()
+            .content("Missing or invalid `confirmation` option — choose `Confirm unlink` to unlink your AniList account.");
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    };
+
+    if !confirmed {
+        let builder = match handle_unregister(UnregisterOutcome::Cancelled) {
+            CommandResponse::Content(content) => EditInteractionResponse::new().content(content),
+            CommandResponse::Embed(embed) => EditInteractionResponse::new().embed(*embed),
+            CommandResponse::Message(content) => EditInteractionResponse::new().content(content),
+        };
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
 
     let Some(database_pool) = database::get_pool_from_context(ctx).await else {
         let builder = EditInteractionResponse::new()
@@ -136,5 +190,39 @@ mod tests {
         let content = response.unwrap_content();
         assert!(content.contains("internal error"));
         assert!(content.contains("try again later"));
+    }
+
+    #[test]
+    fn handle_unregister_cancelled_confirms_no_change() {
+        let response = handle_unregister(UnregisterOutcome::Cancelled);
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(content.contains("Cancelled"));
+        assert!(content.contains("not changed"));
+    }
+
+    #[test]
+    fn parses_confirmed_unregister_option() {
+        let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
+            "name": "confirmation",
+            "type": 3,
+            "value": "confirm"
+        }]))
+        .expect("options deserialize");
+
+        assert_eq!(parse_unregister_confirmation(&options), Some(true));
+    }
+
+    #[test]
+    fn parses_cancelled_unregister_option() {
+        let options: Vec<CommandDataOption> = serde_json::from_value(serde_json::json!([{
+            "name": "confirmation",
+            "type": 3,
+            "value": "cancel"
+        }]))
+        .expect("options deserialize");
+
+        assert_eq!(parse_unregister_confirmation(&options), Some(false));
     }
 }

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -15,9 +15,9 @@ use serenity::{
 use tokio::task;
 use tracing::{error, instrument};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnregisterOutcome {
-    Unlinked,
+    Unlinked { username: String },
     NotLinked,
     Failed,
 }
@@ -29,9 +29,9 @@ pub fn register() -> CreateCommand {
 #[instrument(name = "command.unregister.handle")]
 pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
     match outcome {
-        UnregisterOutcome::Unlinked => CommandResponse::Content(
-            "Your AniList account has been unlinked from Annie Mei.".to_string(),
-        ),
+        UnregisterOutcome::Unlinked { username } => CommandResponse::Content(format!(
+            "Your AniList account **{username}** has been unlinked from Annie Mei."
+        )),
         UnregisterOutcome::NotLinked => CommandResponse::Content(
             "You do not have a linked AniList account. Run `/register` if you want to link one."
                 .to_string(),
@@ -47,7 +47,7 @@ pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
 fn delete_user_registration(
     database_pool: crate::utils::database::DbPool,
     discord_id: i64,
-) -> Result<usize, diesel::result::Error> {
+) -> Result<Option<User>, diesel::result::Error> {
     let mut connection = database::get_connection(&database_pool);
     User::delete_user_by_discord_id(discord_id, &mut connection)
 }
@@ -71,8 +71,10 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         task::spawn_blocking(move || delete_user_registration(database_pool, discord_id)).await;
 
     let outcome = match db_result {
-        Ok(Ok(deleted_count)) if deleted_count > 0 => UnregisterOutcome::Unlinked,
-        Ok(Ok(_)) => UnregisterOutcome::NotLinked,
+        Ok(Ok(Some(deleted_user))) => UnregisterOutcome::Unlinked {
+            username: deleted_user.anilist_username,
+        },
+        Ok(Ok(None)) => UnregisterOutcome::NotLinked,
         Ok(Err(err)) => {
             error!(
                 error = %err,
@@ -106,11 +108,14 @@ mod tests {
 
     #[test]
     fn handle_unregister_with_linked_account_confirms_unlink() {
-        let response = handle_unregister(UnregisterOutcome::Unlinked);
+        let response = handle_unregister(UnregisterOutcome::Unlinked {
+            username: "annie".to_string(),
+        });
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
         assert!(content.contains("has been unlinked"));
+        assert!(content.contains("**annie**"));
     }
 
     #[test]

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -1,0 +1,135 @@
+use crate::{
+    commands::response::CommandResponse,
+    models::db::user::User,
+    utils::{
+        database,
+        privacy::{configure_sentry_scope, hash_user_id},
+    },
+};
+
+use serenity::{
+    all::{CommandInteraction, EditInteractionResponse},
+    builder::CreateCommand,
+    client::Context,
+};
+use tokio::task;
+use tracing::{error, instrument};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnregisterOutcome {
+    Unlinked,
+    NotLinked,
+    Failed,
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("unregister").description("Unlink your AniList account from Annie Mei")
+}
+
+#[instrument(name = "command.unregister.handle")]
+pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
+    match outcome {
+        UnregisterOutcome::Unlinked => CommandResponse::Content(
+            "Your AniList account has been unlinked from Annie Mei.".to_string(),
+        ),
+        UnregisterOutcome::NotLinked => CommandResponse::Content(
+            "You do not have a linked AniList account. Run `/register` if you want to link one."
+                .to_string(),
+        ),
+        UnregisterOutcome::Failed => CommandResponse::Content(
+            "I hit an internal error while unlinking your AniList account. Please try again later."
+                .to_string(),
+        ),
+    }
+}
+
+#[instrument(name = "unregister.delete_profile_blocking", skip(database_pool, discord_id), fields(discord_user_id = %hash_user_id(discord_id as u64)))]
+fn delete_unregistered_profile(
+    database_pool: crate::utils::database::DbPool,
+    discord_id: i64,
+) -> Result<usize, diesel::result::Error> {
+    let mut connection = database::get_connection(&database_pool);
+    User::delete_user_by_discord_id(discord_id, &mut connection)
+}
+
+#[instrument(name = "command.unregister.run", skip(ctx, interaction))]
+pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
+    let _ = interaction.defer_ephemeral(&ctx.http).await;
+
+    let user = &interaction.user;
+    configure_sentry_scope("Unregister", user.id.get(), None);
+
+    let Some(database_pool) = database::get_pool_from_context(ctx).await else {
+        let builder = EditInteractionResponse::new()
+            .content("Database is not initialized. Please try again later.");
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    };
+
+    let discord_id = user.id.get() as i64;
+    let db_result =
+        task::spawn_blocking(move || delete_unregistered_profile(database_pool, discord_id)).await;
+
+    let outcome = match db_result {
+        Ok(Ok(deleted_count)) if deleted_count > 0 => UnregisterOutcome::Unlinked,
+        Ok(Ok(_)) => UnregisterOutcome::NotLinked,
+        Ok(Err(err)) => {
+            error!(
+                error = %err,
+                discord_user_id = %hash_user_id(discord_id as u64),
+                "Failed to delete AniList profile link from database"
+            );
+            UnregisterOutcome::Failed
+        }
+        Err(err) => {
+            error!(
+                error = %err,
+                discord_user_id = %hash_user_id(discord_id as u64),
+                "Failed to join unregister database task"
+            );
+            UnregisterOutcome::Failed
+        }
+    };
+
+    let builder = match handle_unregister(outcome) {
+        CommandResponse::Content(content) => EditInteractionResponse::new().content(content),
+        CommandResponse::Embed(embed) => EditInteractionResponse::new().embed(*embed),
+        CommandResponse::Message(content) => EditInteractionResponse::new().content(content),
+    };
+
+    let _ = interaction.edit_response(&ctx.http, builder).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_unregister_with_linked_account_confirms_unlink() {
+        let response = handle_unregister(UnregisterOutcome::Unlinked);
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(content.contains("has been unlinked"));
+    }
+
+    #[test]
+    fn handle_unregister_without_linked_account_is_user_friendly() {
+        let response = handle_unregister(UnregisterOutcome::NotLinked);
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(content.contains("do not have a linked AniList account"));
+        assert!(content.contains("/register"));
+    }
+
+    #[test]
+    fn handle_unregister_failure_returns_retry_message() {
+        let response = handle_unregister(UnregisterOutcome::Failed);
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(content.contains("internal error"));
+        assert!(content.contains("try again later"));
+    }
+}

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -43,8 +43,8 @@ pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
     }
 }
 
-#[instrument(name = "unregister.delete_profile_blocking", skip(database_pool, discord_id), fields(discord_user_id = %hash_user_id(discord_id as u64)))]
-fn delete_unregistered_profile(
+#[instrument(name = "unregister.delete_user_registration_blocking", skip(database_pool, discord_id), fields(discord_user_id = %hash_user_id(discord_id as u64)))]
+fn delete_user_registration(
     database_pool: crate::utils::database::DbPool,
     discord_id: i64,
 ) -> Result<usize, diesel::result::Error> {
@@ -68,7 +68,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let discord_id = user.id.get() as i64;
     let db_result =
-        task::spawn_blocking(move || delete_unregistered_profile(database_pool, discord_id)).await;
+        task::spawn_blocking(move || delete_user_registration(database_pool, discord_id)).await;
 
     let outcome = match db_result {
         Ok(Ok(deleted_count)) if deleted_count > 0 => UnregisterOutcome::Unlinked,

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -46,6 +46,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
+#[instrument(name = "command.unregister.parse_confirmation", skip(options))]
 fn parse_unregister_confirmation(options: &[CommandDataOption]) -> Option<bool> {
     options
         .iter()
@@ -60,7 +61,7 @@ fn parse_unregister_confirmation(options: &[CommandDataOption]) -> Option<bool> 
         })
 }
 
-#[instrument(name = "command.unregister.handle")]
+#[instrument(name = "command.unregister.handle", skip(outcome))]
 pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
     match outcome {
         UnregisterOutcome::Unlinked { username } => CommandResponse::Content(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ impl EventHandler for Handler {
                     "anime" => commands::anime::command::run(&ctx, &mut command).await,
                     "character" => commands::character::command::run(&ctx, &mut command).await,
                     "register" => commands::register::command::run(&ctx, &command).await,
+                    "unregister" => commands::unregister::run(&ctx, &mut command).await,
                     "whoami" => commands::whoami::run(&ctx, &mut command).await,
                     _ => {
                         let embed = CreateEmbed::new()
@@ -101,6 +102,7 @@ impl EventHandler for Handler {
             commands::anime::command::register(),
             commands::character::command::register(),
             commands::register::command::register(),
+            commands::unregister::register(),
             commands::whoami::register(),
         ];
 

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -38,4 +38,14 @@ impl User {
             .load::<User>(conn)
             .ok()
     }
+
+    #[instrument(name = "db.user.delete_by_discord_id", skip(conn, user_discord_id), fields(discord_user_id = %hash_user_id(user_discord_id as u64)))]
+    pub fn delete_user_by_discord_id(
+        user_discord_id: i64,
+        conn: &mut PgConnection,
+    ) -> Result<usize, diesel::result::Error> {
+        use crate::schema::users::dsl::*;
+
+        diesel::delete(users.filter(discord_id.eq(user_discord_id))).execute(conn)
+    }
 }

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -46,17 +46,8 @@ impl User {
     ) -> Result<Option<User>, diesel::result::Error> {
         use crate::schema::users::dsl::*;
 
-        conn.transaction(|conn| {
-            let existing_user = users
-                .filter(discord_id.eq(user_discord_id))
-                .first::<User>(conn)
-                .optional()?;
-
-            if existing_user.is_some() {
-                diesel::delete(users.filter(discord_id.eq(user_discord_id))).execute(conn)?;
-            }
-
-            Ok(existing_user)
-        })
+        diesel::delete(users.filter(discord_id.eq(user_discord_id)))
+            .get_result::<User>(conn)
+            .optional()
     }
 }

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -43,9 +43,20 @@ impl User {
     pub fn delete_user_by_discord_id(
         user_discord_id: i64,
         conn: &mut PgConnection,
-    ) -> Result<usize, diesel::result::Error> {
+    ) -> Result<Option<User>, diesel::result::Error> {
         use crate::schema::users::dsl::*;
 
-        diesel::delete(users.filter(discord_id.eq(user_discord_id))).execute(conn)
+        conn.transaction(|conn| {
+            let existing_user = users
+                .filter(discord_id.eq(user_discord_id))
+                .first::<User>(conn)
+                .optional()?;
+
+            if existing_user.is_some() {
+                diesel::delete(users.filter(discord_id.eq(user_discord_id))).execute(conn)?;
+            }
+
+            Ok(existing_user)
+        })
     }
 }


### PR DESCRIPTION
## Summary

Adds a self-service `/unregister` command that lets users unlink their AniList account from Annie Mei.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore

## Changes
- 5a702bed9008309d1e422c518804ccedf7c54278: added the `/unregister` slash command, database unlink path, command registration/dispatch, user-facing help/README copy, tests, and a minor version bump.

## Validation
- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo clippy` (passes with pre-existing dead-code warnings in the LLM module/statics)

---

This PR description was written by GPT-5.5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
