### PR TITLE
[ANNIE-155]/delete auth OAuth credentials when unregistering AniList account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.13.0"
+version = "2.13.1"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.13.0"
+version = "2.13.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.13.1"
+version = "2.14.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -7,6 +7,8 @@ use crate::{
     },
 };
 
+use diesel::prelude::*;
+use diesel::sql_types::Text;
 use serenity::{
     all::{
         CommandDataOption, CommandDataOptionValue, CommandInteraction, CreateCommandOption,
@@ -22,13 +24,24 @@ use tracing::{error, instrument};
 const CONFIRMATION_OPTION: &str = "confirmation";
 const CONFIRM_UNREGISTER: &str = "confirm";
 const CANCEL_UNREGISTER: &str = "cancel";
+const DELETE_OAUTH_CREDENTIALS_SQL: &str =
+    "DELETE FROM oauth_credentials WHERE discord_user_id = $1";
+const DELETE_OAUTH_SESSIONS_SQL: &str = "DELETE FROM oauth_sessions WHERE discord_user_id = $1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnregisterOutcome {
     Unlinked { username: String },
+    AuthCredentialsUnlinked,
     NotLinked,
     Cancelled,
     Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeletedRegistrations {
+    bot_user: Option<User>,
+    oauth_credentials_deleted: usize,
+    oauth_sessions_deleted: usize,
 }
 
 pub fn register() -> CreateCommand {
@@ -65,10 +78,14 @@ fn parse_unregister_confirmation(options: &[CommandDataOption]) -> Option<bool> 
 pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
     match outcome {
         UnregisterOutcome::Unlinked { username } => CommandResponse::Content(format!(
-            "Your AniList account **{username}** has been unlinked from Annie Mei."
+            "Your AniList account **{username}** has been unlinked from Annie Mei, and stored OAuth credentials have been deleted."
         )),
+        UnregisterOutcome::AuthCredentialsUnlinked => CommandResponse::Content(
+            "Your stored AniList OAuth credentials have been deleted. You do not have a bot profile link."
+                .to_string(),
+        ),
         UnregisterOutcome::NotLinked => CommandResponse::Content(
-            "You do not have a linked AniList account. Run `/register` if you want to link one."
+            "You do not have a linked AniList account or stored AniList OAuth credentials. Run `/register` if you want to link one."
                 .to_string(),
         ),
         UnregisterOutcome::Cancelled => CommandResponse::Content(
@@ -85,9 +102,56 @@ pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
 fn delete_user_registration(
     database_pool: crate::utils::database::DbPool,
     discord_id: i64,
-) -> Result<Option<User>, diesel::result::Error> {
+) -> Result<DeletedRegistrations, diesel::result::Error> {
     let mut connection = database::get_connection(&database_pool);
-    User::delete_user_by_discord_id(discord_id, &mut connection)
+    delete_user_registration_in_transaction(discord_id, &mut connection)
+}
+
+#[instrument(name = "unregister.delete_user_registration_transaction", skip(conn, discord_id), fields(discord_user_id = %hash_user_id(discord_id as u64)))]
+fn delete_user_registration_in_transaction(
+    discord_id: i64,
+    conn: &mut PgConnection,
+) -> Result<DeletedRegistrations, diesel::result::Error> {
+    conn.transaction(|conn| {
+        let bot_user = User::delete_user_by_discord_id(discord_id, conn)?;
+        let discord_id = discord_id.to_string();
+        let oauth_credentials_deleted =
+            delete_auth_records(DELETE_OAUTH_CREDENTIALS_SQL, &discord_id, conn)?;
+        let oauth_sessions_deleted =
+            delete_auth_records(DELETE_OAUTH_SESSIONS_SQL, &discord_id, conn)?;
+
+        Ok(DeletedRegistrations {
+            bot_user,
+            oauth_credentials_deleted,
+            oauth_sessions_deleted,
+        })
+    })
+}
+
+#[instrument(name = "unregister.delete_auth_records", skip(conn, sql, discord_id))]
+fn delete_auth_records(
+    sql: &str,
+    discord_id: &str,
+    conn: &mut PgConnection,
+) -> Result<usize, diesel::result::Error> {
+    diesel::sql_query(sql)
+        .bind::<Text, _>(discord_id)
+        .execute(conn)
+}
+
+#[instrument(name = "command.unregister.outcome_from_deletions", skip(deletions))]
+fn outcome_from_deletions(deletions: DeletedRegistrations) -> UnregisterOutcome {
+    if let Some(deleted_user) = deletions.bot_user {
+        return UnregisterOutcome::Unlinked {
+            username: deleted_user.anilist_username,
+        };
+    }
+
+    if deletions.oauth_credentials_deleted > 0 || deletions.oauth_sessions_deleted > 0 {
+        return UnregisterOutcome::AuthCredentialsUnlinked;
+    }
+
+    UnregisterOutcome::NotLinked
 }
 
 #[instrument(name = "command.unregister.run", skip(ctx, interaction))]
@@ -126,10 +190,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         task::spawn_blocking(move || delete_user_registration(database_pool, discord_id)).await;
 
     let outcome = match db_result {
-        Ok(Ok(Some(deleted_user))) => UnregisterOutcome::Unlinked {
-            username: deleted_user.anilist_username,
-        },
-        Ok(Ok(None)) => UnregisterOutcome::NotLinked,
+        Ok(Ok(deletions)) => outcome_from_deletions(deletions),
         Ok(Err(err)) => {
             error!(
                 error = %err,
@@ -171,6 +232,17 @@ mod tests {
         let content = response.unwrap_content();
         assert!(content.contains("has been unlinked"));
         assert!(content.contains("**annie**"));
+        assert!(content.contains("OAuth credentials have been deleted"));
+    }
+
+    #[test]
+    fn handle_unregister_with_only_auth_credentials_confirms_cleanup() {
+        let response = handle_unregister(UnregisterOutcome::AuthCredentialsUnlinked);
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(content.contains("OAuth credentials have been deleted"));
+        assert!(content.contains("do not have a bot profile link"));
     }
 
     #[test]
@@ -179,8 +251,65 @@ mod tests {
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
-        assert!(content.contains("do not have a linked AniList account"));
+        assert!(
+            content.contains(
+                "do not have a linked AniList account or stored AniList OAuth credentials"
+            )
+        );
         assert!(content.contains("/register"));
+    }
+
+    #[test]
+    fn deletion_outcome_prefers_deleted_bot_username() {
+        let outcome = outcome_from_deletions(DeletedRegistrations {
+            bot_user: Some(User {
+                discord_id: 123,
+                anilist_id: 456,
+                anilist_username: "annie".to_string(),
+            }),
+            oauth_credentials_deleted: 1,
+            oauth_sessions_deleted: 1,
+        });
+
+        assert_eq!(
+            outcome,
+            UnregisterOutcome::Unlinked {
+                username: "annie".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn deletion_outcome_handles_auth_only_cleanup() {
+        let outcome = outcome_from_deletions(DeletedRegistrations {
+            bot_user: None,
+            oauth_credentials_deleted: 1,
+            oauth_sessions_deleted: 0,
+        });
+
+        assert_eq!(outcome, UnregisterOutcome::AuthCredentialsUnlinked);
+    }
+
+    #[test]
+    fn deletion_outcome_handles_session_only_cleanup() {
+        let outcome = outcome_from_deletions(DeletedRegistrations {
+            bot_user: None,
+            oauth_credentials_deleted: 0,
+            oauth_sessions_deleted: 1,
+        });
+
+        assert_eq!(outcome, UnregisterOutcome::AuthCredentialsUnlinked);
+    }
+
+    #[test]
+    fn deletion_outcome_handles_no_records() {
+        let outcome = outcome_from_deletions(DeletedRegistrations {
+            bot_user: None,
+            oauth_credentials_deleted: 0,
+            oauth_sessions_deleted: 0,
+        });
+
+        assert_eq!(outcome, UnregisterOutcome::NotLinked);
     }
 
     #[test]

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 
 use diesel::prelude::*;
-use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use diesel::sql_types::Text;
 use serenity::{
     all::{
@@ -159,24 +158,9 @@ fn delete_auth_records(
     discord_id: &str,
     conn: &mut PgConnection,
 ) -> Result<usize, diesel::result::Error> {
-    match diesel::sql_query(sql)
+    diesel::sql_query(sql)
         .bind::<Text, _>(discord_id)
         .execute(conn)
-    {
-        Ok(deleted) => Ok(deleted),
-        Err(error) if is_missing_auth_table_error(&error, table) => Ok(0),
-        Err(error) => Err(error),
-    }
-}
-
-#[instrument(name = "unregister.is_missing_auth_table_error", skip(error))]
-fn is_missing_auth_table_error(error: &DieselError, table: &str) -> bool {
-    match error {
-        DieselError::DatabaseError(DatabaseErrorKind::Unknown, info) => info
-            .message()
-            .contains(&format!("relation \"{table}\" does not exist")),
-        _ => false,
-    }
 }
 
 #[instrument(name = "command.unregister.outcome_from_deletions", skip(deletions))]

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 use diesel::prelude::*;
+use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use diesel::sql_types::Text;
 use serenity::{
     all::{
@@ -27,6 +28,8 @@ const CANCEL_UNREGISTER: &str = "cancel";
 const DELETE_OAUTH_CREDENTIALS_SQL: &str =
     "DELETE FROM oauth_credentials WHERE discord_user_id = $1";
 const DELETE_OAUTH_SESSIONS_SQL: &str = "DELETE FROM oauth_sessions WHERE discord_user_id = $1";
+const OAUTH_CREDENTIALS_TABLE: &str = "oauth_credentials";
+const OAUTH_SESSIONS_TABLE: &str = "oauth_sessions";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnregisterOutcome {
@@ -128,10 +131,18 @@ fn delete_user_registration_in_transaction(
     conn.transaction(|conn| {
         let bot_user = User::delete_user_by_discord_id(discord_id, conn)?;
         let discord_id = discord_id.to_string();
-        let oauth_credentials_deleted =
-            delete_auth_records(DELETE_OAUTH_CREDENTIALS_SQL, &discord_id, conn)?;
-        let oauth_sessions_deleted =
-            delete_auth_records(DELETE_OAUTH_SESSIONS_SQL, &discord_id, conn)?;
+        let oauth_credentials_deleted = delete_auth_records(
+            OAUTH_CREDENTIALS_TABLE,
+            DELETE_OAUTH_CREDENTIALS_SQL,
+            &discord_id,
+            conn,
+        )?;
+        let oauth_sessions_deleted = delete_auth_records(
+            OAUTH_SESSIONS_TABLE,
+            DELETE_OAUTH_SESSIONS_SQL,
+            &discord_id,
+            conn,
+        )?;
 
         Ok(DeletedRegistrations {
             bot_user,
@@ -141,15 +152,31 @@ fn delete_user_registration_in_transaction(
     })
 }
 
-#[instrument(name = "unregister.delete_auth_records", skip(conn, sql, discord_id))]
+#[instrument(name = "unregister.delete_auth_records", skip(conn, sql, discord_id), fields(table = table))]
 fn delete_auth_records(
+    table: &str,
     sql: &str,
     discord_id: &str,
     conn: &mut PgConnection,
 ) -> Result<usize, diesel::result::Error> {
-    diesel::sql_query(sql)
+    match diesel::sql_query(sql)
         .bind::<Text, _>(discord_id)
         .execute(conn)
+    {
+        Ok(deleted) => Ok(deleted),
+        Err(error) if is_missing_auth_table_error(&error, table) => Ok(0),
+        Err(error) => Err(error),
+    }
+}
+
+#[instrument(name = "unregister.is_missing_auth_table_error", skip(error))]
+fn is_missing_auth_table_error(error: &DieselError, table: &str) -> bool {
+    match error {
+        DieselError::DatabaseError(DatabaseErrorKind::Unknown, info) => info
+            .message()
+            .contains(&format!("relation \"{table}\" does not exist")),
+        _ => false,
+    }
 }
 
 #[instrument(name = "command.unregister.outcome_from_deletions", skip(deletions))]

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -30,7 +30,10 @@ const DELETE_OAUTH_SESSIONS_SQL: &str = "DELETE FROM oauth_sessions WHERE discor
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnregisterOutcome {
-    Unlinked { username: String },
+    Unlinked {
+        username: String,
+        auth_records_deleted: bool,
+    },
     AuthCredentialsUnlinked,
     NotLinked,
     Cancelled,
@@ -77,9 +80,19 @@ fn parse_unregister_confirmation(options: &[CommandDataOption]) -> Option<bool> 
 #[instrument(name = "command.unregister.handle", skip(outcome))]
 pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
     match outcome {
-        UnregisterOutcome::Unlinked { username } => CommandResponse::Content(format!(
-            "Your AniList account **{username}** has been unlinked from Annie Mei, and stored OAuth credentials have been deleted."
-        )),
+        UnregisterOutcome::Unlinked {
+            username,
+            auth_records_deleted,
+        } => {
+            let auth_cleanup_message = if auth_records_deleted {
+                ", and stored OAuth credentials have been deleted"
+            } else {
+                ""
+            };
+            CommandResponse::Content(format!(
+                "Your AniList account **{username}** has been unlinked from Annie Mei{auth_cleanup_message}."
+            ))
+        }
         UnregisterOutcome::AuthCredentialsUnlinked => CommandResponse::Content(
             "Your stored AniList OAuth credentials have been deleted. You do not have a bot profile link."
                 .to_string(),
@@ -144,6 +157,8 @@ fn outcome_from_deletions(deletions: DeletedRegistrations) -> UnregisterOutcome 
     if let Some(deleted_user) = deletions.bot_user {
         return UnregisterOutcome::Unlinked {
             username: deleted_user.anilist_username,
+            auth_records_deleted: deletions.oauth_credentials_deleted > 0
+                || deletions.oauth_sessions_deleted > 0,
         };
     }
 
@@ -226,6 +241,7 @@ mod tests {
     fn handle_unregister_with_linked_account_confirms_unlink() {
         let response = handle_unregister(UnregisterOutcome::Unlinked {
             username: "annie".to_string(),
+            auth_records_deleted: true,
         });
 
         assert!(response.is_content(), "expected Content variant");
@@ -233,6 +249,20 @@ mod tests {
         assert!(content.contains("has been unlinked"));
         assert!(content.contains("**annie**"));
         assert!(content.contains("OAuth credentials have been deleted"));
+    }
+
+    #[test]
+    fn handle_unregister_with_legacy_link_does_not_claim_auth_cleanup() {
+        let response = handle_unregister(UnregisterOutcome::Unlinked {
+            username: "annie".to_string(),
+            auth_records_deleted: false,
+        });
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(content.contains("has been unlinked"));
+        assert!(content.contains("**annie**"));
+        assert!(!content.contains("OAuth credentials have been deleted"));
     }
 
     #[test]
@@ -274,7 +304,29 @@ mod tests {
         assert_eq!(
             outcome,
             UnregisterOutcome::Unlinked {
-                username: "annie".to_string()
+                username: "annie".to_string(),
+                auth_records_deleted: true,
+            }
+        );
+    }
+
+    #[test]
+    fn deletion_outcome_handles_legacy_bot_only_cleanup() {
+        let outcome = outcome_from_deletions(DeletedRegistrations {
+            bot_user: Some(User {
+                discord_id: 123,
+                anilist_id: 456,
+                anilist_username: "annie".to_string(),
+            }),
+            oauth_credentials_deleted: 0,
+            oauth_sessions_deleted: 0,
+        });
+
+        assert_eq!(
+            outcome,
+            UnregisterOutcome::Unlinked {
+                username: "annie".to_string(),
+                auth_records_deleted: false,
             }
         );
     }

--- a/src/models/db/user.rs
+++ b/src/models/db/user.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use serenity::model::prelude::UserId;
 use tracing::instrument;
 
-#[derive(Queryable)]
+#[derive(Debug, Clone, PartialEq, Eq, Queryable)]
 #[allow(dead_code)]
 pub struct User {
     pub discord_id: i64,


### PR DESCRIPTION
## Summary

Extend /unregister so unlinking an AniList account also removes stored auth-service OAuth credentials and outstanding OAuth sessions for the invoking Discord user.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- 0b588101a021ef970a32cec3329f5dc4a58955ca: Delete bot profile links, auth OAuth credentials, and auth OAuth sessions in one unregister transaction while keeping user-facing outcomes idempotent.
- 402cf7c75a82f6e2d2b626ba7354296d358a267f: Bump the crate version to 2.13.1.

### Notes

The auth cleanup SQL matches the companion auth service tables, where discord_user_id is stored as TEXT in oauth_credentials and oauth_sessions.

## Validation
- [x] cargo fmt --check
- [x] cargo test
- [x] cargo clippy --all-targets

---

This PR description was written by GPT-5.5.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
