### PR TITLE
[ANNIE-154]/add graceful register fallback for linked AniList accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.15.0"
+version = "2.16.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.15.0"
+version = "2.16.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -48,7 +48,7 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
     }
 }
 
-#[instrument(name = "command.register.handle_already_linked")]
+#[instrument(name = "command.register.handle_already_linked", skip(anilist_id))]
 fn handle_already_linked(anilist_id: i64) -> RegisterResponse {
     RegisterResponse {
         content: format!(

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -214,6 +214,38 @@ mod tests {
     }
 
     #[test]
+    fn already_linked_user_does_not_receive_oauth_link() {
+        let response = handle_already_linked(4567);
+
+        assert_eq!(response.oauth_url, None);
+        assert!(response.content.contains("already linked"));
+        assert!(response.content.contains("**4567**"));
+        assert!(response.content.contains("https://anilist.co/user/4567/"));
+        assert!(response.content.contains("/unregister"));
+        assert!(response.content.contains("/register"));
+    }
+
+    #[test]
+    fn unregistered_user_still_receives_oauth_link() {
+        let response = handle_register("https://auth.example.com/oauth/anilist/start?ctx=abc", 300);
+
+        assert_eq!(
+            response.oauth_url,
+            Some("https://auth.example.com/oauth/anilist/start?ctx=abc".to_string())
+        );
+        assert!(response.content.contains("link your AniList account"));
+    }
+
+    #[test]
+    fn lookup_failure_returns_retry_message_without_oauth_link() {
+        let response = handle_lookup_error();
+
+        assert_eq!(response.oauth_url, None);
+        assert!(response.content.contains("couldn't check"));
+        assert!(response.content.contains("try `/register` again"));
+    }
+
+    #[test]
     fn register_missing_config_returns_user_facing_message() {
         let response =
             handle_register_error(&OAuthContextError::MissingEnv("AUTH_SERVICE_BASE_URL"));

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -1,16 +1,19 @@
-use crate::utils::{
-    oauth::{OAuthContextError, build_oauth_start_url, get_config_from_context},
-    privacy::{configure_sentry_scope, hash_user_id},
+use crate::{
+    models::db::oauth_credential::OAuthCredential,
+    utils::{
+        database,
+        oauth::{OAuthContextError, build_oauth_start_url, get_config_from_context},
+        privacy::{configure_sentry_scope, hash_user_id},
+    },
 };
 
 use serenity::{
-    all::{
-        CommandInteraction, CreateButton, CreateInteractionResponse,
-        CreateInteractionResponseMessage,
-    },
+    all::{CommandInteraction, CreateButton, EditInteractionResponse},
     builder::CreateCommand,
     client::Context,
+    model::prelude::UserId,
 };
+use tokio::task;
 use tracing::{error, info, instrument};
 
 pub fn register() -> CreateCommand {
@@ -45,6 +48,24 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
     }
 }
 
+#[instrument(name = "command.register.handle_already_linked")]
+fn handle_already_linked(anilist_id: i64) -> RegisterResponse {
+    RegisterResponse {
+        content: format!(
+            "You're already linked to AniList account ID **{anilist_id}**.\nProfile: <https://anilist.co/user/{anilist_id}/>\nIf you want to link a different AniList account, run `/unregister confirmation:Confirm unlink` first, then run `/register` again."
+        ),
+        oauth_url: None,
+    }
+}
+
+#[instrument(name = "command.register.handle_lookup_error")]
+fn handle_lookup_error() -> RegisterResponse {
+    RegisterResponse {
+        content: "I couldn't check your existing AniList link right now. Please try `/register` again in a moment.".to_string(),
+        oauth_url: None,
+    }
+}
+
 #[instrument(name = "command.register.handle_error", skip(err))]
 fn handle_register_error(err: &OAuthContextError) -> RegisterResponse {
     let content = match err {
@@ -62,63 +83,103 @@ fn handle_register_error(err: &OAuthContextError) -> RegisterResponse {
     }
 }
 
-#[instrument(name = "command.register.run", skip(ctx, interaction))]
-pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
-    let user = &interaction.user;
-    configure_sentry_scope("Register", user.id.get(), None);
+#[instrument(name = "register.fetch_existing_link_blocking", skip(database_pool, discord_id), fields(discord_user_id = %hash_user_id(discord_id.get())))]
+fn fetch_existing_link(
+    database_pool: crate::utils::database::DbPool,
+    discord_id: UserId,
+) -> Result<Option<OAuthCredential>, diesel::result::Error> {
+    let mut connection = database::get_connection(&database_pool);
+    OAuthCredential::get_by_discord_id(discord_id, &mut connection)
+}
 
-    let response = match get_config_from_context(ctx).await {
-        Some(config) => {
-            let guild_id = interaction.guild_id.map(|id| id.to_string());
-            match build_oauth_start_url(
-                &user.id.get().to_string(),
-                guild_id.as_deref(),
-                &interaction.id.to_string(),
-                &config,
-            ) {
-                Ok(oauth_url) => {
-                    info!(
-                        discord_user_id = %hash_user_id(user.id.get()),
-                        has_guild_id = interaction.guild_id.is_some(),
-                        ttl_seconds = config.ttl_seconds,
-                        "Generated OAuth register link"
-                    );
-                    handle_register(oauth_url.as_ref(), config.ttl_seconds)
-                }
-                Err(err) => {
-                    error!(
-                        error = %err,
-                        discord_user_id = %hash_user_id(user.id.get()),
-                        "Failed to build OAuth start URL"
-                    );
-                    handle_register_error(&err)
+#[instrument(name = "command.register.run", skip(ctx, interaction))]
+pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
+    let _ = interaction.defer_ephemeral(&ctx.http).await;
+
+    let discord_id = interaction.user.id;
+    configure_sentry_scope("Register", discord_id.get(), None);
+
+    let Some(database_pool) = database::get_pool_from_context(ctx).await else {
+        error!(
+            discord_user_id = %hash_user_id(discord_id.get()),
+            "Database pool not found while checking existing AniList link"
+        );
+        let response = handle_lookup_error();
+        let builder = EditInteractionResponse::new().content(response.content);
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    };
+
+    let linked_account =
+        task::spawn_blocking(move || fetch_existing_link(database_pool, discord_id)).await;
+
+    let response = match linked_account {
+        Ok(Ok(Some(existing_link))) => handle_already_linked(existing_link.anilist_id),
+        Ok(Ok(None)) => match get_config_from_context(ctx).await {
+            Some(config) => {
+                let guild_id = interaction.guild_id.map(|id| id.to_string());
+                match build_oauth_start_url(
+                    &discord_id.get().to_string(),
+                    guild_id.as_deref(),
+                    &interaction.id.to_string(),
+                    &config,
+                ) {
+                    Ok(oauth_url) => {
+                        info!(
+                            discord_user_id = %hash_user_id(discord_id.get()),
+                            has_guild_id = interaction.guild_id.is_some(),
+                            ttl_seconds = config.ttl_seconds,
+                            "Generated OAuth register link"
+                        );
+                        handle_register(oauth_url.as_ref(), config.ttl_seconds)
+                    }
+                    Err(err) => {
+                        error!(
+                            error = %err,
+                            discord_user_id = %hash_user_id(discord_id.get()),
+                            "Failed to build OAuth start URL"
+                        );
+                        handle_register_error(&err)
+                    }
                 }
             }
-        }
-        None => {
+            None => {
+                error!(
+                    discord_user_id = %hash_user_id(discord_id.get()),
+                    "OAuth configuration not found in context"
+                );
+                handle_register_error(&OAuthContextError::MissingEnv("OAuth config not available"))
+            }
+        },
+        Ok(Err(err)) => {
             error!(
-                discord_user_id = %hash_user_id(user.id.get()),
-                "OAuth configuration not found in context"
+                error = %err,
+                discord_user_id = %hash_user_id(discord_id.get()),
+                "Failed to fetch existing AniList link from database"
             );
-            handle_register_error(&OAuthContextError::MissingEnv("OAuth config not available"))
+            handle_lookup_error()
+        }
+        Err(err) => {
+            error!(
+                error = %err,
+                discord_user_id = %hash_user_id(discord_id.get()),
+                "Failed to join register database task"
+            );
+            handle_lookup_error()
         }
     };
 
-    let mut message = CreateInteractionResponseMessage::new()
-        .ephemeral(true)
-        .content(response.content);
+    let mut builder = EditInteractionResponse::new().content(response.content);
 
     if let Some(url) = response.oauth_url {
-        message = message.button(CreateButton::new_link(url).label("Link AniList Account"));
+        builder = builder.button(CreateButton::new_link(url).label("Link AniList Account"));
     }
 
-    let response = CreateInteractionResponse::Message(message);
-
-    if let Err(err) = interaction.create_response(&ctx.http, response).await {
+    if let Err(err) = interaction.edit_response(&ctx.http, builder).await {
         error!(
             error = %err,
-            discord_user_id = %hash_user_id(user.id.get()),
-            "Failed to create register interaction response"
+            discord_user_id = %hash_user_id(discord_id.get()),
+            "Failed to edit register interaction response"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ impl EventHandler for Handler {
                     "manga" => commands::manga::command::run(&ctx, &mut command).await,
                     "anime" => commands::anime::command::run(&ctx, &mut command).await,
                     "character" => commands::character::command::run(&ctx, &mut command).await,
-                    "register" => commands::register::command::run(&ctx, &command).await,
+                    "register" => commands::register::command::run(&ctx, &mut command).await,
                     "unregister" => commands::unregister::run(&ctx, &mut command).await,
                     "whoami" => commands::whoami::run(&ctx, &mut command).await,
                     _ => {


### PR DESCRIPTION
## Summary

Adds a graceful `/register` fallback for Discord users who already have a linked AniList account, avoiding generation of a fresh OAuth link when the existing link is present.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- f70ca1b2ca74bef22786f73ca30d1ca12852c914: check for an existing AniList OAuth credential before building a new registration URL, defer the interaction ephemerally, and return already-linked or lookup-failure guidance as appropriate
- fec9226cb34e359564ceb356b3119ee88bf52cd0: add register handler tests covering already-linked, unregistered, and lookup-failure responses
- 767286c9fba0b1c91c66a07ae3733de43373d7f1: bump the application version to 2.16.0 and update Cargo.lock

### Notes

The already-linked response includes the linked AniList ID/profile URL and points users to `/unregister confirmation:Confirm unlink` before registering a different AniList account.

## Validation
- [x] cargo fmt
- [x] cargo check
- [x] cargo test register
- [x] cargo test
- [x] cargo clippy
- [x] cargo clippy --all-targets --all-features -- -D warnings (blocked by existing unrelated dead-code warnings in `src/utils/llm` and `src/utils/statics`)

---

This PR description was written by OpenAI ChatGPT.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->