### PR TITLE
[ANNIE-159]/display linked AniList username

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.16.4"
+version = "2.17.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.16.4"
+version = "2.17.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.94"

--- a/docs/oauth-contract.md
+++ b/docs/oauth-contract.md
@@ -51,6 +51,7 @@ Source of truth for **linked** AniList accounts.
 | --------------------- | --------------- | --------------------------------------------------------------------------------- |
 | `discord_user_id`     | `TEXT` (PK)     | Raw Discord snowflake **as a string** (`user.id.get().to_string()`).              |
 | `anilist_id`          | `BIGINT`        | AniList user ID. Unique across the table.                                         |
+| `anilist_username`    | `TEXT NULL`     | Public AniList username captured from the OAuth viewer response for friendly linked-account displays. |
 | `access_token`        | `TEXT`          | AniList OAuth access token.                                                       |
 | `refresh_token`       | `TEXT NULL`     | AniList OAuth refresh token, when issued.                                         |
 | `token_expires_at`    | `TIMESTAMPTZ NULL` | Token expiry, when AniList provides one.                                          |
@@ -63,6 +64,14 @@ Source of truth for **linked** AniList accounts.
 provides `get_by_discord_id` (used by `/whoami`) and
 `get_by_discord_ids` (used by the per-guild MediaList overlay in
 `crate::utils::guild`). The bot does **not** write to this table.
+
+`anilist_username` is nullable so existing linked users can keep working
+after the auth-service migration. It is populated by the auth-service on
+the next successful OAuth callback/relink. Existing rows can be
+backfilled by querying AniList for each stored `anilist_id` and updating
+`anilist_username`, or users can run `/register` again after
+`/unregister` to relink. Until then, bot displays fall back to the
+numeric `anilist_id`.
 
 **Bot deletes:** `/unregister` deletes by `discord_user_id` in the
 same transaction as `oauth_sessions`. See
@@ -130,12 +139,15 @@ When making one of those changes:
 
 `oauth_credentials.discord_user_id` and `oauth_sessions.discord_user_id`
 intentionally store the raw Discord snowflake so that `/register`,
-`/whoami`, and `/unregister` can all match on the same value. **Logs,
-spans, and Sentry telemetry must not include the raw snowflake.** Use
-`crate::utils::privacy::hash_user_id` (bot) or
-`utils::observability::identifier_fingerprint` (auth-service) to emit
-a salted hash instead. Both helpers use the shared `USERID_HASH_SALT`
-environment variable so fingerprints correlate across repos.
+`/whoami`, and `/unregister` can all match on the same value. The
+`oauth_credentials.anilist_id` and `oauth_credentials.anilist_username`
+fields are also user-identifying account-linkage data. **Logs, spans,
+metrics labels, breadcrumbs, and Sentry telemetry must not include any
+of those raw identifiers.** Use `crate::utils::privacy::hash_user_id`
+(bot) or `utils::observability::identifier_fingerprint` (auth-service)
+to emit a salted hash when a stable correlation key is needed. Both
+helpers use the shared `USERID_HASH_SALT` environment variable so
+fingerprints correlate across repos.
 
 The `ctx` query parameter on `/oauth/anilist/start` is base64url-encoded
 JSON plus a signature, not encrypted data. It contains raw
@@ -149,10 +161,10 @@ service.
 `oauth_credentials.access_token` and `oauth_credentials.refresh_token`
 are bearer credentials that grant full access to the linked AniList
 account. The bot's current `OAuthCredential` model intentionally only
-selects `discord_user_id` and `anilist_id`, but if a future change
-expands the projection to read either token column, **the values must
-never appear in logs, spans, breadcrumbs, error payloads, Sentry
-events, or any other observability sink — not in plain text and not
-as a fingerprint.** Move the secrets behind a wrapper type whose
+selects `discord_user_id`, `anilist_id`, and `anilist_username`, but if
+a future change expands the projection to read either token column,
+**the values must never appear in logs, spans, breadcrumbs, error
+payloads, Sentry events, or any other observability sink — not in plain
+text and not as a fingerprint.** Move the secrets behind a wrapper type whose
 `Debug`/`Display` impls do not expose them, and never include
 `Authorization: Bearer …` headers in logged HTTP requests.

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -48,23 +48,13 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
     }
 }
 
-#[instrument(
-    name = "command.register.handle_already_linked",
-    skip(anilist_id, anilist_username)
-)]
-fn handle_already_linked(anilist_id: i64, anilist_username: Option<&str>) -> RegisterResponse {
-    let display_name = anilist_username.map_or_else(
-        || format!("AniList account ID {anilist_id}"),
-        ToOwned::to_owned,
-    );
-    let profile_url = anilist_username.map_or_else(
-        || format!("https://anilist.co/user/{anilist_id}/"),
-        |username| format!("https://anilist.co/user/{username}/"),
-    );
-
+#[instrument(name = "command.register.handle_already_linked", skip(credential))]
+fn handle_already_linked(credential: &OAuthCredential) -> RegisterResponse {
     RegisterResponse {
         content: format!(
-            "You're already linked to AniList account **{display_name}**.\nProfile: <{profile_url}>\nIf you want to link a different AniList account, run `/unregister confirmation:Confirm unlink` first, then run `/register` again."
+            "You're already linked to AniList account **{}**.\nProfile: <{}>\nIf you want to link a different AniList account, run `/unregister confirmation:Confirm unlink` first, then run `/register` again.",
+            credential.anilist_display_name(),
+            credential.anilist_profile_url(),
         ),
         oauth_url: None,
     }
@@ -126,10 +116,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         task::spawn_blocking(move || fetch_existing_link(database_pool, discord_id)).await;
 
     let response = match linked_account {
-        Ok(Ok(Some(existing_link))) => handle_already_linked(
-            existing_link.anilist_id,
-            existing_link.anilist_username.as_deref(),
-        ),
+        Ok(Ok(Some(existing_link))) => handle_already_linked(&existing_link),
         Ok(Ok(None)) => match get_config_from_context(ctx).await {
             Some(config) => {
                 let guild_id = interaction.guild_id.map(|id| id.to_string());
@@ -205,6 +192,14 @@ mod tests {
 
     use crate::utils::oauth::OAuthContextError;
 
+    fn oauth_credential(anilist_username: Option<&str>) -> OAuthCredential {
+        OAuthCredential {
+            discord_user_id: "123456789".to_string(),
+            anilist_id: 4567,
+            anilist_username: anilist_username.map(str::to_owned),
+        }
+    }
+
     #[test]
     fn register_happy_path_returns_oauth_link() {
         let response = handle_register("https://auth.example.com/oauth/anilist/start?ctx=abc", 300);
@@ -230,7 +225,8 @@ mod tests {
 
     #[test]
     fn already_linked_user_does_not_receive_oauth_link() {
-        let response = handle_already_linked(4567, Some("AniUser"));
+        let credential = oauth_credential(Some("AniUser"));
+        let response = handle_already_linked(&credential);
 
         assert_eq!(response.oauth_url, None);
         assert!(response.content.contains("already linked"));
@@ -246,7 +242,8 @@ mod tests {
 
     #[test]
     fn already_linked_user_without_username_falls_back_to_anilist_id() {
-        let response = handle_already_linked(4567, None);
+        let credential = oauth_credential(None);
+        let response = handle_already_linked(&credential);
 
         assert_eq!(response.oauth_url, None);
         assert!(response.content.contains("**AniList account ID 4567**"));

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -53,12 +53,14 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
     skip(anilist_id, anilist_username)
 )]
 fn handle_already_linked(anilist_id: i64, anilist_username: Option<&str>) -> RegisterResponse {
-    let display_name = anilist_username
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| format!("AniList account ID {anilist_id}"));
-    let profile_url = anilist_username
-        .map(|username| format!("https://anilist.co/user/{username}/"))
-        .unwrap_or_else(|| format!("https://anilist.co/user/{anilist_id}/"));
+    let display_name = anilist_username.map_or_else(
+        || format!("AniList account ID {anilist_id}"),
+        ToOwned::to_owned,
+    );
+    let profile_url = anilist_username.map_or_else(
+        || format!("https://anilist.co/user/{anilist_id}/"),
+        |username| format!("https://anilist.co/user/{username}/"),
+    );
 
     RegisterResponse {
         content: format!(

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -48,11 +48,21 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
     }
 }
 
-#[instrument(name = "command.register.handle_already_linked", skip(anilist_id))]
-fn handle_already_linked(anilist_id: i64) -> RegisterResponse {
+#[instrument(
+    name = "command.register.handle_already_linked",
+    skip(anilist_id, anilist_username)
+)]
+fn handle_already_linked(anilist_id: i64, anilist_username: Option<&str>) -> RegisterResponse {
+    let display_name = anilist_username
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("AniList account ID {anilist_id}"));
+    let profile_url = anilist_username
+        .map(|username| format!("https://anilist.co/user/{username}/"))
+        .unwrap_or_else(|| format!("https://anilist.co/user/{anilist_id}/"));
+
     RegisterResponse {
         content: format!(
-            "You're already linked to AniList account ID **{anilist_id}**.\nProfile: <https://anilist.co/user/{anilist_id}/>\nIf you want to link a different AniList account, run `/unregister confirmation:Confirm unlink` first, then run `/register` again."
+            "You're already linked to AniList account **{display_name}**.\nProfile: <{profile_url}>\nIf you want to link a different AniList account, run `/unregister confirmation:Confirm unlink` first, then run `/register` again."
         ),
         oauth_url: None,
     }
@@ -114,7 +124,10 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         task::spawn_blocking(move || fetch_existing_link(database_pool, discord_id)).await;
 
     let response = match linked_account {
-        Ok(Ok(Some(existing_link))) => handle_already_linked(existing_link.anilist_id),
+        Ok(Ok(Some(existing_link))) => handle_already_linked(
+            existing_link.anilist_id,
+            existing_link.anilist_username.as_deref(),
+        ),
         Ok(Ok(None)) => match get_config_from_context(ctx).await {
             Some(config) => {
                 let guild_id = interaction.guild_id.map(|id| id.to_string());
@@ -215,14 +228,27 @@ mod tests {
 
     #[test]
     fn already_linked_user_does_not_receive_oauth_link() {
-        let response = handle_already_linked(4567);
+        let response = handle_already_linked(4567, Some("AniUser"));
 
         assert_eq!(response.oauth_url, None);
         assert!(response.content.contains("already linked"));
-        assert!(response.content.contains("**4567**"));
-        assert!(response.content.contains("https://anilist.co/user/4567/"));
+        assert!(response.content.contains("**AniUser**"));
+        assert!(
+            response
+                .content
+                .contains("https://anilist.co/user/AniUser/")
+        );
         assert!(response.content.contains("/unregister"));
         assert!(response.content.contains("/register"));
+    }
+
+    #[test]
+    fn already_linked_user_without_username_falls_back_to_anilist_id() {
+        let response = handle_already_linked(4567, None);
+
+        assert_eq!(response.oauth_url, None);
+        assert!(response.content.contains("**AniList account ID 4567**"));
+        assert!(response.content.contains("https://anilist.co/user/4567/"));
     }
 
     #[test]

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -44,9 +44,10 @@ impl LinkedAniListProfile {
     }
 
     fn display_name(&self) -> String {
-        self.anilist_username
-            .clone()
-            .unwrap_or_else(|| format!("AniList account ID {}", self.anilist_id))
+        self.anilist_username.as_deref().map_or_else(
+            || format!("AniList account ID {}", self.anilist_id),
+            str::to_owned,
+        )
     }
 }
 

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -13,55 +13,20 @@ use serenity::{
     client::Context,
     model::prelude::UserId,
 };
-use std::fmt;
 use tokio::task;
 use tracing::{error, instrument};
-
-#[derive(Clone, PartialEq, Eq)]
-pub struct LinkedAniListProfile {
-    pub anilist_id: i64,
-    pub anilist_username: Option<String>,
-}
-
-impl fmt::Debug for LinkedAniListProfile {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LinkedAniListProfile")
-            .field("anilist_id", &"[REDACTED]")
-            .field(
-                "anilist_username",
-                &self.anilist_username.as_ref().map(|_| "[REDACTED]"),
-            )
-            .finish()
-    }
-}
-
-impl LinkedAniListProfile {
-    fn profile_url(&self) -> String {
-        match self.anilist_username.as_deref() {
-            Some(username) => format!("https://anilist.co/user/{username}/"),
-            None => format!("https://anilist.co/user/{}/", self.anilist_id),
-        }
-    }
-
-    fn display_name(&self) -> String {
-        self.anilist_username.as_deref().map_or_else(
-            || format!("AniList account ID {}", self.anilist_id),
-            str::to_owned,
-        )
-    }
-}
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("whoami").description("Show your currently linked AniList account")
 }
 
 #[instrument(name = "command.whoami.handle", skip(profile))]
-pub fn handle_whoami(profile: Option<LinkedAniListProfile>) -> CommandResponse {
+pub fn handle_whoami(profile: Option<OAuthCredential>) -> CommandResponse {
     match profile {
         Some(profile) => CommandResponse::Content(format!(
             "Your linked AniList account is **{}**.\nProfile: <{}>",
-            profile.display_name(),
-            profile.profile_url()
+            profile.anilist_display_name(),
+            profile.anilist_profile_url()
         )),
         None => CommandResponse::Content(
             "You have not linked an AniList account yet. Run `/register` first.".to_string(),
@@ -102,10 +67,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         task::spawn_blocking(move || fetch_whoami_profile(database_pool, discord_id)).await;
 
     let response = match db_result {
-        Ok(Ok(profile)) => handle_whoami(profile.map(|entry| LinkedAniListProfile {
-            anilist_id: entry.anilist_id,
-            anilist_username: entry.anilist_username,
-        })),
+        Ok(Ok(profile)) => handle_whoami(profile),
         Ok(Err(err)) => {
             error!(
                 error = %err,
@@ -143,12 +105,17 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 mod tests {
     use super::*;
 
+    fn oauth_credential(anilist_username: Option<&str>) -> OAuthCredential {
+        OAuthCredential {
+            discord_user_id: "123456789".to_string(),
+            anilist_id: 4567,
+            anilist_username: anilist_username.map(str::to_owned),
+        }
+    }
+
     #[test]
     fn handle_whoami_with_linked_profile_returns_anilist_username_and_url() {
-        let response = handle_whoami(Some(LinkedAniListProfile {
-            anilist_id: 4567,
-            anilist_username: Some("AniUser".to_string()),
-        }));
+        let response = handle_whoami(Some(oauth_credential(Some("AniUser"))));
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
@@ -164,10 +131,7 @@ mod tests {
 
     #[test]
     fn handle_whoami_without_username_falls_back_to_anilist_id() {
-        let response = handle_whoami(Some(LinkedAniListProfile {
-            anilist_id: 4567,
-            anilist_username: None,
-        }));
+        let response = handle_whoami(Some(oauth_credential(None)));
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
@@ -191,19 +155,5 @@ mod tests {
             content.contains("/register"),
             "expected /register guidance for unlinked users"
         );
-    }
-
-    #[test]
-    fn linked_anilist_profile_debug_redacts_identifiers() {
-        let profile = LinkedAniListProfile {
-            anilist_id: 4567,
-            anilist_username: Some("AniUser".to_string()),
-        };
-
-        let debug = format!("{profile:?}");
-
-        assert!(debug.contains("[REDACTED]"));
-        assert!(!debug.contains("4567"));
-        assert!(!debug.contains("AniUser"));
     }
 }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -19,11 +19,21 @@ use tracing::{error, instrument};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkedAniListProfile {
     pub anilist_id: i64,
+    pub anilist_username: Option<String>,
 }
 
 impl LinkedAniListProfile {
     fn profile_url(&self) -> String {
-        format!("https://anilist.co/user/{}/", self.anilist_id)
+        match self.anilist_username.as_deref() {
+            Some(username) => format!("https://anilist.co/user/{username}/"),
+            None => format!("https://anilist.co/user/{}/", self.anilist_id),
+        }
+    }
+
+    fn display_name(&self) -> String {
+        self.anilist_username
+            .clone()
+            .unwrap_or_else(|| format!("AniList account ID {}", self.anilist_id))
     }
 }
 
@@ -35,8 +45,8 @@ pub fn register() -> CreateCommand {
 pub fn handle_whoami(profile: Option<LinkedAniListProfile>) -> CommandResponse {
     match profile {
         Some(profile) => CommandResponse::Content(format!(
-            "Your linked AniList account ID is **{}**.\nProfile: <{}>",
-            profile.anilist_id,
+            "Your linked AniList account is **{}**.\nProfile: <{}>",
+            profile.display_name(),
             profile.profile_url()
         )),
         None => CommandResponse::Content(
@@ -80,6 +90,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let response = match db_result {
         Ok(Ok(profile)) => handle_whoami(profile.map(|entry| LinkedAniListProfile {
             anilist_id: entry.anilist_id,
+            anilist_username: entry.anilist_username,
         })),
         Ok(Err(err)) => {
             error!(
@@ -119,18 +130,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn handle_whoami_with_linked_profile_returns_anilist_id_and_url() {
-        let response = handle_whoami(Some(LinkedAniListProfile { anilist_id: 4567 }));
+    fn handle_whoami_with_linked_profile_returns_anilist_username_and_url() {
+        let response = handle_whoami(Some(LinkedAniListProfile {
+            anilist_id: 4567,
+            anilist_username: Some("AniUser".to_string()),
+        }));
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
         assert!(
-            content.contains("**4567**"),
-            "expected AniList ID in response"
+            content.contains("**AniUser**"),
+            "expected AniList username in response"
+        );
+        assert!(
+            content.contains("https://anilist.co/user/AniUser/"),
+            "expected AniList profile URL in response"
+        );
+    }
+
+    #[test]
+    fn handle_whoami_without_username_falls_back_to_anilist_id() {
+        let response = handle_whoami(Some(LinkedAniListProfile {
+            anilist_id: 4567,
+            anilist_username: None,
+        }));
+
+        assert!(response.is_content(), "expected Content variant");
+        let content = response.unwrap_content();
+        assert!(
+            content.contains("**AniList account ID 4567**"),
+            "expected AniList ID fallback in response"
         );
         assert!(
             content.contains("https://anilist.co/user/4567/"),
-            "expected AniList profile URL in response"
+            "expected numeric AniList profile URL fallback in response"
         );
     }
 

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -13,13 +13,26 @@ use serenity::{
     client::Context,
     model::prelude::UserId,
 };
+use std::fmt;
 use tokio::task;
 use tracing::{error, instrument};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct LinkedAniListProfile {
     pub anilist_id: i64,
     pub anilist_username: Option<String>,
+}
+
+impl fmt::Debug for LinkedAniListProfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinkedAniListProfile")
+            .field("anilist_id", &"[REDACTED]")
+            .field(
+                "anilist_username",
+                &self.anilist_username.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 impl LinkedAniListProfile {
@@ -177,5 +190,19 @@ mod tests {
             content.contains("/register"),
             "expected /register guidance for unlinked users"
         );
+    }
+
+    #[test]
+    fn linked_anilist_profile_debug_redacts_identifiers() {
+        let profile = LinkedAniListProfile {
+            anilist_id: 4567,
+            anilist_username: Some("AniUser".to_string()),
+        };
+
+        let debug = format!("{profile:?}");
+
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("4567"));
+        assert!(!debug.contains("AniUser"));
     }
 }

--- a/src/models/db/oauth_credential.rs
+++ b/src/models/db/oauth_credential.rs
@@ -12,27 +12,43 @@
 //! `docs/oauth-contract.md`.
 //!
 //! `oauth_credentials.discord_user_id` is `TEXT` and contains the raw Discord
-//! snowflake string (`user.id.get().to_string()`); `anilist_id` is `BIGINT`.
+//! snowflake string (`user.id.get().to_string()`); `anilist_id` is `BIGINT` and
+//! `anilist_username` is nullable `TEXT`.
 
 use crate::utils::privacy::hash_user_id;
 use diesel::prelude::*;
-use diesel::sql_types::{BigInt, Text};
+use diesel::sql_types::{BigInt, Nullable, Text};
 use serenity::model::prelude::UserId;
+use std::fmt;
 use tracing::instrument;
 
-const SELECT_OAUTH_CREDENTIAL_BY_DISCORD_ID_SQL: &str =
-    "SELECT discord_user_id, anilist_id FROM oauth_credentials WHERE discord_user_id = $1";
+const SELECT_OAUTH_CREDENTIAL_BY_DISCORD_ID_SQL: &str = "SELECT discord_user_id, anilist_id, anilist_username FROM oauth_credentials WHERE discord_user_id = $1";
 
-const SELECT_OAUTH_CREDENTIALS_BY_DISCORD_IDS_SQL: &str = "SELECT discord_user_id, anilist_id FROM oauth_credentials \
+const SELECT_OAUTH_CREDENTIALS_BY_DISCORD_IDS_SQL: &str = "SELECT discord_user_id, anilist_id, anilist_username FROM oauth_credentials \
      WHERE discord_user_id = ANY($1)";
 
-#[derive(Debug, Clone, PartialEq, Eq, QueryableByName)]
+#[derive(Clone, PartialEq, Eq, QueryableByName)]
 pub struct OAuthCredential {
     /// Raw Discord snowflake stored as TEXT in the auth-service schema.
     #[diesel(sql_type = Text)]
     pub discord_user_id: String,
     #[diesel(sql_type = BigInt)]
     pub anilist_id: i64,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub anilist_username: Option<String>,
+}
+
+impl fmt::Debug for OAuthCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OAuthCredential")
+            .field("discord_user_id", &"[REDACTED]")
+            .field("anilist_id", &"[REDACTED]")
+            .field(
+                "anilist_username",
+                &self.anilist_username.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 impl OAuthCredential {
@@ -98,6 +114,7 @@ mod tests {
         let credential = OAuthCredential {
             discord_user_id: "987654321".to_string(),
             anilist_id: 1,
+            anilist_username: Some("AniUser".to_string()),
         };
         assert_eq!(credential.discord_id_u64(), Some(987654321));
     }
@@ -110,6 +127,7 @@ mod tests {
         let credential = OAuthCredential {
             discord_user_id: u64::MAX.to_string(),
             anilist_id: 1,
+            anilist_username: None,
         };
         assert_eq!(credential.discord_id_u64(), Some(u64::MAX));
     }
@@ -119,7 +137,24 @@ mod tests {
         let credential = OAuthCredential {
             discord_user_id: "not-a-number".to_string(),
             anilist_id: 1,
+            anilist_username: None,
         };
         assert_eq!(credential.discord_id_u64(), None);
+    }
+
+    #[test]
+    fn debug_redacts_identifiers() {
+        let credential = OAuthCredential {
+            discord_user_id: "987654321".to_string(),
+            anilist_id: 4567,
+            anilist_username: Some("AniUser".to_string()),
+        };
+
+        let debug = format!("{credential:?}");
+
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("987654321"));
+        assert!(!debug.contains("4567"));
+        assert!(!debug.contains("AniUser"));
     }
 }

--- a/src/models/db/oauth_credential.rs
+++ b/src/models/db/oauth_credential.rs
@@ -52,6 +52,28 @@ impl fmt::Debug for OAuthCredential {
 }
 
 impl OAuthCredential {
+    /// Display label for the linked AniList account.
+    ///
+    /// Prefers the AniList username populated by the auth service, while
+    /// preserving the numeric ID fallback for older rows that do not have one.
+    pub fn anilist_display_name(&self) -> String {
+        self.anilist_username.as_deref().map_or_else(
+            || format!("AniList account ID {}", self.anilist_id),
+            str::to_owned,
+        )
+    }
+
+    /// Public AniList profile URL for the linked account.
+    ///
+    /// Uses the username URL when available and falls back to the numeric
+    /// profile URL for existing credential rows without `anilist_username`.
+    pub fn anilist_profile_url(&self) -> String {
+        match self.anilist_username.as_deref() {
+            Some(username) => format!("https://anilist.co/user/{username}/"),
+            None => format!("https://anilist.co/user/{}/", self.anilist_id),
+        }
+    }
+
     /// Look up an OAuth credential row for the given Discord snowflake.
     ///
     /// Returns `Ok(None)` when no row exists for the user. Takes the
@@ -108,6 +130,36 @@ impl OAuthCredential {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn oauth_credential(anilist_username: Option<&str>) -> OAuthCredential {
+        OAuthCredential {
+            discord_user_id: "987654321".to_string(),
+            anilist_id: 4567,
+            anilist_username: anilist_username.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn anilist_display_fields_use_username_when_available() {
+        let credential = oauth_credential(Some("AniUser"));
+
+        assert_eq!(credential.anilist_display_name(), "AniUser");
+        assert_eq!(
+            credential.anilist_profile_url(),
+            "https://anilist.co/user/AniUser/"
+        );
+    }
+
+    #[test]
+    fn anilist_display_fields_fall_back_to_id_without_username() {
+        let credential = oauth_credential(None);
+
+        assert_eq!(credential.anilist_display_name(), "AniList account ID 4567");
+        assert_eq!(
+            credential.anilist_profile_url(),
+            "https://anilist.co/user/4567/"
+        );
+    }
 
     #[test]
     fn discord_id_u64_parses_valid_snowflake() {

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -198,10 +198,12 @@ mod tests {
             OAuthCredential {
                 discord_user_id: "1".to_string(),
                 anilist_id: 100,
+                anilist_username: Some("UserOne".to_string()),
             },
             OAuthCredential {
                 discord_user_id: "2".to_string(),
                 anilist_id: 200,
+                anilist_username: Some("UserTwo".to_string()),
             },
         ];
 


### PR DESCRIPTION
## Summary

Display the linked AniList username in Discord linked-account UX when the auth-owned OAuth credentials row has one, while preserving numeric ID fallback for existing rows.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore

## Changes
- 71be83dbafca54e3c8f705a4ffa4376c8027bec3: read nullable anilist_username from oauth_credentials, show username/profile URL in /whoami and already-linked /register copy with numeric fallback, redact OAuthCredential identifiers from Debug, update OAuth contract docs, and bump bot to 2.17.0

### Notes

The bot remains read-only for oauth_credentials. Existing rows without anilist_username still display the AniList ID and numeric profile URL until the auth-service migration/backfill/relink path populates the username.

## Validation

- [x] cargo fmt --check
- [x] cargo check (passes with existing unrelated dead-code warnings in src/utils/llm)
- [x] cargo test handle_whoami
- [x] cargo test already_linked_user
- [x] cargo test debug_redacts_identifiers
- [x] cargo clippy --all-targets --all-features -- -D warnings currently fails on existing unrelated dead-code warnings in the LLM module/statics

## References

- Companion auth-service PR owns the oauth_credentials schema migration and callback write path.

---

This PR description was written by Amp.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->