### PR TITLE
[ANNIE-162]/rename health check secret

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -222,5 +222,5 @@ jobs:
           EOF
       - name: Verify /healthz over Cloudflare
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-delay 5 "https://${{ secrets.CF_HEALTHZ_HOSTNAME }}/healthz" > healthz.json
+          curl --fail --silent --show-error --retry 6 --retry-delay 5 "https://${{ secrets.AUTH_HEALTHZ_HOSTNAME }}/healthz" > healthz.json
           python3 -c 'import json; from pathlib import Path; payload = json.loads(Path("healthz.json").read_text()); assert payload.get("status") == "healthy", f"Unexpected health payload: {payload}"; print("Cloudflare health check passed")'


### PR DESCRIPTION
## Summary

Rename the release workflow health check hostname secret to reflect that health checks now use the auth service endpoint rather than a Cloudflare tunnel hostname.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- a2ac6ca8c6b548be2b2f8315c71868e29036555c: update the release workflow health check to read `AUTH_HEALTHZ_HOSTNAME` instead of the legacy Cloudflare-specific secret name.

## Validation
- [x] Parsed `.github/workflows/build-release.yml` with Ruby YAML loader
- [x] Set `AUTH_HEALTHZ_HOSTNAME` repository secret to the current auth health hostname

---

This PR description was written by GPT-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->