### PR TITLE
[ANNIE-182]/validate search inputs consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.19.0"
+version = "2.19.1"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.19.0"
+version = "2.19.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     commands::{
+        input_validation::validate_search_term,
         response::CommandResponse,
         traits::{AniListSource, MediaDataSource},
     },
@@ -82,6 +83,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         return;
     };
     let search_term = search_term.clone();
+
+    if let Err(err) = validate_search_term(&search_term) {
+        let builder = EditInteractionResponse::new().content(format!(
+            "Invalid search input: {err}. Please check your input and try again."
+        ));
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
 
     configure_sentry_scope("Anime", user.id.get(), Some(json!(search_term.clone())));
 

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -1,5 +1,6 @@
 use crate::{
     commands::{
+        input_validation::validate_search_term,
         response::CommandResponse,
         traits::{AniListSource, CharacterDataSource},
     },
@@ -100,6 +101,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
+
+    if let Err(err) = validate_search_term(&search_term) {
+        let builder = EditInteractionResponse::new().content(format!(
+            "Invalid search input: {err}. Please check your input and try again."
+        ));
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
 
     configure_sentry_scope("Character", user.id.get(), Some(json!(search_term.clone())));
 

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     commands::{
+        input_validation::validate_search_term,
         response::CommandResponse,
         traits::{AniListSource, MediaDataSource},
     },
@@ -82,6 +83,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         return;
     };
     let search_term = search_term.clone();
+
+    if let Err(err) = validate_search_term(&search_term) {
+        let builder = EditInteractionResponse::new().content(format!(
+            "Invalid search input: {err}. Please check your input and try again."
+        ));
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
 
     configure_sentry_scope("Manga", user.id.get(), Some(json!(search_term.clone())));
 

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::{
     commands::{
-        input_validation::validate_search_term,
+        input_validation::{ValidationError, validate_search_term},
         response::CommandResponse,
         traits::{AniListSource, MediaDataSource},
     },
@@ -31,6 +31,7 @@ use serenity::{
 use tracing::{info, instrument, warn};
 
 const NOT_FOUND_SEARCH: &str = "I couldn't find an anime or manga for that search.";
+const MAX_LLM_SEARCH_TERM_LENGTH: usize = 120;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchMediaType {
@@ -108,9 +109,9 @@ impl SearchIntent {
     #[instrument(name = "command.search.intent_terms", skip(self))]
     fn search_terms(&self) -> Vec<String> {
         let mut terms = Vec::with_capacity(self.candidates.len() + 1);
-        push_unique_search_term(&mut terms, self.search.clone());
+        let _ = push_unique_search_term(&mut terms, self.search.clone());
         for candidate in &self.candidates {
-            push_unique_search_term(&mut terms, candidate.clone());
+            let _ = push_unique_search_term(&mut terms, candidate.clone());
         }
         terms
     }
@@ -417,14 +418,15 @@ fn validate_raw_intent(raw: RawSearchIntent) -> Result<SearchIntent, SearchInten
     };
 
     let mut search_terms = Vec::with_capacity(raw.candidates.len() + 1);
-    push_unique_search_term(&mut search_terms, normalize_search_phrase(&raw.search));
+    let primary_search_error =
+        push_unique_search_term(&mut search_terms, normalize_search_phrase(&raw.search)).err();
     for candidate in raw.candidates.into_iter().take(5) {
-        push_unique_search_term(&mut search_terms, normalize_search_phrase(&candidate));
+        let _ = push_unique_search_term(&mut search_terms, normalize_search_phrase(&candidate));
     }
 
     if search_terms.is_empty() {
         return Err(SearchIntentError::InvalidIntent(
-            "search cannot be empty".to_string(),
+            primary_search_error.unwrap_or_else(|| "search cannot be empty".to_string()),
         ));
     }
 
@@ -438,20 +440,41 @@ fn validate_raw_intent(raw: RawSearchIntent) -> Result<SearchIntent, SearchInten
 }
 
 #[instrument(name = "command.search.push_unique_term", skip(terms, term))]
-fn push_unique_search_term(terms: &mut Vec<String>, term: String) {
+fn push_unique_search_term(terms: &mut Vec<String>, term: String) -> Result<(), String> {
     let trimmed = term.trim();
-    if validate_search_term(trimmed).is_err() {
-        return;
-    }
+    validate_llm_search_term(trimmed)?;
 
     if terms
         .iter()
         .any(|existing| existing.eq_ignore_ascii_case(trimmed))
     {
-        return;
+        return Ok(());
     }
 
     terms.push(trimmed.to_string());
+    Ok(())
+}
+
+#[instrument(name = "command.search.validate_llm_term", skip(term))]
+fn validate_llm_search_term(term: &str) -> Result<(), String> {
+    match validate_search_term(term) {
+        Ok(()) => {}
+        Err(ValidationError::Empty) => return Err("search cannot be empty".to_string()),
+        Err(ValidationError::TooLong { max, actual }) => {
+            return Err(format!(
+                "search is too long ({actual} characters, max {max} allowed)"
+            ));
+        }
+    }
+
+    let actual = term.chars().count();
+    if actual > MAX_LLM_SEARCH_TERM_LENGTH {
+        return Err(format!(
+            "search is too long ({actual} characters, max {MAX_LLM_SEARCH_TERM_LENGTH} allowed)"
+        ));
+    }
+
+    Ok(())
 }
 
 #[instrument(name = "command.search.normalize_phrase", skip(search))]
@@ -608,8 +631,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_search_intent_json_rejects_overlong_search() {
-        let search = "a".repeat(256);
+    fn parse_search_intent_json_rejects_overlong_search_with_specific_error() {
+        let search = "a".repeat(MAX_LLM_SEARCH_TERM_LENGTH + 1);
         let response = serde_json::json!({
             "media_type": "anime",
             "search": search,
@@ -617,12 +640,18 @@ mod tests {
 
         let result = parse_search_intent_json(&response.to_string());
 
-        assert!(matches!(result, Err(SearchIntentError::InvalidIntent(_))));
+        match result {
+            Err(SearchIntentError::InvalidIntent(error)) => {
+                assert!(error.contains("search is too long"));
+                assert!(error.contains("max 120 allowed"));
+            }
+            other => panic!("expected overlong invalid intent, got {other:?}"),
+        }
     }
 
     #[test]
     fn parse_search_intent_json_skips_overlong_candidates() {
-        let candidate = "a".repeat(256);
+        let candidate = "a".repeat(MAX_LLM_SEARCH_TERM_LENGTH + 1);
         let response = serde_json::json!({
             "media_type": "anime",
             "search": "cowboy bebop",

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -455,6 +455,7 @@ fn push_llm_search_term(terms: &mut Vec<String>, term: String) -> Result<(), Str
     Ok(())
 }
 
+#[instrument(name = "command.search.push_unique_trimmed_term", skip(terms, trimmed))]
 fn push_unique_trimmed_search_term(terms: &mut Vec<String>, trimmed: &str) {
     if terms
         .iter()
@@ -480,6 +481,7 @@ fn validate_llm_search_term(term: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[instrument(name = "command.search.validation_error_message", skip(error))]
 fn search_validation_error_message(error: ValidationError) -> String {
     match error {
         ValidationError::Empty => "search cannot be empty".to_string(),

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -109,9 +109,9 @@ impl SearchIntent {
     #[instrument(name = "command.search.intent_terms", skip(self))]
     fn search_terms(&self) -> Vec<String> {
         let mut terms = Vec::with_capacity(self.candidates.len() + 1);
-        let _ = push_unique_search_term(&mut terms, self.search.clone());
+        let _ = push_valid_search_term(&mut terms, self.search.clone());
         for candidate in &self.candidates {
-            let _ = push_unique_search_term(&mut terms, candidate.clone());
+            let _ = push_valid_search_term(&mut terms, candidate.clone());
         }
         terms
     }
@@ -419,9 +419,9 @@ fn validate_raw_intent(raw: RawSearchIntent) -> Result<SearchIntent, SearchInten
 
     let mut search_terms = Vec::with_capacity(raw.candidates.len() + 1);
     let primary_search_error =
-        push_unique_search_term(&mut search_terms, normalize_search_phrase(&raw.search)).err();
+        push_llm_search_term(&mut search_terms, normalize_search_phrase(&raw.search)).err();
     for candidate in raw.candidates.into_iter().take(5) {
-        let _ = push_unique_search_term(&mut search_terms, normalize_search_phrase(&candidate));
+        let _ = push_llm_search_term(&mut search_terms, normalize_search_phrase(&candidate));
     }
 
     if search_terms.is_empty() {
@@ -439,33 +439,36 @@ fn validate_raw_intent(raw: RawSearchIntent) -> Result<SearchIntent, SearchInten
     })
 }
 
-#[instrument(name = "command.search.push_unique_term", skip(terms, term))]
-fn push_unique_search_term(terms: &mut Vec<String>, term: String) -> Result<(), String> {
+#[instrument(name = "command.search.push_valid_term", skip(terms, term))]
+fn push_valid_search_term(terms: &mut Vec<String>, term: String) -> Result<(), String> {
+    let trimmed = term.trim();
+    validate_search_term(trimmed).map_err(search_validation_error_message)?;
+    push_unique_trimmed_search_term(terms, trimmed);
+    Ok(())
+}
+
+#[instrument(name = "command.search.push_llm_term", skip(terms, term))]
+fn push_llm_search_term(terms: &mut Vec<String>, term: String) -> Result<(), String> {
     let trimmed = term.trim();
     validate_llm_search_term(trimmed)?;
+    push_unique_trimmed_search_term(terms, trimmed);
+    Ok(())
+}
 
+fn push_unique_trimmed_search_term(terms: &mut Vec<String>, trimmed: &str) {
     if terms
         .iter()
         .any(|existing| existing.eq_ignore_ascii_case(trimmed))
     {
-        return Ok(());
+        return;
     }
 
     terms.push(trimmed.to_string());
-    Ok(())
 }
 
 #[instrument(name = "command.search.validate_llm_term", skip(term))]
 fn validate_llm_search_term(term: &str) -> Result<(), String> {
-    match validate_search_term(term) {
-        Ok(()) => {}
-        Err(ValidationError::Empty) => return Err("search cannot be empty".to_string()),
-        Err(ValidationError::TooLong { max, actual }) => {
-            return Err(format!(
-                "search is too long ({actual} characters, max {max} allowed)"
-            ));
-        }
-    }
+    validate_search_term(term).map_err(search_validation_error_message)?;
 
     let actual = term.chars().count();
     if actual > MAX_LLM_SEARCH_TERM_LENGTH {
@@ -475,6 +478,15 @@ fn validate_llm_search_term(term: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn search_validation_error_message(error: ValidationError) -> String {
+    match error {
+        ValidationError::Empty => "search cannot be empty".to_string(),
+        ValidationError::TooLong { max, actual } => {
+            format!("search is too long ({actual} characters, max {max} allowed)")
+        }
+    }
 }
 
 #[instrument(name = "command.search.normalize_phrase", skip(search))]
@@ -736,6 +748,21 @@ mod tests {
 
         assert!(matches!(result, MediaSearchResult::NotFound));
         assert_eq!(source.calls(), vec!["anime:monster", "manga:monster"]);
+    }
+
+    #[tokio::test]
+    async fn fetch_search_result_accepts_long_valid_fallback_term() {
+        let source = FakeMediaSource::new();
+        let query = "a".repeat(MAX_LLM_SEARCH_TERM_LENGTH + 1);
+        let intent = fallback_intent(&query);
+
+        let result = fetch_search_result(&source, intent).await;
+
+        assert!(matches!(result, MediaSearchResult::NotFound));
+        assert_eq!(
+            source.calls(),
+            vec![format!("anime:{query}"), format!("manga:{query}")]
+        );
     }
 
     #[tokio::test]

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::{
     commands::{
+        input_validation::validate_search_term,
         response::CommandResponse,
         traits::{AniListSource, MediaDataSource},
     },
@@ -287,6 +288,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
     let query = query.clone();
 
+    if let Err(err) = validate_search_term(&query) {
+        let builder = EditInteractionResponse::new().content(format!(
+            "Invalid search input: {err}. Please check your input and try again."
+        ));
+        let _ = interaction.edit_response(&ctx.http, builder).await;
+        return;
+    }
+
     configure_sentry_scope("Search", user.id.get(), Some(json!(query.clone())));
 
     info!("Got command 'search'");
@@ -431,7 +440,7 @@ fn validate_raw_intent(raw: RawSearchIntent) -> Result<SearchIntent, SearchInten
 #[instrument(name = "command.search.push_unique_term", skip(terms, term))]
 fn push_unique_search_term(terms: &mut Vec<String>, term: String) {
     let trimmed = term.trim();
-    if trimmed.is_empty() || trimmed.chars().count() > 120 {
+    if validate_search_term(trimmed).is_err() {
         return;
     }
 
@@ -596,6 +605,34 @@ mod tests {
         let result = parse_search_intent_json(r#"{"media_type":"anime","search":"   "}"#);
 
         assert!(matches!(result, Err(SearchIntentError::InvalidIntent(_))));
+    }
+
+    #[test]
+    fn parse_search_intent_json_rejects_overlong_search() {
+        let search = "a".repeat(256);
+        let response = serde_json::json!({
+            "media_type": "anime",
+            "search": search,
+        });
+
+        let result = parse_search_intent_json(&response.to_string());
+
+        assert!(matches!(result, Err(SearchIntentError::InvalidIntent(_))));
+    }
+
+    #[test]
+    fn parse_search_intent_json_skips_overlong_candidates() {
+        let candidate = "a".repeat(256);
+        let response = serde_json::json!({
+            "media_type": "anime",
+            "search": "cowboy bebop",
+            "candidates": [candidate, "samurai champloo"],
+        });
+
+        let intent = parse_search_intent_json(&response.to_string()).unwrap();
+
+        assert_eq!(intent.search, "cowboy bebop");
+        assert_eq!(intent.candidates, vec!["samurai champloo"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Apply shared search-term validation consistently across user-facing lookup commands so invalid empty or overlong inputs are rejected before AniList, MAL, or LLM lookup work.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- 97013472c3a936d29cc0460bd40d9b059c814e20: Validate direct AniList search inputs for `/anime`, `/manga`, and `/character` with the existing invalid-input response style.
- c05ae693486c887ba1a67ebf3ce7b83988d506dc: Validate `/search` raw queries and filter normalized LLM/fallback terms through shared search-term validation, with focused overlong-term tests.
- 3d6678332a65336f467b39a58aa8c8ac7f4d0353: Bump the bot patch version to `2.19.1` and update `Cargo.lock`.

## Validation
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo check`

---

This PR description was written by OpenAI GPT-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->