### PR TITLE
[ANNIE-185]/add configurable title display preference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.0.2"
+version = "3.1.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.0.2"
+version = "3.1.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -102,7 +102,10 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     info!("Got command 'anime' with search_term: {search_term}");
 
-    let fetch_result: Option<(Anime, TitleVariant)> = AniListSource.fetch_anime(&search_term).await;
+    let (fetch_result, title_preference): (Option<(Anime, TitleVariant)>, TitleDisplayPreference) = tokio::join!(
+        AniListSource.fetch_anime(&search_term),
+        resolve_title_display_preference(ctx, user.id, interaction.guild_id),
+    );
     let (anime_result, title_variant): (Option<Anime>, Option<TitleVariant>) = match fetch_result {
         Some((anime, variant)) => (Some(anime), Some(variant)),
         None => (None, None),
@@ -135,8 +138,6 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
 
     // Delegate to the transport-agnostic core logic.
-    let title_preference =
-        resolve_title_display_preference(ctx, user.id, interaction.guild_id).await;
     let response = handle_anime(
         anime_result,
         guild_members_data,

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -7,13 +7,14 @@ use crate::{
         traits::{AniListSource, MediaDataSource},
     },
     models::{
-        anilist_anime::Anime, anilist_common::TitleVariant, transformers::Transformers,
-        user_media_list::MediaListData,
+        anilist_anime::Anime, anilist_common::TitleVariant, settings::TitleDisplayPreference,
+        transformers::Transformers, user_media_list::MediaListData,
     },
     utils::{
         channel::is_nsfw_channel,
         guild::{get_current_guild_members, get_guild_data_for_media},
         privacy::configure_sentry_scope,
+        settings::resolve_title_display_preference,
         statics::{NOT_FOUND_ANIME, NSFW_NOT_ALLOWED},
     },
 };
@@ -55,11 +56,16 @@ pub fn handle_anime(
     anime: Option<Anime>,
     guild_members_data: Option<HashMap<u64, MediaListData>>,
     title_variant: Option<TitleVariant>,
+    title_preference: TitleDisplayPreference,
 ) -> CommandResponse {
     match anime {
         None => CommandResponse::Content(NOT_FOUND_ANIME.to_string()),
         Some(anime_response) => {
-            let embed = anime_response.transform_response_embed(guild_members_data, title_variant);
+            let embed = anime_response.transform_response_embed(
+                guild_members_data,
+                title_variant,
+                title_preference,
+            );
             CommandResponse::Embed(Box::new(embed))
         }
     }
@@ -129,7 +135,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
 
     // Delegate to the transport-agnostic core logic.
-    let response = handle_anime(anime_result, guild_members_data, title_variant);
+    let title_preference =
+        resolve_title_display_preference(ctx, user.id, interaction.guild_id).await;
+    let response = handle_anime(
+        anime_result,
+        guild_members_data,
+        title_variant,
+        title_preference,
+    );
 
     // Map the CommandResponse to the appropriate Discord API call.
     let _result = match response {
@@ -197,9 +210,13 @@ mod tests {
         .expect("sample anime JSON should deserialize")
     }
 
+    fn matched_title_preference() -> TitleDisplayPreference {
+        TitleDisplayPreference::Matched
+    }
+
     #[test]
     fn anime_not_found_returns_content_with_message() {
-        let response = handle_anime(None, None, None);
+        let response = handle_anime(None, None, None, matched_title_preference());
 
         assert!(response.is_content(), "expected Content variant");
         assert_eq!(response.unwrap_content(), NOT_FOUND_ANIME);
@@ -207,7 +224,7 @@ mod tests {
 
     #[test]
     fn anime_success_returns_embed() {
-        let response = handle_anime(Some(sample_anime()), None, None);
+        let response = handle_anime(Some(sample_anime()), None, None, matched_title_preference());
 
         assert!(
             response.is_embed(),
@@ -220,7 +237,7 @@ mod tests {
 
     #[test]
     fn anime_success_with_no_guild_data_still_returns_embed() {
-        let response = handle_anime(Some(sample_anime()), None, None);
+        let response = handle_anime(Some(sample_anime()), None, None, matched_title_preference());
 
         assert!(response.is_embed());
     }
@@ -264,6 +281,43 @@ mod tests {
         .expect("sample anime JSON should deserialize")
     }
 
+    fn anime_without_english_or_native_title() -> Anime {
+        serde_json::from_value(serde_json::json!({
+            "type": "ANIME",
+            "id": 1,
+            "idMal": null,
+            "isAdult": false,
+            "title": {
+                "romaji": "Haibane Renmei",
+                "english": null,
+                "native": null
+            },
+            "synonyms": [],
+            "season": null,
+            "seasonYear": null,
+            "format": "TV",
+            "status": "FINISHED",
+            "episodes": 13,
+            "duration": 24,
+            "genres": [],
+            "source": null,
+            "coverImage": {
+                "extraLarge": null,
+                "large": null,
+                "medium": null,
+                "color": null
+            },
+            "averageScore": null,
+            "studios": { "edges": [], "nodes": [] },
+            "siteUrl": "https://anilist.co/anime/1",
+            "externalLinks": [],
+            "trailer": null,
+            "description": "",
+            "tags": []
+        }))
+        .expect("sample anime JSON should deserialize")
+    }
+
     fn embed_title_and_footer(response: CommandResponse) -> (String, String) {
         let embed = response.unwrap_embed();
         let value = serde_json::to_value(&embed).expect("embed serializes");
@@ -281,6 +335,7 @@ mod tests {
             Some(anime_with_distinct_titles()),
             None,
             Some(TitleVariant::English),
+            matched_title_preference(),
         );
 
         let (title, footer) = embed_title_and_footer(response);
@@ -294,6 +349,7 @@ mod tests {
             Some(anime_with_distinct_titles()),
             None,
             Some(TitleVariant::Romaji),
+            matched_title_preference(),
         );
 
         let (title, footer) = embed_title_and_footer(response);
@@ -303,10 +359,71 @@ mod tests {
 
     #[test]
     fn no_variant_signal_preserves_legacy_romaji_title_english_footer() {
-        let response = handle_anime(Some(anime_with_distinct_titles()), None, None);
+        let response = handle_anime(
+            Some(anime_with_distinct_titles()),
+            None,
+            None,
+            matched_title_preference(),
+        );
 
         let (title, footer) = embed_title_and_footer(response);
         assert_eq!(title, "Shingeki No Kyojin");
         assert_eq!(footer, "Attack on Titan");
+    }
+
+    #[test]
+    fn english_preference_overrides_matched_variant() {
+        let response = handle_anime(
+            Some(anime_with_distinct_titles()),
+            None,
+            Some(TitleVariant::Romaji),
+            TitleDisplayPreference::English,
+        );
+
+        let (title, footer) = embed_title_and_footer(response);
+        assert_eq!(title, "Attack on Titan");
+        assert_eq!(footer, "Shingeki No Kyojin");
+    }
+
+    #[test]
+    fn romaji_preference_overrides_matched_variant() {
+        let response = handle_anime(
+            Some(anime_with_distinct_titles()),
+            None,
+            Some(TitleVariant::English),
+            TitleDisplayPreference::Romaji,
+        );
+
+        let (title, footer) = embed_title_and_footer(response);
+        assert_eq!(title, "Shingeki No Kyojin");
+        assert_eq!(footer, "Attack on Titan");
+    }
+
+    #[test]
+    fn native_preference_uses_native_title() {
+        let response = handle_anime(
+            Some(anime_with_distinct_titles()),
+            None,
+            Some(TitleVariant::English),
+            TitleDisplayPreference::Native,
+        );
+
+        let (title, footer) = embed_title_and_footer(response);
+        assert_eq!(title, "進撃の巨人");
+        assert_eq!(footer, "Shingeki No Kyojin");
+    }
+
+    #[test]
+    fn preferred_title_falls_back_when_variant_is_unavailable() {
+        let response = handle_anime(
+            Some(anime_without_english_or_native_title()),
+            None,
+            Some(TitleVariant::English),
+            TitleDisplayPreference::Native,
+        );
+
+        let (title, footer) = embed_title_and_footer(response);
+        assert_eq!(title, "Haibane Renmei");
+        assert_eq!(footer, "Haibane Renmei");
     }
 }

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -102,7 +102,10 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     info!("Got command 'manga' with search_term: {search_term}");
 
-    let fetch_result: Option<(Manga, TitleVariant)> = AniListSource.fetch_manga(&search_term).await;
+    let (fetch_result, title_preference): (Option<(Manga, TitleVariant)>, TitleDisplayPreference) = tokio::join!(
+        AniListSource.fetch_manga(&search_term),
+        resolve_title_display_preference(ctx, user.id, interaction.guild_id),
+    );
     let (manga_result, title_variant): (Option<Manga>, Option<TitleVariant>) = match fetch_result {
         Some((manga, variant)) => (Some(manga), Some(variant)),
         None => (None, None),
@@ -135,8 +138,6 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
 
     // Delegate to the transport-agnostic core logic.
-    let title_preference =
-        resolve_title_display_preference(ctx, user.id, interaction.guild_id).await;
     let response = handle_manga(
         manga_result,
         guild_members_data,

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -7,13 +7,14 @@ use crate::{
         traits::{AniListSource, MediaDataSource},
     },
     models::{
-        anilist_common::TitleVariant, anilist_manga::Manga, transformers::Transformers,
-        user_media_list::MediaListData,
+        anilist_common::TitleVariant, anilist_manga::Manga, settings::TitleDisplayPreference,
+        transformers::Transformers, user_media_list::MediaListData,
     },
     utils::{
         channel::is_nsfw_channel,
         guild::{get_current_guild_members, get_guild_data_for_media},
         privacy::configure_sentry_scope,
+        settings::resolve_title_display_preference,
         statics::{NOT_FOUND_MANGA, NSFW_NOT_ALLOWED},
     },
 };
@@ -55,11 +56,16 @@ pub fn handle_manga(
     manga: Option<Manga>,
     guild_members_data: Option<HashMap<u64, MediaListData>>,
     title_variant: Option<TitleVariant>,
+    title_preference: TitleDisplayPreference,
 ) -> CommandResponse {
     match manga {
         None => CommandResponse::Content(NOT_FOUND_MANGA.to_string()),
         Some(manga_response) => {
-            let embed = manga_response.transform_response_embed(guild_members_data, title_variant);
+            let embed = manga_response.transform_response_embed(
+                guild_members_data,
+                title_variant,
+                title_preference,
+            );
             CommandResponse::Embed(Box::new(embed))
         }
     }
@@ -129,7 +135,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
 
     // Delegate to the transport-agnostic core logic.
-    let response = handle_manga(manga_result, guild_members_data, title_variant);
+    let title_preference =
+        resolve_title_display_preference(ctx, user.id, interaction.guild_id).await;
+    let response = handle_manga(
+        manga_result,
+        guild_members_data,
+        title_variant,
+        title_preference,
+    );
 
     // Map the CommandResponse to the appropriate Discord API call.
     let _result = match response {
@@ -193,9 +206,13 @@ mod tests {
         .expect("sample manga JSON should deserialize")
     }
 
+    fn matched_title_preference() -> TitleDisplayPreference {
+        TitleDisplayPreference::Matched
+    }
+
     #[test]
     fn manga_not_found_returns_content_with_message() {
-        let response = handle_manga(None, None, None);
+        let response = handle_manga(None, None, None, matched_title_preference());
 
         assert!(response.is_content(), "expected Content variant");
         assert_eq!(response.unwrap_content(), NOT_FOUND_MANGA);
@@ -203,7 +220,7 @@ mod tests {
 
     #[test]
     fn manga_success_returns_embed() {
-        let response = handle_manga(Some(sample_manga()), None, None);
+        let response = handle_manga(Some(sample_manga()), None, None, matched_title_preference());
 
         assert!(
             response.is_embed(),
@@ -214,7 +231,7 @@ mod tests {
 
     #[test]
     fn manga_success_with_no_guild_data_still_returns_embed() {
-        let response = handle_manga(Some(sample_manga()), None, None);
+        let response = handle_manga(Some(sample_manga()), None, None, matched_title_preference());
 
         assert!(response.is_embed());
     }

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -11,6 +11,7 @@ use crate::{
         },
         media_response::FetchResponse as SearchResponse,
         media_type::MediaType,
+        settings::TitleDisplayPreference,
         transformers::Transformers,
     },
     utils::{
@@ -19,6 +20,7 @@ use crate::{
         formatter::{code, linker, remove_underscores_and_titlecase, titlecase},
         privacy::configure_sentry_scope,
         redis::{check_cache, try_to_cache_response},
+        settings::resolve_title_display_preference,
         statics::{EMPTY_STR, NOT_FOUND_ANIME, NOT_FOUND_MANGA, NSFW_NOT_ALLOWED},
     },
 };
@@ -95,6 +97,7 @@ pub fn handle_recommend(
     media: Option<RecommendationMedia>,
     media_type: MediaType,
     title_variant: Option<TitleVariant>,
+    title_preference: TitleDisplayPreference,
     allow_adult_media: bool,
 ) -> CommandResponse {
     let Some(media) = media else {
@@ -120,7 +123,7 @@ pub fn handle_recommend(
     if recommendations.is_empty() {
         return CommandResponse::Content(format!(
             "No recommendations found for {}.",
-            media_title(&media, title_variant)
+            media.transform_preferred_title(title_variant, title_preference)
         ));
     }
 
@@ -128,6 +131,7 @@ pub fn handle_recommend(
         &media,
         &recommendations,
         title_variant,
+        title_preference,
     )))
 }
 
@@ -172,7 +176,15 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     };
     let allow_adult_media =
         is_nsfw_channel(ctx, interaction.channel_id, interaction.guild_id).await;
-    let response = handle_recommend(media, media_type, title_variant, allow_adult_media);
+    let title_preference =
+        resolve_title_display_preference(ctx, interaction.user.id, interaction.guild_id).await;
+    let response = handle_recommend(
+        media,
+        media_type,
+        title_variant,
+        title_preference,
+        allow_adult_media,
+    );
 
     let _result = match response {
         CommandResponse::Content(text) | CommandResponse::Message(text) => {
@@ -315,12 +327,13 @@ fn recommendations_embed(
     media: &RecommendationMedia,
     recommendations: &[(&Recommendation, &RecommendedMedia)],
     title_variant: Option<TitleVariant>,
+    title_preference: TitleDisplayPreference,
 ) -> CreateEmbed {
     let mut embed = CreateEmbed::new()
         .color(media.transform_color())
         .title(format!(
             "Recommendations for {}",
-            media_title(media, title_variant)
+            media.transform_preferred_title(title_variant, title_preference)
         ))
         .url(media.transform_anilist())
         .footer(CreateEmbedFooter::new(format!(
@@ -335,7 +348,11 @@ fn recommendations_embed(
 
     for (index, (recommendation, recommended_media)) in recommendations.iter().enumerate() {
         embed = embed.field(
-            format!("{}. {}", index + 1, recommended_media.display_title()),
+            format!(
+                "{}. {}",
+                index + 1,
+                recommended_media.display_title(title_preference)
+            ),
             format_recommendation(recommendation, recommended_media),
             false,
         );
@@ -391,15 +408,6 @@ fn format_media_descriptor(recommended_media: &RecommendedMedia) -> String {
             remove_underscores_and_titlecase(format),
             remove_underscores_and_titlecase(status)
         ),
-    }
-}
-
-#[instrument(skip(media))]
-fn media_title(media: &RecommendationMedia, title_variant: Option<TitleVariant>) -> String {
-    match title_variant {
-        Some(TitleVariant::English) => media.transform_english_title(),
-        Some(TitleVariant::Native) => media.transform_native_title(),
-        Some(TitleVariant::Romaji) | None => media.transform_romaji_title(),
     }
 }
 
@@ -504,7 +512,13 @@ mod tests {
 
     #[test]
     fn not_found_returns_type_specific_message() {
-        let response = handle_recommend(None, MediaType::Manga, None, true);
+        let response = handle_recommend(
+            None,
+            MediaType::Manga,
+            None,
+            TitleDisplayPreference::Matched,
+            true,
+        );
 
         assert!(response.is_content());
         assert_eq!(response.unwrap_content(), NOT_FOUND_MANGA);
@@ -516,6 +530,7 @@ mod tests {
             Some(sample_media(true, false)),
             MediaType::Anime,
             None,
+            TitleDisplayPreference::Matched,
             false,
         );
 
@@ -529,6 +544,7 @@ mod tests {
             Some(sample_media(false, true)),
             MediaType::Anime,
             None,
+            TitleDisplayPreference::Matched,
             false,
         );
 
@@ -546,6 +562,7 @@ mod tests {
             Some(sample_media_without_recommendations()),
             MediaType::Manga,
             Some(TitleVariant::English),
+            TitleDisplayPreference::Matched,
             true,
         );
 
@@ -562,6 +579,7 @@ mod tests {
             Some(sample_media(false, false)),
             MediaType::Anime,
             Some(TitleVariant::English),
+            TitleDisplayPreference::Matched,
             false,
         );
 
@@ -576,5 +594,22 @@ mod tests {
                 .unwrap()
                 .contains("AniList rating: 42")
         );
+    }
+
+    #[test]
+    fn recommendations_use_configured_title_preference() {
+        let response = handle_recommend(
+            Some(sample_media(false, false)),
+            MediaType::Anime,
+            Some(TitleVariant::English),
+            TitleDisplayPreference::Native,
+            false,
+        );
+
+        assert!(response.is_embed());
+        let embed = response.unwrap_embed();
+        let value = serde_json::to_value(&embed).expect("embed serializes");
+        assert_eq!(value["title"], "Recommendations for カウボーイビバップ");
+        assert_eq!(value["fields"][0]["name"], "1. サムライチャンプルー");
     }
 }

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -351,7 +351,7 @@ fn recommendations_embed(
             format!(
                 "{}. {}",
                 index + 1,
-                recommended_media.display_title(title_preference)
+                recommended_media.display_title(title_variant, title_preference)
             ),
             format_recommendation(recommendation, recommended_media),
             false,

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -169,15 +169,16 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         "Got command 'recommend' with search_term: {search_term}"
     );
 
-    let fetch_result = fetch_recommendation_media(&search_term, media_type.clone()).await;
+    let (fetch_result, title_preference) = tokio::join!(
+        fetch_recommendation_media(&search_term, media_type.clone()),
+        resolve_title_display_preference(ctx, interaction.user.id, interaction.guild_id),
+    );
     let (media, title_variant) = match fetch_result {
         Some((media, variant)) => (Some(media), Some(variant)),
         None => (None, None),
     };
     let allow_adult_media =
         is_nsfw_channel(ctx, interaction.channel_id, interaction.guild_id).await;
-    let title_preference =
-        resolve_title_display_preference(ctx, interaction.user.id, interaction.guild_id).await;
     let response = handle_recommend(
         media,
         media_type,

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -313,42 +313,48 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     info!("Got command 'search'");
 
-    let intent = match get_gemini_client_from_context(ctx).await {
-        Some(client) => {
-            let telemetry_context = LlmTelemetryContext {
-                distinct_id: Some(hash_user_id(user.id.get()).to_string()),
-                guild_id: interaction
-                    .guild_id
-                    .map(|guild_id| hash_discord_id(guild_id.get()).to_string()),
-                command: Some("search".to_string()),
-                environment: std::env::var(ENV).ok(),
-                input: Some(json!([
-                    { "role": "system", "content": SEARCH_SYSTEM_PROMPT },
-                    { "role": "user", "content": query },
-                ])),
-            };
-            let user_message = format_intent_user_message(&query);
+    let search_result_future = async {
+        let intent = match get_gemini_client_from_context(ctx).await {
+            Some(client) => {
+                let telemetry_context = LlmTelemetryContext {
+                    distinct_id: Some(hash_user_id(user.id.get()).to_string()),
+                    guild_id: interaction
+                        .guild_id
+                        .map(|guild_id| hash_discord_id(guild_id.get()).to_string()),
+                    command: Some("search".to_string()),
+                    environment: std::env::var(ENV).ok(),
+                    input: Some(json!([
+                        { "role": "system", "content": SEARCH_SYSTEM_PROMPT },
+                        { "role": "user", "content": query },
+                    ])),
+                };
+                let user_message = format_intent_user_message(&query);
 
-            match client
-                .chat_with_telemetry_context(&user_message, telemetry_context)
-                .await
-                .map_err(SearchIntentError::Llm)
-                .and_then(|response| parse_search_intent_json(&response))
-            {
-                Ok(intent) => intent,
-                Err(error) => {
-                    warn!(error = %error, "Natural-language search parsing failed; falling back to raw query");
-                    fallback_intent(&query)
+                match client
+                    .chat_with_telemetry_context(&user_message, telemetry_context)
+                    .await
+                    .map_err(SearchIntentError::Llm)
+                    .and_then(|response| parse_search_intent_json(&response))
+                {
+                    Ok(intent) => intent,
+                    Err(error) => {
+                        warn!(error = %error, "Natural-language search parsing failed; falling back to raw query");
+                        fallback_intent(&query)
+                    }
                 }
             }
-        }
-        None => {
-            warn!("LLM client unavailable; falling back to raw query");
-            fallback_intent(&query)
-        }
-    };
+            None => {
+                warn!("LLM client unavailable; falling back to raw query");
+                fallback_intent(&query)
+            }
+        };
 
-    let result = fetch_search_result(&AniListSource, intent).await;
+        fetch_search_result(&AniListSource, intent).await
+    };
+    let (result, title_preference) = tokio::join!(
+        search_result_future,
+        resolve_title_display_preference(ctx, user.id, interaction.guild_id),
+    );
 
     match &result {
         MediaSearchResult::Anime { anime, .. }
@@ -376,8 +382,6 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         }
         MediaSearchResult::NotFound => None,
     };
-    let title_preference =
-        resolve_title_display_preference(ctx, user.id, interaction.guild_id).await;
     let response = build_response(result, title_preference);
     let _result = match response {
         CommandResponse::Content(text) | CommandResponse::Message(text) => {

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -9,13 +9,14 @@ use crate::{
     },
     models::{
         anilist_anime::Anime, anilist_common::TitleVariant, anilist_manga::Manga,
-        transformers::Transformers,
+        settings::TitleDisplayPreference, transformers::Transformers,
     },
     utils::{
         channel::is_nsfw_channel,
         llm::{LlmError, get_gemini_client_from_context},
         posthog::LlmTelemetryContext,
         privacy::{configure_sentry_scope, hash_discord_id, hash_user_id},
+        settings::resolve_title_display_preference,
         statics::ENV,
         statics::NSFW_NOT_ALLOWED,
     },
@@ -257,22 +258,29 @@ async fn fetch_manga_candidates<S: MediaDataSource>(
 }
 
 #[instrument(name = "command.search.build_response", skip(result))]
-pub fn build_response(result: MediaSearchResult) -> CommandResponse {
+pub fn build_response(
+    result: MediaSearchResult,
+    title_preference: TitleDisplayPreference,
+) -> CommandResponse {
     match result {
         MediaSearchResult::Anime {
             anime,
             title_variant,
             ..
-        } => CommandResponse::Embed(Box::new(
-            anime.transform_response_embed(None, title_variant),
-        )),
+        } => CommandResponse::Embed(Box::new(anime.transform_response_embed(
+            None,
+            title_variant,
+            title_preference,
+        ))),
         MediaSearchResult::Manga {
             manga,
             title_variant,
             ..
-        } => CommandResponse::Embed(Box::new(
-            manga.transform_response_embed(None, title_variant),
-        )),
+        } => CommandResponse::Embed(Box::new(manga.transform_response_embed(
+            None,
+            title_variant,
+            title_preference,
+        ))),
         MediaSearchResult::NotFound => CommandResponse::Content(NOT_FOUND_SEARCH.to_string()),
     }
 }
@@ -368,7 +376,9 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         }
         MediaSearchResult::NotFound => None,
     };
-    let response = build_response(result);
+    let title_preference =
+        resolve_title_display_preference(ctx, user.id, interaction.guild_id).await;
+    let response = build_response(result, title_preference);
     let _result = match response {
         CommandResponse::Content(text) | CommandResponse::Message(text) => {
             let builder = EditInteractionResponse::new().content(match interpretation {

--- a/src/commands/traits.rs
+++ b/src/commands/traits.rs
@@ -6,15 +6,23 @@
 //! ## Example: testing the core handler directly
 //!
 //! ```ignore
-//! use crate::commands::{anime::command::handle_anime, response::CommandResponse};
+//! use crate::{
+//!     commands::{anime::command::handle_anime, response::CommandResponse},
+//!     models::settings::TitleDisplayPreference,
+//! };
 //!
 //! // Not-found path — no anime, no guild data, no variant signal.
-//! let response = handle_anime(None, None, None);
+//! let response = handle_anime(None, None, None, TitleDisplayPreference::Matched);
 //! assert!(response.is_content());
 //!
 //! // Success path — pass a pre-built Anime, optional guild data, and the
 //! // matched title variant (so the embed surfaces the user's typed variant).
-//! let response = handle_anime(Some(sample_anime), Some(guild_data), Some(title_variant));
+//! let response = handle_anime(
+//!     Some(sample_anime),
+//!     Some(guild_data),
+//!     Some(title_variant),
+//!     TitleDisplayPreference::Matched,
+//! );
 //! assert!(response.is_embed());
 //! ```
 

--- a/src/models/anilist_recommendation.rs
+++ b/src/models/anilist_recommendation.rs
@@ -1,6 +1,7 @@
 use crate::{
     models::{
         anilist_common::{CoverImage, Tag, Title},
+        settings::TitleDisplayPreference,
         transformers::Transformers,
     },
     utils::{formatter::titlecase, statics::EMPTY_STR},
@@ -86,15 +87,39 @@ impl Recommendation {
 }
 
 impl RecommendedMedia {
-    pub fn display_title(&self) -> String {
-        titlecase(
-            self.title
-                .english
+    pub fn display_title(&self, title_preference: TitleDisplayPreference) -> String {
+        match title_preference {
+            TitleDisplayPreference::Matched | TitleDisplayPreference::English => titlecase(
+                self.title
+                    .english
+                    .as_deref()
+                    .or(self.title.romaji.as_deref())
+                    .or(self.title.native.as_deref())
+                    .unwrap_or_default(),
+            ),
+            TitleDisplayPreference::Romaji => titlecase(
+                self.title
+                    .romaji
+                    .as_deref()
+                    .or(self.title.english.as_deref())
+                    .or(self.title.native.as_deref())
+                    .unwrap_or_default(),
+            ),
+            TitleDisplayPreference::Native => self
+                .title
+                .native
                 .as_deref()
-                .or(self.title.romaji.as_deref())
-                .or(self.title.native.as_deref())
-                .unwrap_or_default(),
-        )
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| {
+                    titlecase(
+                        self.title
+                            .romaji
+                            .as_deref()
+                            .or(self.title.english.as_deref())
+                            .unwrap_or_default(),
+                    )
+                }),
+        }
     }
 
     pub fn media_type(&self) -> &str {
@@ -315,7 +340,10 @@ mod tests {
         let recommendation = media.recommendations().next().unwrap();
         let recommended_media = recommendation.recommended_media().unwrap();
         assert_eq!(recommendation.rating_text(), "42");
-        assert_eq!(recommended_media.display_title(), "Samurai Champloo");
+        assert_eq!(
+            recommended_media.display_title(TitleDisplayPreference::Matched),
+            "Samurai Champloo"
+        );
         assert_eq!(recommended_media.media_type(), "anime");
     }
 }

--- a/src/models/anilist_recommendation.rs
+++ b/src/models/anilist_recommendation.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::{
-        anilist_common::{CoverImage, Tag, Title},
+        anilist_common::{CoverImage, Tag, Title, TitleVariant},
         settings::TitleDisplayPreference,
         transformers::Transformers,
     },
@@ -87,39 +87,61 @@ impl Recommendation {
 }
 
 impl RecommendedMedia {
-    pub fn display_title(&self, title_preference: TitleDisplayPreference) -> String {
+    pub fn display_title(
+        &self,
+        title_variant: Option<TitleVariant>,
+        title_preference: TitleDisplayPreference,
+    ) -> String {
         match title_preference {
-            TitleDisplayPreference::Matched | TitleDisplayPreference::English => titlecase(
-                self.title
-                    .english
-                    .as_deref()
-                    .or(self.title.romaji.as_deref())
-                    .or(self.title.native.as_deref())
-                    .unwrap_or_default(),
-            ),
-            TitleDisplayPreference::Romaji => titlecase(
-                self.title
-                    .romaji
-                    .as_deref()
-                    .or(self.title.english.as_deref())
-                    .or(self.title.native.as_deref())
-                    .unwrap_or_default(),
-            ),
-            TitleDisplayPreference::Native => self
-                .title
-                .native
-                .as_deref()
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| {
-                    titlecase(
-                        self.title
-                            .romaji
-                            .as_deref()
-                            .or(self.title.english.as_deref())
-                            .unwrap_or_default(),
-                    )
-                }),
+            TitleDisplayPreference::Matched => {
+                match title_variant.unwrap_or(TitleVariant::Romaji) {
+                    TitleVariant::English => self.english_display_title(),
+                    TitleVariant::Romaji => self.romaji_display_title(),
+                    TitleVariant::Native => self.native_display_title(),
+                }
+            }
+            TitleDisplayPreference::English => self.english_display_title(),
+            TitleDisplayPreference::Romaji => self.romaji_display_title(),
+            TitleDisplayPreference::Native => self.native_display_title(),
         }
+    }
+
+    fn english_display_title(&self) -> String {
+        titlecase(
+            self.title
+                .english
+                .as_deref()
+                .or(self.title.romaji.as_deref())
+                .or(self.title.native.as_deref())
+                .unwrap_or_default(),
+        )
+    }
+
+    fn romaji_display_title(&self) -> String {
+        titlecase(
+            self.title
+                .romaji
+                .as_deref()
+                .or(self.title.english.as_deref())
+                .or(self.title.native.as_deref())
+                .unwrap_or_default(),
+        )
+    }
+
+    fn native_display_title(&self) -> String {
+        self.title
+            .native
+            .as_deref()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| {
+                titlecase(
+                    self.title
+                        .romaji
+                        .as_deref()
+                        .or(self.title.english.as_deref())
+                        .unwrap_or_default(),
+                )
+            })
     }
 
     pub fn media_type(&self) -> &str {
@@ -279,6 +301,37 @@ mod tests {
     use super::*;
 
     #[test]
+    fn matched_recommendation_title_uses_search_variant() {
+        let media = RecommendedMedia {
+            media_type: Some("ANIME".to_string()),
+            is_adult: Some(false),
+            title: Title {
+                romaji: Some("Sousou no Frieren".to_string()),
+                english: Some("Frieren: Beyond Journey's End".to_string()),
+                native: Some("葬送のフリーレン".to_string()),
+            },
+            format: Some("TV".to_string()),
+            status: Some("FINISHED".to_string()),
+            genres: vec!["Adventure".to_string()],
+            average_score: Some(88),
+            site_url: "https://anilist.co/anime/154587".to_string(),
+        };
+
+        assert_eq!(
+            media.display_title(Some(TitleVariant::Romaji), TitleDisplayPreference::Matched),
+            "Sousou No Frieren"
+        );
+        assert_eq!(
+            media.display_title(Some(TitleVariant::English), TitleDisplayPreference::Matched),
+            "Frieren: Beyond Journey's End"
+        );
+        assert_eq!(
+            media.display_title(Some(TitleVariant::Native), TitleDisplayPreference::Matched),
+            "葬送のフリーレン"
+        );
+    }
+
+    #[test]
     fn deserializes_recommendation_media_response() {
         let response: RecommendationMediaResponse = serde_json::from_value(serde_json::json!({
             "data": {
@@ -341,7 +394,7 @@ mod tests {
         let recommended_media = recommendation.recommended_media().unwrap();
         assert_eq!(recommendation.rating_text(), "42");
         assert_eq!(
-            recommended_media.display_title(TitleDisplayPreference::Matched),
+            recommended_media.display_title(None, TitleDisplayPreference::Matched),
             "Samurai Champloo"
         );
         assert_eq!(recommended_media.media_type(), "anime");

--- a/src/models/transformers.rs
+++ b/src/models/transformers.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::{
     models::{
         anilist_common::{CoverImage, Tag, TitleVariant},
+        settings::TitleDisplayPreference,
         user_media_list::MediaListData,
     },
     utils::{formatter::*, statics::EMPTY_STR},
@@ -10,6 +11,7 @@ use crate::{
 
 use html2md::parse_html;
 use serenity::all::{CreateEmbed, CreateEmbedFooter};
+use tracing::instrument;
 
 pub trait Transformers {
     fn get_id(&self) -> u32;
@@ -68,6 +70,29 @@ pub trait Transformers {
                 Some(title) => titlecase(title),
                 None => titlecase(self.get_english_title().unwrap_or_default()),
             },
+        }
+    }
+
+    fn transform_preferred_title(
+        &self,
+        title_variant: Option<TitleVariant>,
+        title_preference: TitleDisplayPreference,
+    ) -> String {
+        match effective_title_variant(title_variant, title_preference) {
+            TitleVariant::English => self.transform_english_title(),
+            TitleVariant::Native => self.transform_native_title(),
+            TitleVariant::Romaji => self.transform_romaji_title(),
+        }
+    }
+
+    fn transform_footer_title(
+        &self,
+        title_variant: Option<TitleVariant>,
+        title_preference: TitleDisplayPreference,
+    ) -> String {
+        match effective_title_variant(title_variant, title_preference) {
+            TitleVariant::English | TitleVariant::Native => self.transform_romaji_title(),
+            TitleVariant::Romaji => self.transform_english_title(),
         }
     }
 
@@ -161,29 +186,15 @@ pub trait Transformers {
         &self,
         guild_members_data: Option<HashMap<u64, MediaListData>>,
         title_variant: Option<TitleVariant>,
+        title_preference: TitleDisplayPreference,
     ) -> CreateEmbed {
         let is_anime = self.get_type() == "anime";
 
         // Surface whichever variant the user typed as the primary title;
         // park the other one in the footer. Default (no signal) keeps the
         // long-standing Romaji-as-title behaviour.
-        let (primary_title, footer_title) = match title_variant {
-            Some(TitleVariant::English) => (
-                self.transform_english_title(),
-                self.transform_romaji_title(),
-            ),
-            // Native primary pairs with Romaji in the footer: Romaji is the
-            // direct transliteration, so it acts as a pronunciation aid for
-            // the Native script. English is intentionally omitted here — it
-            // is the variant least related to a native-script search.
-            Some(TitleVariant::Native) => {
-                (self.transform_native_title(), self.transform_romaji_title())
-            }
-            Some(TitleVariant::Romaji) | None => (
-                self.transform_romaji_title(),
-                self.transform_english_title(),
-            ),
-        };
+        let primary_title = self.transform_preferred_title(title_variant, title_preference);
+        let footer_title = self.transform_footer_title(title_variant, title_preference);
 
         let mut embed = CreateEmbed::new()
             // General Embed Fields
@@ -255,5 +266,18 @@ pub trait Transformers {
             }
             None => embed,
         }
+    }
+}
+
+#[instrument(name = "transformers.effective_title_variant")]
+fn effective_title_variant(
+    title_variant: Option<TitleVariant>,
+    title_preference: TitleDisplayPreference,
+) -> TitleVariant {
+    match title_preference {
+        TitleDisplayPreference::Matched => title_variant.unwrap_or(TitleVariant::Romaji),
+        TitleDisplayPreference::Romaji => TitleVariant::Romaji,
+        TitleDisplayPreference::English => TitleVariant::English,
+        TitleDisplayPreference::Native => TitleVariant::Native,
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,7 @@ pub mod privacy;
 pub mod redis;
 pub mod requests;
 pub mod response_fetcher;
+pub mod settings;
 pub mod spotify;
 pub mod statics;
 pub mod tls;

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -23,7 +23,10 @@ pub async fn resolve_title_display_preference(
     match resolve_setting_layers(&pool, user_id, guild_id, SettingKey::TitleDisplay).await {
         Ok(layers) => match layers.effective.value {
             SettingValue::TitleDisplay(preference) => preference,
-            SettingValue::AnalyticsPrivacy(_) => default_title_display_preference(),
+            SettingValue::AnalyticsPrivacy(_) => {
+                warn!("Unexpected analytics privacy value for title display key; using default");
+                default_title_display_preference()
+            }
         },
         Err(error) => {
             warn!(error = %error, "Failed to resolve title display preference; using default");

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -32,6 +32,7 @@ pub async fn resolve_title_display_preference(
     }
 }
 
+#[instrument(name = "settings.default_title_display")]
 fn default_title_display_preference() -> TitleDisplayPreference {
     match SettingKey::TitleDisplay.default_value() {
         SettingValue::TitleDisplay(preference) => preference,

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -1,0 +1,40 @@
+use serenity::{all::UserId, client::Context, model::prelude::GuildId};
+use tracing::{instrument, warn};
+
+use crate::{
+    models::{
+        db::settings::resolve_setting_layers,
+        settings::{SettingKey, SettingValue, TitleDisplayPreference},
+    },
+    utils::database::get_pool_from_context,
+};
+
+#[instrument(name = "settings.resolve_title_display", skip(ctx, user_id, guild_id))]
+pub async fn resolve_title_display_preference(
+    ctx: &Context,
+    user_id: UserId,
+    guild_id: Option<GuildId>,
+) -> TitleDisplayPreference {
+    let Some(pool) = get_pool_from_context(ctx).await else {
+        warn!("Database pool unavailable; using default title display preference");
+        return default_title_display_preference();
+    };
+
+    match resolve_setting_layers(&pool, user_id, guild_id, SettingKey::TitleDisplay).await {
+        Ok(layers) => match layers.effective.value {
+            SettingValue::TitleDisplay(preference) => preference,
+            SettingValue::AnalyticsPrivacy(_) => default_title_display_preference(),
+        },
+        Err(error) => {
+            warn!(error = %error, "Failed to resolve title display preference; using default");
+            default_title_display_preference()
+        }
+    }
+}
+
+fn default_title_display_preference() -> TitleDisplayPreference {
+    match SettingKey::TitleDisplay.default_value() {
+        SettingValue::TitleDisplay(preference) => preference,
+        SettingValue::AnalyticsPrivacy(_) => TitleDisplayPreference::Matched,
+    }
+}


### PR DESCRIPTION
## Summary

Add configurable title display preference support to anime, manga, search, and recommendation responses while preserving the existing matched-title behavior by default.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore

## Changes
- 0d9d8390299f2175336ad44e7089cc6a93249454: Apply the resolved title display preference to media embeds and recommendation titles, with tests for supported preferences and fallback behavior.
- 849939c123bd87f013dbebbd472039e9491b789a: Bump the crate version to 3.1.0 and update Cargo.lock.
- efeef57e83552bfb9c7cd237e0e062a14e9850c0: Honor the matched search title variant when rendering recommendation field titles.
- 066e50c2a56a77c75b94845080aa7151e351ae35: Update the command handler trait doc example for the new title preference parameter.
- fe31e05103fe18a2477238f108a1a2f2a97f5369: Add tracing instrumentation to the default title preference helper.
- a391d16d48ac7b64b5694baa7be400caa8ba5da7: Warn when title preference resolution receives an unexpected setting value type.
- 03a3a7f940a7ebfa49a2e57b639d36445d61219d: Fetch title preferences concurrently with upstream command work to avoid unnecessary latency.

### Notes

Title display resolution falls back to the configured default if settings storage is unavailable, preserving existing response behavior.

## Validation
- [x] cargo fmt --check
- [x] cargo test
- [x] cargo test utils::settings
- [x] cargo clippy --all-targets --all-features -- -D warnings

---

This PR description was written by openai/gpt-5.5.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
