### PR TITLE
[ANNIE-189]/separate bot database schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,8 +128,9 @@ Notes:
 ### Database Changes
 
 The bot uses **SQLx** for database access. The auth-service owns OAuth schema;
-the bot reads from the shared `oauth_credentials` table and owns Annie Mei-specific
-settings tables such as `user_settings` and `guild_settings`.
+the bot reads from the auth-owned `auth.oauth_credentials` table and owns
+Annie Mei-specific settings tables in the `annie_mei` schema, such as
+`user_settings` and `guild_settings`.
 
 1. Keep migrations limited to bot-owned tables; coordinate auth-service schema changes in the auth-service
 2. Use `sqlx::query_as()` with `#[derive(FromRow)]` for queries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.21.0"
+version = "3.0.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.20.0"
+version = "2.21.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "2.21.0"
+version = "3.0.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A Discord bot written in Rust that fetches anime and manga information from AniL
 ## Documentation
 
 - [OAuth data contract](docs/oauth-contract.md) — shared schema and payload contract with the [`auth`](https://github.com/annie-mei/auth) repo
+- [Database schema ownership](docs/database-schemas.md) — shared Postgres schemas, migration isolation, grants, and deployment order
 
 ## Legal
 

--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -11,12 +11,27 @@ Runtime queries should use schema-qualified table names. Do not rely on `search_
 
 ## Migration history
 
-Each service should track SQLx migrations in its own schema:
+Each service should track new SQLx migrations in its own schema:
 
 - Auth-service startup moves existing public OAuth tables when safe, then sets `search_path` to `auth,public` before running migrations, so SQLx uses `auth._sqlx_migrations`.
-- Annie Mei migrations should be run with `search_path` set to `annie_mei,auth,public`, so SQLx uses `annie_mei._sqlx_migrations`.
+- Fresh Annie Mei installs can run migrations with `search_path` set to `annie_mei,auth,public`, so SQLx uses `annie_mei._sqlx_migrations`.
 
-Create `annie_mei` before running Annie Mei migrations if you want SQLx to create `annie_mei._sqlx_migrations`; SQLx creates/checks its migration table before it runs migration SQL. Do not reconcile or share `public._sqlx_migrations`; it may contain older migrations from either service.
+Create `annie_mei` before running Annie Mei migrations if you want SQLx to create `annie_mei._sqlx_migrations`; SQLx creates/checks its migration table before it runs migration SQL.
+
+For existing deployments with prior Annie Mei rows in `public._sqlx_migrations`, do not switch directly to `search_path=annie_mei,auth,public`. That makes SQLx replay historical migrations into `annie_mei` before the table-move migration runs, which can create duplicate empty tables and stop the migration. Instead, first apply the schema-move migration with the existing migration-history location, then seed `annie_mei._sqlx_migrations` with only Annie Mei migration rows before using schema-local migration history.
+
+Example SQLx-history cutover after the Annie Mei schema-move migration has run:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS annie_mei;
+CREATE TABLE IF NOT EXISTS annie_mei._sqlx_migrations (LIKE public._sqlx_migrations INCLUDING ALL);
+
+INSERT INTO annie_mei._sqlx_migrations
+SELECT *
+FROM public._sqlx_migrations
+WHERE description IN ('create_settings_tables', 'move_settings_to_annie_mei_schema')
+ON CONFLICT (version) DO NOTHING;
+```
 
 ## Existing data move
 
@@ -53,22 +68,15 @@ The auth-service database role should own or fully manage objects in `auth`.
 
 1. Deploy auth-service schema changes first, or run its migrations manually, so `auth.oauth_credentials` and `auth.oauth_sessions` exist.
 2. Grant Annie Mei access to the `auth` schema and OAuth tables.
-3. Create the `annie_mei` schema before running Annie Mei migrations if this deployment should use `annie_mei._sqlx_migrations`.
-4. Run Annie Mei migrations with `search_path=annie_mei,auth,public`.
+3. For existing databases, run Annie Mei migrations once with the current migration-history location so the table-move migration can move `public.user_settings` and `public.guild_settings` before any historical migrations are replayed in `annie_mei`.
+4. If Annie Mei should use `annie_mei._sqlx_migrations` after that cutover, create `annie_mei._sqlx_migrations` from the existing Annie Mei migration rows only. Do not copy auth-service migration rows into Annie Mei's migration table.
 5. Deploy Annie Mei code that reads `auth.*` and writes `annie_mei.*`.
 
-For a short zero-downtime bridge for old bot reads, create compatibility views in `public`. Do not rely on these views for old auth-service writes that use `INSERT ... ON CONFLICT`; deploy auth-service before moving traffic that needs to write OAuth credentials. Drop the views after both services are schema-qualified.
-
-```sql
-CREATE OR REPLACE VIEW public.oauth_credentials AS SELECT * FROM auth.oauth_credentials;
-CREATE OR REPLACE VIEW public.oauth_sessions AS SELECT * FROM auth.oauth_sessions;
-```
-
-Avoid compatibility views for settings writes unless the deployment requires them and they are tested as updatable views.
+Avoid public compatibility views for this cutover. They can confuse startup duplicate checks and do not safely cover old write paths such as OAuth upserts.
 
 ## Rollback
 
-If schema-qualified code must be rolled back, either keep compatibility views in `public` or move tables back:
+If schema-qualified code must be rolled back, move tables back:
 
 ```sql
 ALTER TABLE IF EXISTS auth.oauth_credentials SET SCHEMA public;

--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -1,0 +1,80 @@
+# Database schema ownership
+
+Annie Mei and the auth-service share one Postgres database but own separate schemas so their SQLx migration histories do not conflict.
+
+| Schema | Owner | Tables |
+| --- | --- | --- |
+| `auth` | auth-service | `oauth_credentials`, `oauth_sessions` |
+| `annie_mei` | Annie Mei bot | `user_settings`, `guild_settings` |
+
+Runtime queries should use schema-qualified table names. Do not rely on `search_path` for application reads or writes.
+
+## Migration history
+
+Each service should track SQLx migrations in its own schema:
+
+- Auth-service startup moves existing public OAuth tables when safe, then sets `search_path` to `auth,public` before running migrations, so SQLx uses `auth._sqlx_migrations`.
+- Annie Mei migrations should be run with `search_path` set to `annie_mei,auth,public`, so SQLx uses `annie_mei._sqlx_migrations`.
+
+Create `annie_mei` before running Annie Mei migrations if you want SQLx to create `annie_mei._sqlx_migrations`; SQLx creates/checks its migration table before it runs migration SQL. Do not reconcile or share `public._sqlx_migrations`; it may contain older migrations from either service.
+
+## Existing data move
+
+Move existing public tables into their owner schema instead of copying data. `ALTER TABLE ... SET SCHEMA` preserves rows, indexes, constraints, and defaults.
+
+```sql
+CREATE SCHEMA IF NOT EXISTS auth;
+CREATE SCHEMA IF NOT EXISTS annie_mei;
+
+ALTER TABLE IF EXISTS public.oauth_credentials SET SCHEMA auth;
+ALTER TABLE IF EXISTS public.oauth_sessions SET SCHEMA auth;
+ALTER TABLE IF EXISTS public.user_settings SET SCHEMA annie_mei;
+ALTER TABLE IF EXISTS public.guild_settings SET SCHEMA annie_mei;
+```
+
+Auth-service startup performs the OAuth table move before SQLx runs migrations, and the auth-service also has a forward migration for direct SQLx tooling and local tests. Annie Mei has a forward migration that moves `public.user_settings` and `public.guild_settings` into `annie_mei`, and it fails if both schemas contain the same table.
+
+## Permissions
+
+The Annie Mei database role needs:
+
+```sql
+GRANT USAGE ON SCHEMA auth TO annie_mei_bot;
+GRANT SELECT, DELETE ON auth.oauth_credentials TO annie_mei_bot;
+GRANT SELECT, DELETE ON auth.oauth_sessions TO annie_mei_bot;
+
+GRANT USAGE ON SCHEMA annie_mei TO annie_mei_bot;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA annie_mei TO annie_mei_bot;
+```
+
+The auth-service database role should own or fully manage objects in `auth`.
+
+## Deployment order
+
+1. Deploy auth-service schema changes first, or run its migrations manually, so `auth.oauth_credentials` and `auth.oauth_sessions` exist.
+2. Grant Annie Mei access to the `auth` schema and OAuth tables.
+3. Create the `annie_mei` schema before running Annie Mei migrations if this deployment should use `annie_mei._sqlx_migrations`.
+4. Run Annie Mei migrations with `search_path=annie_mei,auth,public`.
+5. Deploy Annie Mei code that reads `auth.*` and writes `annie_mei.*`.
+
+For a short zero-downtime bridge for old bot reads, create compatibility views in `public`. Do not rely on these views for old auth-service writes that use `INSERT ... ON CONFLICT`; deploy auth-service before moving traffic that needs to write OAuth credentials. Drop the views after both services are schema-qualified.
+
+```sql
+CREATE OR REPLACE VIEW public.oauth_credentials AS SELECT * FROM auth.oauth_credentials;
+CREATE OR REPLACE VIEW public.oauth_sessions AS SELECT * FROM auth.oauth_sessions;
+```
+
+Avoid compatibility views for settings writes unless the deployment requires them and they are tested as updatable views.
+
+## Rollback
+
+If schema-qualified code must be rolled back, either keep compatibility views in `public` or move tables back:
+
+```sql
+ALTER TABLE IF EXISTS auth.oauth_credentials SET SCHEMA public;
+ALTER TABLE IF EXISTS auth.oauth_sessions SET SCHEMA public;
+ALTER TABLE IF EXISTS annie_mei.user_settings SET SCHEMA public;
+ALTER TABLE IF EXISTS annie_mei.guild_settings SET SCHEMA public;
+```
+
+Prefer table moves over copy-and-delete rollback so table metadata and data stay intact.

--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -29,7 +29,15 @@ CREATE TABLE IF NOT EXISTS annie_mei._sqlx_migrations (LIKE public._sqlx_migrati
 INSERT INTO annie_mei._sqlx_migrations
 SELECT *
 FROM public._sqlx_migrations
-WHERE description IN ('create_settings_tables', 'move_settings_to_annie_mei_schema')
+WHERE description IN (
+    'diesel_initial_setup',
+    'create_users',
+    'remove_unique_constraint_from_user',
+    'users_add_index_discord_id_anilist_id',
+    'drop_users_table',
+    'create_settings_tables',
+    'move_settings_to_annie_mei_schema'
+)
 ON CONFLICT (version) DO NOTHING;
 ```
 
@@ -66,11 +74,12 @@ The auth-service database role should own or fully manage objects in `auth`.
 
 ## Deployment order
 
-1. Deploy auth-service schema changes first, or run its migrations manually, so `auth.oauth_credentials` and `auth.oauth_sessions` exist.
-2. Grant Annie Mei access to the `auth` schema and OAuth tables.
-3. For existing databases, run Annie Mei migrations once with the current migration-history location so the table-move migration can move `public.user_settings` and `public.guild_settings` before any historical migrations are replayed in `annie_mei`.
-4. If Annie Mei should use `annie_mei._sqlx_migrations` after that cutover, create `annie_mei._sqlx_migrations` from the existing Annie Mei migration rows only. Do not copy auth-service migration rows into Annie Mei's migration table.
-5. Deploy Annie Mei code that reads `auth.*` and writes `annie_mei.*`.
+1. Drain or stop old auth-service instances before moving OAuth tables. Old auth-service code uses unqualified public table names and is not safe to overlap with the table move.
+2. Deploy auth-service schema changes first, or run its migrations manually, so `auth.oauth_credentials` and `auth.oauth_sessions` exist.
+3. Grant Annie Mei access to the `auth` schema and OAuth tables.
+4. For existing databases, run Annie Mei migrations once with the current migration-history location so the table-move migration can move `public.user_settings` and `public.guild_settings` before any historical migrations are replayed in `annie_mei`.
+5. If Annie Mei should use `annie_mei._sqlx_migrations` after that cutover, create `annie_mei._sqlx_migrations` from the existing Annie Mei migration rows only. Do not copy auth-service migration rows into Annie Mei's migration table.
+6. Deploy Annie Mei code that reads `auth.*` and writes `annie_mei.*`.
 
 Avoid public compatibility views for this cutover. They can confuse startup duplicate checks and do not safely cover old write paths such as OAuth upserts.
 

--- a/docs/oauth-contract.md
+++ b/docs/oauth-contract.md
@@ -25,11 +25,11 @@ The auth-service mirrors this document at
                        │ /oauth/anilist  │        │ /oauth/anilist │
                        │   /start        │        │   /callback    │
                        ╰────────┬────────╯        ╰────────┬───────╯
-                                │ writes oauth_sessions    │ writes oauth_credentials
+                                 │ writes auth.oauth_sessions │ writes auth.oauth_credentials
                                 ▼                          ▼
                        ╭──────────────────────────────────────────╮
-                       │              Postgres (shared)           │
-                       │  oauth_sessions      oauth_credentials   │
+                        │              Postgres (shared)           │
+                        │ auth.oauth_sessions  auth.oauth_credentials │
                        ╰──────────────────────────────────────────╯
                                                 ▲
                                                 │ reads (whoami, guild overlay)
@@ -37,13 +37,14 @@ The auth-service mirrors this document at
                                           Annie Mei bot
 ```
 
-The bot owns no database tables of its own. Account-link state lives in
-the auth-service tables and the bot reads/deletes those rows directly
-via SQLx, sharing the same Postgres database.
+Account-link state lives in the auth-service-owned `auth` schema, and
+the bot reads/deletes those rows directly via SQLx. Bot-owned settings
+tables live in the `annie_mei` schema. Schema ownership and migration
+isolation are documented in [Database schema ownership](database-schemas.md).
 
 ## Tables
 
-### `oauth_credentials`
+### `auth.oauth_credentials`
 
 Source of truth for **linked** AniList accounts.
 
@@ -77,21 +78,27 @@ numeric `anilist_id`.
 same transaction as `oauth_sessions`. See
 [`src/commands/unregister.rs`](../src/commands/unregister.rs).
 
-### `oauth_sessions`
+### `auth.oauth_sessions`
 
 Short-lived state for in-flight OAuth flows.
 
 | Column            | Type           | Notes                                                                       |
 | ----------------- | -------------- | --------------------------------------------------------------------------- |
 | `state`           | `TEXT` (PK)    | Opaque per-flow state token issued by the auth-service.                     |
-| `discord_user_id` | `TEXT`         | Raw Discord snowflake string, mirroring `oauth_credentials.discord_user_id`. |
+| `discord_user_id` | `TEXT`         | Raw Discord snowflake string, mirroring `auth.oauth_credentials.discord_user_id`. |
 | `expires_at`      | `TIMESTAMPTZ`  | When the session token stops being valid.                                   |
 | `used_at`         | `TIMESTAMPTZ NULL` | When the session was redeemed (replay protection).                          |
 | `created_at`      | `TIMESTAMPTZ`  | Initial creation time.                                                      |
 
-**Bot deletes:** `/unregister` includes a `DELETE FROM oauth_sessions
+**Bot deletes:** `/unregister` includes a `DELETE FROM auth.oauth_sessions
 WHERE discord_user_id = $1` in the same transaction so half-finished
 flows do not linger after a user unlinks.
+
+### `annie_mei.user_settings` and `annie_mei.guild_settings`
+
+The bot owns configurable user and guild settings in the `annie_mei`
+schema. Auth-service migrations must not create, alter, or drop these
+tables.
 
 ## OAuth context payload
 
@@ -119,7 +126,7 @@ The signature segment is appended after `.` to form
 Make the matching change in both repos in the same release window if
 you touch any of the following:
 
-- A column on `oauth_credentials` or `oauth_sessions` (rename, type
+- A column on `auth.oauth_credentials` or `auth.oauth_sessions` (rename, type
   change, deletion, or new NOT NULL column).
 - The `discord_user_id` representation (it must stay the raw Discord
   snowflake stringified via `user.id.get().to_string()` so bot
@@ -137,10 +144,10 @@ When making one of those changes:
 
 ## Privacy
 
-`oauth_credentials.discord_user_id` and `oauth_sessions.discord_user_id`
+`auth.oauth_credentials.discord_user_id` and `auth.oauth_sessions.discord_user_id`
 intentionally store the raw Discord snowflake so that `/register`,
 `/whoami`, and `/unregister` can all match on the same value. The
-`oauth_credentials.anilist_id` and `oauth_credentials.anilist_username`
+`auth.oauth_credentials.anilist_id` and `auth.oauth_credentials.anilist_username`
 fields are also user-identifying account-linkage data. **Logs, spans,
 metrics labels, breadcrumbs, and Sentry telemetry must not include any
 of those raw identifiers.** Use `crate::utils::privacy::hash_user_id`
@@ -158,7 +165,7 @@ Sentry transactions, request breadcrumbs, distributed tracing spans, and
 any reverse-proxy logs before those observability records leave the
 service.
 
-`oauth_credentials.access_token` and `oauth_credentials.refresh_token`
+`auth.oauth_credentials.access_token` and `auth.oauth_credentials.refresh_token`
 are bearer credentials that grant full access to the linked AniList
 account. The bot's current `OAuthCredential` model intentionally only
 selects `discord_user_id`, `anilist_id`, and `anilist_username`, but if

--- a/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/down.sql
+++ b/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/down.sql
@@ -1,16 +1,16 @@
 DO $$
 BEGIN
-    IF to_regclass('annie_mei.guild_settings') IS NOT NULL
-       AND to_regclass('public.guild_settings') IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
         RAISE EXCEPTION 'both annie_mei.guild_settings and public.guild_settings exist; resolve manually before reverting';
-    ELSIF to_regclass('annie_mei.guild_settings') IS NOT NULL THEN
+    ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE annie_mei.guild_settings SET SCHEMA public;
     END IF;
 
-    IF to_regclass('annie_mei.user_settings') IS NOT NULL
-       AND to_regclass('public.user_settings') IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
         RAISE EXCEPTION 'both annie_mei.user_settings and public.user_settings exist; resolve manually before reverting';
-    ELSIF to_regclass('annie_mei.user_settings') IS NOT NULL THEN
+    ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE annie_mei.user_settings SET SCHEMA public;
     END IF;
 END $$;

--- a/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/down.sql
+++ b/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/down.sql
@@ -1,14 +1,14 @@
 DO $$
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p'))
-       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p', 'v', 'm'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p', 'v', 'm')) THEN
         RAISE EXCEPTION 'both annie_mei.guild_settings and public.guild_settings exist; resolve manually before reverting';
     ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE annie_mei.guild_settings SET SCHEMA public;
     END IF;
 
-    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p'))
-       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p', 'v', 'm'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p', 'v', 'm')) THEN
         RAISE EXCEPTION 'both annie_mei.user_settings and public.user_settings exist; resolve manually before reverting';
     ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE annie_mei.user_settings SET SCHEMA public;

--- a/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/down.sql
+++ b/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/down.sql
@@ -1,0 +1,16 @@
+DO $$
+BEGIN
+    IF to_regclass('annie_mei.guild_settings') IS NOT NULL
+       AND to_regclass('public.guild_settings') IS NOT NULL THEN
+        RAISE EXCEPTION 'both annie_mei.guild_settings and public.guild_settings exist; resolve manually before reverting';
+    ELSIF to_regclass('annie_mei.guild_settings') IS NOT NULL THEN
+        ALTER TABLE annie_mei.guild_settings SET SCHEMA public;
+    END IF;
+
+    IF to_regclass('annie_mei.user_settings') IS NOT NULL
+       AND to_regclass('public.user_settings') IS NOT NULL THEN
+        RAISE EXCEPTION 'both annie_mei.user_settings and public.user_settings exist; resolve manually before reverting';
+    ELSIF to_regclass('annie_mei.user_settings') IS NOT NULL THEN
+        ALTER TABLE annie_mei.user_settings SET SCHEMA public;
+    END IF;
+END $$;

--- a/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/up.sql
+++ b/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/up.sql
@@ -2,15 +2,15 @@ CREATE SCHEMA IF NOT EXISTS annie_mei;
 
 DO $$
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p'))
-       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p', 'v', 'm'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p', 'v', 'm')) THEN
         RAISE EXCEPTION 'both public.user_settings and annie_mei.user_settings exist; resolve manually before continuing';
     ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE public.user_settings SET SCHEMA annie_mei;
     END IF;
 
-    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p'))
-       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p', 'v', 'm'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p', 'v', 'm')) THEN
         RAISE EXCEPTION 'both public.guild_settings and annie_mei.guild_settings exist; resolve manually before continuing';
     ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE public.guild_settings SET SCHEMA annie_mei;

--- a/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/up.sql
+++ b/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/up.sql
@@ -2,17 +2,17 @@ CREATE SCHEMA IF NOT EXISTS annie_mei;
 
 DO $$
 BEGIN
-    IF to_regclass('public.user_settings') IS NOT NULL
-       AND to_regclass('annie_mei.user_settings') IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
         RAISE EXCEPTION 'both public.user_settings and annie_mei.user_settings exist; resolve manually before continuing';
-    ELSIF to_regclass('public.user_settings') IS NOT NULL THEN
+    ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'user_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE public.user_settings SET SCHEMA annie_mei;
     END IF;
 
-    IF to_regclass('public.guild_settings') IS NOT NULL
-       AND to_regclass('annie_mei.guild_settings') IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p'))
+       AND EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'annie_mei' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
         RAISE EXCEPTION 'both public.guild_settings and annie_mei.guild_settings exist; resolve manually before continuing';
-    ELSIF to_regclass('public.guild_settings') IS NOT NULL THEN
+    ELSIF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relname = 'guild_settings' AND c.relkind IN ('r', 'p')) THEN
         ALTER TABLE public.guild_settings SET SCHEMA annie_mei;
     END IF;
 END $$;

--- a/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/up.sql
+++ b/migrations/2026-05-17-000001_move_settings_to_annie_mei_schema/up.sql
@@ -1,0 +1,36 @@
+CREATE SCHEMA IF NOT EXISTS annie_mei;
+
+DO $$
+BEGIN
+    IF to_regclass('public.user_settings') IS NOT NULL
+       AND to_regclass('annie_mei.user_settings') IS NOT NULL THEN
+        RAISE EXCEPTION 'both public.user_settings and annie_mei.user_settings exist; resolve manually before continuing';
+    ELSIF to_regclass('public.user_settings') IS NOT NULL THEN
+        ALTER TABLE public.user_settings SET SCHEMA annie_mei;
+    END IF;
+
+    IF to_regclass('public.guild_settings') IS NOT NULL
+       AND to_regclass('annie_mei.guild_settings') IS NOT NULL THEN
+        RAISE EXCEPTION 'both public.guild_settings and annie_mei.guild_settings exist; resolve manually before continuing';
+    ELSIF to_regclass('public.guild_settings') IS NOT NULL THEN
+        ALTER TABLE public.guild_settings SET SCHEMA annie_mei;
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS annie_mei.user_settings (
+    discord_user_id TEXT NOT NULL,
+    setting_key TEXT NOT NULL,
+    setting_value TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (discord_user_id, setting_key)
+);
+
+CREATE TABLE IF NOT EXISTS annie_mei.guild_settings (
+    guild_id TEXT NOT NULL,
+    setting_key TEXT NOT NULL,
+    setting_value TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (guild_id, setting_key)
+);

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -22,10 +22,11 @@ const CONFIRMATION_OPTION: &str = "confirmation";
 const CONFIRM_UNREGISTER: &str = "confirm";
 const CANCEL_UNREGISTER: &str = "cancel";
 const DELETE_OAUTH_CREDENTIALS_SQL: &str =
-    "DELETE FROM oauth_credentials WHERE discord_user_id = $1";
-const DELETE_OAUTH_SESSIONS_SQL: &str = "DELETE FROM oauth_sessions WHERE discord_user_id = $1";
-const OAUTH_CREDENTIALS_TABLE: &str = "oauth_credentials";
-const OAUTH_SESSIONS_TABLE: &str = "oauth_sessions";
+    "DELETE FROM auth.oauth_credentials WHERE discord_user_id = $1";
+const DELETE_OAUTH_SESSIONS_SQL: &str =
+    "DELETE FROM auth.oauth_sessions WHERE discord_user_id = $1";
+const OAUTH_CREDENTIALS_TABLE: &str = "auth.oauth_credentials";
+const OAUTH_SESSIONS_TABLE: &str = "auth.oauth_sessions";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnregisterOutcome {

--- a/src/models/db/oauth_credential.rs
+++ b/src/models/db/oauth_credential.rs
@@ -81,7 +81,7 @@ impl OAuthCredential {
         pool: &DbPool,
     ) -> Result<Option<OAuthCredential>, sqlx::Error> {
         sqlx::query_as::<_, OAuthCredential>(
-            "SELECT discord_user_id, anilist_id, anilist_username FROM oauth_credentials WHERE discord_user_id = $1"
+            "SELECT discord_user_id, anilist_id, anilist_username FROM auth.oauth_credentials WHERE discord_user_id = $1"
         )
         .bind(user_discord_id.get().to_string())
         .fetch_optional(pool)
@@ -107,7 +107,7 @@ impl OAuthCredential {
             .collect();
 
         sqlx::query_as::<_, OAuthCredential>(
-            "SELECT discord_user_id, anilist_id, anilist_username FROM oauth_credentials \
+            "SELECT discord_user_id, anilist_id, anilist_username FROM auth.oauth_credentials \
              WHERE discord_user_id = ANY($1)",
         )
         .bind(ids)

--- a/src/models/db/oauth_credential.rs
+++ b/src/models/db/oauth_credential.rs
@@ -1,8 +1,8 @@
-//! Read-only access to the auth-service `oauth_credentials` table from the bot.
+//! Read-only access to the auth-service `auth.oauth_credentials` table from the bot.
 //!
 //! The auth-service (see `../auth/src/routes/authorized.rs`) is the source of
 //! truth for OAuth-linked AniList accounts. The bot shares the same Postgres
-//! database and reads `oauth_credentials` directly via raw SQL so commands like
+//! database and reads `auth.oauth_credentials` directly via raw SQL so commands like
 //! `/whoami` and the guild-overlay query can recognize users that linked
 //! through the OAuth flow.
 //!
@@ -11,7 +11,7 @@
 //! contract. The shared schema contract is documented in
 //! `docs/oauth-contract.md`.
 //!
-//! `oauth_credentials.discord_user_id` is `TEXT` and contains the raw Discord
+//! `auth.oauth_credentials.discord_user_id` is `TEXT` and contains the raw Discord
 //! snowflake string (`user.id.get().to_string()`); `anilist_id` is `BIGINT` and
 //! `anilist_username` is nullable `TEXT`.
 

--- a/src/models/db/settings.rs
+++ b/src/models/db/settings.rs
@@ -88,7 +88,7 @@ pub async fn set_user_setting(
     value: SettingValue,
 ) -> Result<(), SettingsStorageError> {
     sqlx::query(
-        "INSERT INTO user_settings (discord_user_id, setting_key, setting_value) \
+        "INSERT INTO annie_mei.user_settings (discord_user_id, setting_key, setting_value) \
          VALUES ($1, $2, $3) \
          ON CONFLICT (discord_user_id, setting_key) DO UPDATE \
          SET setting_value = EXCLUDED.setting_value, updated_at = CURRENT_TIMESTAMP",
@@ -113,7 +113,7 @@ pub async fn set_guild_setting(
     value: SettingValue,
 ) -> Result<(), SettingsStorageError> {
     sqlx::query(
-        "INSERT INTO guild_settings (guild_id, setting_key, setting_value) \
+        "INSERT INTO annie_mei.guild_settings (guild_id, setting_key, setting_value) \
          VALUES ($1, $2, $3) \
          ON CONFLICT (guild_id, setting_key) DO UPDATE \
          SET setting_value = EXCLUDED.setting_value, updated_at = CURRENT_TIMESTAMP",
@@ -141,7 +141,7 @@ pub async fn get_user_setting(
     setting_key: SettingKey,
 ) -> Result<Option<SettingValue>, SettingsStorageError> {
     let row = sqlx::query_as::<_, StoredSettingRow>(
-        "SELECT setting_key, setting_value FROM user_settings \
+        "SELECT setting_key, setting_value FROM annie_mei.user_settings \
          WHERE discord_user_id = $1 AND setting_key = $2",
     )
     .bind(user_discord_id.get().to_string())
@@ -163,7 +163,7 @@ pub async fn get_guild_setting(
     setting_key: SettingKey,
 ) -> Result<Option<SettingValue>, SettingsStorageError> {
     let row = sqlx::query_as::<_, StoredSettingRow>(
-        "SELECT setting_key, setting_value FROM guild_settings \
+        "SELECT setting_key, setting_value FROM annie_mei.guild_settings \
          WHERE guild_id = $1 AND setting_key = $2",
     )
     .bind(guild_id.get().to_string())
@@ -195,7 +195,7 @@ pub async fn resolve_setting_layers(
         .await?;
 
     let user_row = sqlx::query_as::<_, StoredSettingRow>(
-        "SELECT setting_key, setting_value FROM user_settings \
+        "SELECT setting_key, setting_value FROM annie_mei.user_settings \
          WHERE discord_user_id = $1 AND setting_key = $2",
     )
     .bind(user_discord_id.get().to_string())
@@ -207,7 +207,7 @@ pub async fn resolve_setting_layers(
     let guild = match guild_id {
         Some(guild_id) => {
             let row = sqlx::query_as::<_, StoredSettingRow>(
-                "SELECT setting_key, setting_value FROM guild_settings \
+                "SELECT setting_key, setting_value FROM annie_mei.guild_settings \
                  WHERE guild_id = $1 AND setting_key = $2",
             )
             .bind(guild_id.get().to_string())


### PR DESCRIPTION
## Summary

Move bot-owned settings tables into the annie_mei schema, qualify cross-service OAuth reads against the auth schema, and document the operational schema split.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore

## Changes
- e47ac0b4d79259c2d9f2aa1162e07805bbe13c57: qualify bot runtime SQL for annie_mei settings tables and auth OAuth tables
- b58c4053badb17dfaf0197eda9e214f1ef3904b5: add data-preserving migration to move user_settings and guild_settings into annie_mei
- 2016f5f1847b12ca94d92d0044560f95336d9454: document bot/auth schema ownership and OAuth contract updates
- 645468a0cced05821d4f35baa25eeb56763ca840: bump bot version for schema split work
- eebd6aaa10134b27bf47e911bf534fac1f739f2c: harden bot migration duplicate detection across tables, views, and materialized views
- 537627658ed62caf471748951717992131779ba1: mark the bot schema split as a major version change
- 2d958b64954b37bca7334cd0ff7cb2f9b98691ed: document complete SQLx history cutover for existing bot databases

### Notes

The migration uses ALTER TABLE ... SET SCHEMA so existing rows, indexes, constraints, and defaults are preserved. Runtime queries are schema-qualified instead of relying on search_path.

Existing deployments should run the schema move before switching future bot migration tracking into annie_mei._sqlx_migrations. The runbook includes SQL for seeding complete bot migration history when needed.

### High-risk resources

- PostgreSQL schemas: public, annie_mei, auth
- Tables: annie_mei.user_settings, annie_mei.guild_settings, auth.oauth_credentials, auth.oauth_sessions
- Migration history: annie_mei._sqlx_migrations

## Validation
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo test, 173 tests
- [x] Grep verified no unqualified runtime SQL access for OAuth/settings tables in Rust files
- [x] Local Postgres rehearsal: fresh bot migration up/down
- [x] Local Postgres rehearsal: existing public user_settings/guild_settings moved with data preserved
- [x] Local Postgres rehearsal: duplicate public and annie_mei relation state fails safely
- [x] Local Postgres rehearsal: leftover public view plus destination table fails safely
- [x] Reviewer subagent loop completed with no actionable findings

## References

---

This PR description was written by gpt-5.5.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->