### PR TITLE
[ANNIE-190]/avoid existing schema creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -39,9 +39,7 @@ pub async fn create_pool() -> DbPool {
 
 #[instrument(name = "db.run_migrations", skip(pool))]
 pub async fn run_migrations(pool: &DbPool) -> Result<(), sqlx::migrate::MigrateError> {
-    sqlx::query("CREATE SCHEMA IF NOT EXISTS annie_mei")
-        .execute(pool)
-        .await?;
+    ensure_annie_mei_schema(pool).await?;
 
     let mut connection = pool.acquire().await?;
     sqlx::query("SET search_path TO annie_mei, annie_auth, public")
@@ -56,6 +54,24 @@ pub async fn run_migrations(pool: &DbPool) -> Result<(), sqlx::migrate::MigrateE
 
     info!("Database migrations completed");
     Ok(())
+}
+
+#[instrument(name = "db.ensure_annie_mei_schema", skip(pool))]
+async fn ensure_annie_mei_schema(pool: &DbPool) -> Result<(), sqlx::Error> {
+    let schema_exists: Option<String> =
+        sqlx::query_scalar("SELECT to_regnamespace('annie_mei')::text")
+            .fetch_one(pool)
+            .await?;
+
+    if schema_exists.is_some() {
+        return Ok(());
+    }
+
+    match sqlx::query("CREATE SCHEMA annie_mei").execute(pool).await {
+        Ok(_) => Ok(()),
+        Err(sqlx::Error::Database(error)) if error.code().as_deref() == Some("42P06") => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 #[instrument(name = "db.pool_from_context", skip(ctx))]


### PR DESCRIPTION
## Summary

Avoid issuing `CREATE SCHEMA` on every bot startup when the `annie_mei` schema already exists.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- 4f68091: check for `annie_mei` with `to_regnamespace` before creating it, tolerate duplicate-schema races, and bump to 3.0.3

### Notes

The v3.0.2 release build succeeded, but Oracle deploy failed while restarting the service and rolled back. The likely cause is startup attempting `CREATE SCHEMA IF NOT EXISTS annie_mei` with a production role that can use the existing schema but may not have database-level `CREATE` privilege. This change skips schema creation when the schema already exists while still allowing first-run schema creation where the runtime role has permission.

## Validation
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo test, 173 tests
- [x] cargo clippy --all-targets --all-features -- -D warnings

## References

---

This PR description was written by gpt-5.5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->