### PR TITLE
[ANNIE-186]/add configurable guild score opt-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ target/
 opencode.json*
 slate.json*
 .factory/settings.json
+.antigravitycli/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -130,7 +130,13 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 info!("No users found in guild");
                 None
             } else {
-                let data = get_guild_data_for_media(ctx, anime_response, guild_members).await;
+                let data = get_guild_data_for_media(
+                    ctx,
+                    anime_response,
+                    interaction.guild_id,
+                    guild_members,
+                )
+                .await;
                 info!("Guild members data: {} entries", data.len());
                 if data.is_empty() { None } else { Some(data) }
             }

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -130,7 +130,13 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 info!("No users found in guild");
                 None
             } else {
-                let data = get_guild_data_for_media(ctx, manga_response, guild_members).await;
+                let data = get_guild_data_for_media(
+                    ctx,
+                    manga_response,
+                    interaction.guild_id,
+                    guild_members,
+                )
+                .await;
                 info!("Guild members data: {} entries", data.len());
                 if data.is_empty() { None } else { Some(data) }
             }

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -5,7 +5,10 @@ use crate::{
             ResolvedSettingLayers, SettingsStorageError, get_guild_setting, get_user_setting,
             resolve_setting_layers, set_guild_setting, set_user_setting,
         },
-        settings::{ALL_SETTING_KEYS, ALL_SETTING_SCOPES, SettingKey, SettingScope, SettingValue},
+        settings::{
+            ALL_SETTING_KEYS, ALL_SETTING_SCOPES, GuildScoresPreference, SettingKey, SettingScope,
+            SettingValue,
+        },
     },
     utils::{
         database::{DbPool, get_pool_from_context},
@@ -404,6 +407,10 @@ fn plan_settings_write(
         }
     };
 
+    if let Err(message) = validate_value_for_scope(options.scope, value) {
+        return SettingsCommandPlan::Respond(CommandResponse::Content(message));
+    }
+
     match options.scope {
         SettingScope::Effective => SettingsCommandPlan::Respond(CommandResponse::Content(
             "`effective` is read-only because it is resolved from user, guild, and default settings. Choose `user` or `guild` when setting a value."
@@ -431,6 +438,21 @@ fn plan_settings_write(
                 value,
             })
         }
+    }
+}
+
+#[instrument(name = "command.settings.validate_value_for_scope", skip(value))]
+fn validate_value_for_scope(scope: SettingScope, value: SettingValue) -> Result<(), String> {
+    match (scope, value) {
+        (SettingScope::User, SettingValue::GuildScores(GuildScoresPreference::Disabled)) => Err(
+            "Use `opted_out` to exclude yourself from guild scores, or `enabled` to participate. `disabled` is only for guild settings."
+                .to_string(),
+        ),
+        (SettingScope::Guild, SettingValue::GuildScores(GuildScoresPreference::OptedOut)) => Err(
+            "Use `disabled` to turn guild scores off for the server, or `enabled` to allow participating users. `opted_out` is only for user settings."
+                .to_string(),
+        ),
+        _ => Ok(()),
     }
 }
 
@@ -711,6 +733,52 @@ mod tests {
         };
 
         assert_eq!(request.target, SettingsWriteTarget::Guild(GuildId::new(7)));
+    }
+
+    #[test]
+    fn rejects_user_guild_scores_disabled_value() {
+        let options = SettingsCommandOptions {
+            action: SettingsAction::Set,
+            key: SettingKey::GuildScores,
+            scope: SettingScope::User,
+            value: Some("disabled".to_string()),
+        };
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: None,
+        };
+
+        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
+            panic!("expected response")
+        };
+
+        let content = response.unwrap_content();
+        assert!(content.contains("opted_out"));
+        assert!(content.contains("only for guild settings"));
+    }
+
+    #[test]
+    fn rejects_guild_guild_scores_opted_out_value() {
+        let options = SettingsCommandOptions {
+            action: SettingsAction::Set,
+            key: SettingKey::GuildScores,
+            scope: SettingScope::Guild,
+            value: Some("opted_out".to_string()),
+        };
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: Some(Permissions::MANAGE_GUILD),
+        };
+
+        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
+            panic!("expected response")
+        };
+
+        let content = response.unwrap_content();
+        assert!(content.contains("disabled"));
+        assert!(content.contains("only for user settings"));
     }
 
     #[test]

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -407,20 +407,26 @@ fn plan_settings_write(
         }
     };
 
-    if let Err(message) = validate_value_for_scope(options.scope, value) {
-        return SettingsCommandPlan::Respond(CommandResponse::Content(message));
-    }
-
     match options.scope {
         SettingScope::Effective => SettingsCommandPlan::Respond(CommandResponse::Content(
             "`effective` is read-only because it is resolved from user, guild, and default settings. Choose `user` or `guild` when setting a value."
                 .to_string(),
         )),
-        SettingScope::User => SettingsCommandPlan::Write(SettingsWriteRequest {
-            target: SettingsWriteTarget::User(context.user_id),
-            value,
-        }),
+        SettingScope::User => {
+            if let Err(message) = validate_value_for_scope(options.scope, value) {
+                return SettingsCommandPlan::Respond(CommandResponse::Content(message));
+            }
+
+            SettingsCommandPlan::Write(SettingsWriteRequest {
+                target: SettingsWriteTarget::User(context.user_id),
+                value,
+            })
+        },
         SettingScope::Guild => {
+            if let Err(message) = validate_value_for_scope(options.scope, value) {
+                return SettingsCommandPlan::Respond(CommandResponse::Content(message));
+            }
+
             let Some(guild_id) = context.guild_id else {
                 return SettingsCommandPlan::Respond(CommandResponse::Content(
                     "Guild settings can only be changed from inside a server.".to_string(),

--- a/src/models/db/settings.rs
+++ b/src/models/db/settings.rs
@@ -29,6 +29,15 @@ struct UserSettingRow {
     setting_value: String,
 }
 
+impl fmt::Debug for UserSettingRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UserSettingRow")
+            .field("discord_user_id", &"[REDACTED]")
+            .field("setting_value", &"[REDACTED]")
+            .finish()
+    }
+}
+
 impl fmt::Debug for StoredSettingRow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StoredSettingRow")
@@ -284,6 +293,21 @@ fn parse_optional_setting(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn user_setting_row_debug_redacts_sensitive_fields() {
+        let row = UserSettingRow {
+            discord_user_id: "123456789".to_string(),
+            setting_value: "opted_out".to_string(),
+        };
+
+        let debug = format!("{row:?}");
+
+        assert!(debug.contains("UserSettingRow"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("123456789"));
+        assert!(!debug.contains("opted_out"));
+    }
 
     #[test]
     fn stored_setting_debug_redacts_value() {

--- a/src/models/db/settings.rs
+++ b/src/models/db/settings.rs
@@ -1,6 +1,6 @@
 //! SQLx persistence helpers for user and guild settings.
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use serenity::model::prelude::{GuildId, UserId};
 use sqlx::FromRow;
@@ -21,6 +21,12 @@ use crate::{
 pub struct StoredSettingRow {
     pub setting_key: String,
     pub setting_value: String,
+}
+
+#[derive(Clone, PartialEq, Eq, FromRow)]
+struct UserSettingRow {
+    discord_user_id: String,
+    setting_value: String,
 }
 
 impl fmt::Debug for StoredSettingRow {
@@ -172,6 +178,37 @@ pub async fn get_guild_setting(
     .await?;
 
     parse_optional_setting(row, setting_key)
+}
+
+#[instrument(
+    name = "db.settings.get_user_settings_for_discord_ids",
+    skip(pool, user_discord_ids),
+    fields(user_count = user_discord_ids.len(), setting_key = %setting_key.as_str())
+)]
+pub async fn get_user_settings_for_discord_ids(
+    pool: &DbPool,
+    user_discord_ids: &[String],
+    setting_key: SettingKey,
+) -> Result<HashMap<String, SettingValue>, SettingsStorageError> {
+    if user_discord_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = sqlx::query_as::<_, UserSettingRow>(
+        "SELECT discord_user_id, setting_value FROM annie_mei.user_settings \
+         WHERE discord_user_id = ANY($1) AND setting_key = $2",
+    )
+    .bind(user_discord_ids)
+    .bind(setting_key.as_str())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            let value = setting_key.parse_value(&row.setting_value)?;
+            Ok((row.discord_user_id, value))
+        })
+        .collect()
 }
 
 #[instrument(

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -320,7 +320,10 @@ pub fn resolve_setting(key: SettingKey, values: ScopedSettingValues) -> Resolved
 
 #[instrument(name = "settings.resolve_guild_scores", skip(values))]
 fn resolve_guild_scores_setting(values: ScopedSettingValues) -> ResolvedSetting {
-    if let Some(SettingValue::GuildScores(GuildScoresPreference::Disabled)) = values.guild {
+    if matches!(
+        values.guild,
+        Some(SettingValue::GuildScores(GuildScoresPreference::Disabled))
+    ) {
         return ResolvedSetting {
             key: SettingKey::GuildScores,
             value: SettingValue::GuildScores(GuildScoresPreference::Disabled),
@@ -328,7 +331,10 @@ fn resolve_guild_scores_setting(values: ScopedSettingValues) -> ResolvedSetting 
         };
     }
 
-    if let Some(SettingValue::GuildScores(GuildScoresPreference::OptedOut)) = values.user {
+    if matches!(
+        values.user,
+        Some(SettingValue::GuildScores(GuildScoresPreference::OptedOut))
+    ) {
         return ResolvedSetting {
             key: SettingKey::GuildScores,
             value: SettingValue::GuildScores(GuildScoresPreference::OptedOut),

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -291,6 +291,10 @@ pub struct ScopedSettingValues {
 
 #[instrument(name = "settings.resolve", skip(values), fields(setting_key = %key.as_str()))]
 pub fn resolve_setting(key: SettingKey, values: ScopedSettingValues) -> ResolvedSetting {
+    if key == SettingKey::GuildScores {
+        return resolve_guild_scores_setting(values);
+    }
+
     if let Some(value) = values.user {
         return ResolvedSetting {
             key,
@@ -310,6 +314,47 @@ pub fn resolve_setting(key: SettingKey, values: ScopedSettingValues) -> Resolved
     ResolvedSetting {
         key,
         value: key.default_value(),
+        source: SettingSource::Default,
+    }
+}
+
+#[instrument(name = "settings.resolve_guild_scores", skip(values))]
+fn resolve_guild_scores_setting(values: ScopedSettingValues) -> ResolvedSetting {
+    if let Some(SettingValue::GuildScores(GuildScoresPreference::Disabled)) = values.guild {
+        return ResolvedSetting {
+            key: SettingKey::GuildScores,
+            value: SettingValue::GuildScores(GuildScoresPreference::Disabled),
+            source: SettingSource::Guild,
+        };
+    }
+
+    if let Some(SettingValue::GuildScores(GuildScoresPreference::OptedOut)) = values.user {
+        return ResolvedSetting {
+            key: SettingKey::GuildScores,
+            value: SettingValue::GuildScores(GuildScoresPreference::OptedOut),
+            source: SettingSource::User,
+        };
+    }
+
+    if let Some(value @ SettingValue::GuildScores(_)) = values.user {
+        return ResolvedSetting {
+            key: SettingKey::GuildScores,
+            value,
+            source: SettingSource::User,
+        };
+    }
+
+    if let Some(value @ SettingValue::GuildScores(_)) = values.guild {
+        return ResolvedSetting {
+            key: SettingKey::GuildScores,
+            value,
+            source: SettingSource::Guild,
+        };
+    }
+
+    ResolvedSetting {
+        key: SettingKey::GuildScores,
+        value: SettingKey::GuildScores.default_value(),
         source: SettingSource::Default,
     }
 }
@@ -418,6 +463,37 @@ mod tests {
         assert_eq!(
             default_resolved.value,
             SettingKey::TitleDisplay.default_value()
+        );
+    }
+
+    #[test]
+    fn resolve_setting_uses_guild_scores_precedence() {
+        let resolved = resolve_setting(
+            SettingKey::GuildScores,
+            ScopedSettingValues {
+                user: Some(SettingValue::GuildScores(GuildScoresPreference::Enabled)),
+                guild: Some(SettingValue::GuildScores(GuildScoresPreference::Disabled)),
+            },
+        );
+
+        assert_eq!(resolved.source, SettingSource::Guild);
+        assert_eq!(
+            resolved.value,
+            SettingValue::GuildScores(GuildScoresPreference::Disabled)
+        );
+
+        let resolved = resolve_setting(
+            SettingKey::GuildScores,
+            ScopedSettingValues {
+                user: Some(SettingValue::GuildScores(GuildScoresPreference::OptedOut)),
+                guild: Some(SettingValue::GuildScores(GuildScoresPreference::Enabled)),
+            },
+        );
+
+        assert_eq!(resolved.source, SettingSource::User);
+        assert_eq!(
+            resolved.value,
+            SettingValue::GuildScores(GuildScoresPreference::OptedOut)
         );
     }
 

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -65,16 +65,21 @@ impl fmt::Display for SettingSource {
 pub enum SettingKey {
     TitleDisplay,
     AnalyticsPrivacy,
+    GuildScores,
 }
 
-pub const ALL_SETTING_KEYS: [SettingKey; 2] =
-    [SettingKey::TitleDisplay, SettingKey::AnalyticsPrivacy];
+pub const ALL_SETTING_KEYS: [SettingKey; 3] = [
+    SettingKey::TitleDisplay,
+    SettingKey::AnalyticsPrivacy,
+    SettingKey::GuildScores,
+];
 
 impl SettingKey {
     pub fn parse(raw: &str) -> Option<Self> {
         match normalize_token(raw).as_str() {
             "title_display" | "title" | "titles" => Some(Self::TitleDisplay),
             "analytics_privacy" | "analytics" | "privacy" => Some(Self::AnalyticsPrivacy),
+            "guild_scores" | "guild_score" | "scores" => Some(Self::GuildScores),
             _ => None,
         }
     }
@@ -83,6 +88,7 @@ impl SettingKey {
         match self {
             Self::TitleDisplay => "title_display",
             Self::AnalyticsPrivacy => "analytics_privacy",
+            Self::GuildScores => "guild_scores",
         }
     }
 
@@ -90,6 +96,7 @@ impl SettingKey {
         match self {
             Self::TitleDisplay => "Title display",
             Self::AnalyticsPrivacy => "Analytics privacy",
+            Self::GuildScores => "Guild scores",
         }
     }
 
@@ -98,6 +105,9 @@ impl SettingKey {
             Self::TitleDisplay => "Which AniList title variant Annie Mei should prefer.",
             Self::AnalyticsPrivacy => {
                 "Whether analytics should use the standard telemetry path or opt out where supported."
+            }
+            Self::GuildScores => {
+                "Whether guild score displays are enabled for a server and whether a user participates. Guild disabled wins over user participation; users who opt out are excluded."
             }
         }
     }
@@ -108,6 +118,7 @@ impl SettingKey {
             Self::AnalyticsPrivacy => {
                 SettingValue::AnalyticsPrivacy(AnalyticsPrivacyPreference::Standard)
             }
+            Self::GuildScores => SettingValue::GuildScores(GuildScoresPreference::Enabled),
         }
     }
 
@@ -115,6 +126,7 @@ impl SettingKey {
         match self {
             Self::TitleDisplay => &["matched", "romaji", "english", "native"],
             Self::AnalyticsPrivacy => &["standard", "opted_out"],
+            Self::GuildScores => &["enabled", "disabled", "opted_out"],
         }
     }
 
@@ -143,6 +155,18 @@ impl SettingKey {
                 }
                 _ => return Err(SettingValidationError::new(self, raw)),
             },
+            Self::GuildScores => match normalized.as_str() {
+                "enabled" | "enable" | "on" | "default" | "participating" => {
+                    SettingValue::GuildScores(GuildScoresPreference::Enabled)
+                }
+                "disabled" | "disable" | "off" => {
+                    SettingValue::GuildScores(GuildScoresPreference::Disabled)
+                }
+                "opted_out" | "optout" | "private" | "excluded" => {
+                    SettingValue::GuildScores(GuildScoresPreference::OptedOut)
+                }
+                _ => return Err(SettingValidationError::new(self, raw)),
+            },
         };
 
         Ok(value)
@@ -164,9 +188,17 @@ pub enum AnalyticsPrivacyPreference {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuildScoresPreference {
+    Enabled,
+    Disabled,
+    OptedOut,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingValue {
     TitleDisplay(TitleDisplayPreference),
     AnalyticsPrivacy(AnalyticsPrivacyPreference),
+    GuildScores(GuildScoresPreference),
 }
 
 impl SettingValue {
@@ -174,6 +206,7 @@ impl SettingValue {
         match self {
             Self::TitleDisplay(_) => SettingKey::TitleDisplay,
             Self::AnalyticsPrivacy(_) => SettingKey::AnalyticsPrivacy,
+            Self::GuildScores(_) => SettingKey::GuildScores,
         }
     }
 
@@ -185,6 +218,9 @@ impl SettingValue {
             Self::TitleDisplay(TitleDisplayPreference::Native) => "native",
             Self::AnalyticsPrivacy(AnalyticsPrivacyPreference::Standard) => "standard",
             Self::AnalyticsPrivacy(AnalyticsPrivacyPreference::OptedOut) => "opted_out",
+            Self::GuildScores(GuildScoresPreference::Enabled) => "enabled",
+            Self::GuildScores(GuildScoresPreference::Disabled) => "disabled",
+            Self::GuildScores(GuildScoresPreference::OptedOut) => "opted_out",
         }
     }
 
@@ -198,6 +234,9 @@ impl SettingValue {
             Self::AnalyticsPrivacy(AnalyticsPrivacyPreference::OptedOut) => {
                 "opted out of analytics"
             }
+            Self::GuildScores(GuildScoresPreference::Enabled) => "guild scores enabled",
+            Self::GuildScores(GuildScoresPreference::Disabled) => "guild scores disabled",
+            Self::GuildScores(GuildScoresPreference::OptedOut) => "opted out of guild scores",
         }
     }
 }
@@ -275,6 +314,26 @@ pub fn resolve_setting(key: SettingKey, values: ScopedSettingValues) -> Resolved
     }
 }
 
+#[instrument(name = "settings.guild_scores_enabled", skip(guild_value))]
+pub fn guild_scores_enabled(guild_value: Option<SettingValue>) -> bool {
+    match guild_value {
+        Some(SettingValue::GuildScores(GuildScoresPreference::Disabled)) => false,
+        Some(SettingValue::GuildScores(GuildScoresPreference::OptedOut)) => false,
+        Some(SettingValue::GuildScores(GuildScoresPreference::Enabled)) | None => true,
+        Some(_) => true,
+    }
+}
+
+#[instrument(name = "settings.user_participates_in_guild_scores", skip(user_value))]
+pub fn user_participates_in_guild_scores(user_value: Option<SettingValue>) -> bool {
+    match user_value {
+        Some(SettingValue::GuildScores(GuildScoresPreference::OptedOut)) => false,
+        Some(SettingValue::GuildScores(GuildScoresPreference::Disabled)) => false,
+        Some(SettingValue::GuildScores(GuildScoresPreference::Enabled)) | None => true,
+        Some(_) => true,
+    }
+}
+
 fn normalize_token(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace([' ', '-'], "_")
 }
@@ -289,7 +348,7 @@ mod tests {
             SettingKey::parse("title-display"),
             Some(SettingKey::TitleDisplay)
         );
-        assert_eq!(SettingKey::parse("scores"), None);
+        assert_eq!(SettingKey::parse("scores"), Some(SettingKey::GuildScores));
         assert_eq!(
             SettingKey::parse("privacy"),
             Some(SettingKey::AnalyticsPrivacy)
@@ -360,5 +419,33 @@ mod tests {
             default_resolved.value,
             SettingKey::TitleDisplay.default_value()
         );
+    }
+
+    #[test]
+    fn guild_scores_default_enabled_with_guild_disable_precedence() {
+        assert!(guild_scores_enabled(None));
+        assert!(guild_scores_enabled(Some(SettingValue::GuildScores(
+            GuildScoresPreference::Enabled
+        ))));
+        assert!(!guild_scores_enabled(Some(SettingValue::GuildScores(
+            GuildScoresPreference::Disabled
+        ))));
+        assert!(!guild_scores_enabled(Some(SettingValue::GuildScores(
+            GuildScoresPreference::OptedOut
+        ))));
+    }
+
+    #[test]
+    fn guild_scores_user_opt_out_excludes_participant() {
+        assert!(user_participates_in_guild_scores(None));
+        assert!(user_participates_in_guild_scores(Some(
+            SettingValue::GuildScores(GuildScoresPreference::Enabled)
+        )));
+        assert!(!user_participates_in_guild_scores(Some(
+            SettingValue::GuildScores(GuildScoresPreference::OptedOut)
+        )));
+        assert!(!user_participates_in_guild_scores(Some(
+            SettingValue::GuildScores(GuildScoresPreference::Disabled)
+        )));
     }
 }

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::{
         database::get_pool_from_context,
         requests::anilist::send_request,
-        settings::{participates_in_guild_scores, resolve_guild_scores_enabled},
+        settings::{participates_in_guild_scores, resolve_guild_scores_enabled_with_pool},
     },
 };
 
@@ -89,15 +89,15 @@ pub async fn get_guild_data_for_media<T: Transformers>(
     guild_id: Option<GuildId>,
     guild_members: Vec<UserId>,
 ) -> HashMap<u64, MediaListData> {
-    if !resolve_guild_scores_enabled(ctx, guild_id).await {
-        info!("Guild scores are disabled for this interaction");
-        return HashMap::new();
-    }
-
     let Some(database_pool) = get_pool_from_context(ctx).await else {
         error!("Database pool is not available in Serenity context");
         return HashMap::new();
     };
+
+    if !resolve_guild_scores_enabled_with_pool(&database_pool, guild_id).await {
+        info!("Guild scores are disabled for this interaction");
+        return HashMap::new();
+    }
 
     let anilist_users =
         match OAuthCredential::get_by_discord_ids(guild_members, &database_pool).await {

--- a/src/utils/guild.rs
+++ b/src/utils/guild.rs
@@ -2,16 +2,22 @@ use std::collections::HashMap;
 
 use crate::{
     models::{
-        db::oauth_credential::OAuthCredential, transformers::Transformers,
+        db::{oauth_credential::OAuthCredential, settings::get_user_settings_for_discord_ids},
+        settings::SettingKey,
+        transformers::Transformers,
         user_media_list::MediaListData,
     },
-    utils::{database::get_pool_from_context, requests::anilist::send_request},
+    utils::{
+        database::get_pool_from_context,
+        requests::anilist::send_request,
+        settings::{participates_in_guild_scores, resolve_guild_scores_enabled},
+    },
 };
 
 use serenity::{
     all::CommandInteraction,
     client::Context,
-    model::prelude::{Guild, UserId},
+    model::prelude::{Guild, GuildId, UserId},
 };
 
 use serde::Deserialize;
@@ -80,8 +86,14 @@ pub fn get_current_guild_members(ctx: &Context, interaction: &CommandInteraction
 pub async fn get_guild_data_for_media<T: Transformers>(
     ctx: &Context,
     media: &T,
+    guild_id: Option<GuildId>,
     guild_members: Vec<UserId>,
 ) -> HashMap<u64, MediaListData> {
+    if !resolve_guild_scores_enabled(ctx, guild_id).await {
+        info!("Guild scores are disabled for this interaction");
+        return HashMap::new();
+    }
+
     let Some(database_pool) = get_pool_from_context(ctx).await else {
         error!("Database pool is not available in Serenity context");
         return HashMap::new();
@@ -96,7 +108,45 @@ pub async fn get_guild_data_for_media<T: Transformers>(
             }
         };
 
-    get_guild_anilist_data(anilist_users, media.get_id(), media.get_type().to_owned()).await
+    let participating_users =
+        match filter_guild_score_participants(anilist_users, &database_pool).await {
+            Ok(users) => users,
+            Err(err) => {
+                error!(error = %err, "Failed to resolve guild score opt-outs");
+                return HashMap::new();
+            }
+        };
+
+    get_guild_anilist_data(
+        participating_users,
+        media.get_id(),
+        media.get_type().to_owned(),
+    )
+    .await
+}
+
+#[instrument(name = "guild.filter_score_participants", skip(guild_members, database_pool), fields(member_count = guild_members.len()))]
+async fn filter_guild_score_participants(
+    guild_members: Vec<OAuthCredential>,
+    database_pool: &crate::utils::database::DbPool,
+) -> Result<Vec<OAuthCredential>, crate::models::db::settings::SettingsStorageError> {
+    let discord_user_ids = guild_members
+        .iter()
+        .map(|credential| credential.discord_user_id.clone())
+        .collect::<Vec<_>>();
+    let user_settings = get_user_settings_for_discord_ids(
+        database_pool,
+        &discord_user_ids,
+        SettingKey::GuildScores,
+    )
+    .await?;
+
+    Ok(guild_members
+        .into_iter()
+        .filter(|credential| {
+            participates_in_guild_scores(user_settings.get(&credential.discord_user_id).copied())
+        })
+        .collect())
 }
 
 #[instrument(name = "guild.fetch_anilist_data", skip(guild_members, media_type), fields(member_count = guild_members.len(), media_id = media_id, media_type = %media_type))]
@@ -170,7 +220,21 @@ async fn get_guild_anilist_data(
 #[cfg(test)]
 mod tests {
     use super::build_batch_media_list_query;
-    use crate::models::db::oauth_credential::OAuthCredential;
+    use crate::models::{
+        db::oauth_credential::OAuthCredential,
+        settings::{GuildScoresPreference, SettingValue, user_participates_in_guild_scores},
+    };
+
+    #[test]
+    fn guild_score_participation_defaults_to_include_and_honors_opt_out() {
+        assert!(user_participates_in_guild_scores(None));
+        assert!(user_participates_in_guild_scores(Some(
+            SettingValue::GuildScores(GuildScoresPreference::Enabled)
+        )));
+        assert!(!user_participates_in_guild_scores(Some(
+            SettingValue::GuildScores(GuildScoresPreference::OptedOut)
+        )));
+    }
 
     #[test]
     fn build_batch_media_list_query_adds_one_lookup_per_user() {

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -70,7 +70,6 @@ pub async fn resolve_guild_scores_enabled(ctx: &Context, guild_id: Option<GuildI
     }
 }
 
-#[instrument(name = "settings.user_participates_in_guild_scores", skip(value))]
 pub fn participates_in_guild_scores(value: Option<SettingValue>) -> bool {
     user_participates_in_guild_scores(value)
 }

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -4,7 +4,10 @@ use tracing::{instrument, warn};
 use crate::{
     models::{
         db::settings::resolve_setting_layers,
-        settings::{SettingKey, SettingValue, TitleDisplayPreference},
+        settings::{
+            SettingKey, SettingValue, TitleDisplayPreference, guild_scores_enabled,
+            user_participates_in_guild_scores,
+        },
     },
     utils::database::get_pool_from_context,
 };
@@ -23,8 +26,8 @@ pub async fn resolve_title_display_preference(
     match resolve_setting_layers(&pool, user_id, guild_id, SettingKey::TitleDisplay).await {
         Ok(layers) => match layers.effective.value {
             SettingValue::TitleDisplay(preference) => preference,
-            SettingValue::AnalyticsPrivacy(_) => {
-                warn!("Unexpected analytics privacy value for title display key; using default");
+            SettingValue::AnalyticsPrivacy(_) | SettingValue::GuildScores(_) => {
+                warn!("Unexpected non-title value for title display key; using default");
                 default_title_display_preference()
             }
         },
@@ -39,6 +42,35 @@ pub async fn resolve_title_display_preference(
 fn default_title_display_preference() -> TitleDisplayPreference {
     match SettingKey::TitleDisplay.default_value() {
         SettingValue::TitleDisplay(preference) => preference,
-        SettingValue::AnalyticsPrivacy(_) => TitleDisplayPreference::Matched,
+        SettingValue::AnalyticsPrivacy(_) | SettingValue::GuildScores(_) => {
+            TitleDisplayPreference::Matched
+        }
     }
+}
+
+#[instrument(name = "settings.resolve_guild_scores_enabled", skip(ctx, guild_id))]
+pub async fn resolve_guild_scores_enabled(ctx: &Context, guild_id: Option<GuildId>) -> bool {
+    let Some(guild_id) = guild_id else {
+        return false;
+    };
+
+    let Some(pool) = get_pool_from_context(ctx).await else {
+        warn!("Database pool unavailable; disabling guild scores for privacy");
+        return false;
+    };
+
+    match crate::models::db::settings::get_guild_setting(&pool, guild_id, SettingKey::GuildScores)
+        .await
+    {
+        Ok(value) => guild_scores_enabled(value),
+        Err(error) => {
+            warn!(error = %error, "Failed to resolve guild scores setting; disabling for privacy");
+            false
+        }
+    }
+}
+
+#[instrument(name = "settings.user_participates_in_guild_scores", skip(value))]
+pub fn participates_in_guild_scores(value: Option<SettingValue>) -> bool {
+    user_participates_in_guild_scores(value)
 }

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -3,13 +3,13 @@ use tracing::{instrument, warn};
 
 use crate::{
     models::{
-        db::settings::resolve_setting_layers,
+        db::settings::{get_guild_setting, resolve_setting_layers},
         settings::{
             SettingKey, SettingValue, TitleDisplayPreference, guild_scores_enabled,
             user_participates_in_guild_scores,
         },
     },
-    utils::database::get_pool_from_context,
+    utils::database::{DbPool, get_pool_from_context},
 };
 
 #[instrument(name = "settings.resolve_title_display", skip(ctx, user_id, guild_id))]
@@ -48,20 +48,19 @@ fn default_title_display_preference() -> TitleDisplayPreference {
     }
 }
 
-#[instrument(name = "settings.resolve_guild_scores_enabled", skip(ctx, guild_id))]
-pub async fn resolve_guild_scores_enabled(ctx: &Context, guild_id: Option<GuildId>) -> bool {
+#[instrument(
+    name = "settings.resolve_guild_scores_enabled_with_pool",
+    skip(pool, guild_id)
+)]
+pub async fn resolve_guild_scores_enabled_with_pool(
+    pool: &DbPool,
+    guild_id: Option<GuildId>,
+) -> bool {
     let Some(guild_id) = guild_id else {
         return false;
     };
 
-    let Some(pool) = get_pool_from_context(ctx).await else {
-        warn!("Database pool unavailable; disabling guild scores for privacy");
-        return false;
-    };
-
-    match crate::models::db::settings::get_guild_setting(&pool, guild_id, SettingKey::GuildScores)
-        .await
-    {
+    match get_guild_setting(pool, guild_id, SettingKey::GuildScores).await {
         Ok(value) => guild_scores_enabled(value),
         Err(error) => {
             warn!(error = %error, "Failed to resolve guild scores setting; disabling for privacy");

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -70,6 +70,7 @@ pub async fn resolve_guild_scores_enabled(ctx: &Context, guild_id: Option<GuildI
     }
 }
 
+#[instrument(name = "settings.participates_in_guild_scores", skip(value))]
 pub fn participates_in_guild_scores(value: Option<SettingValue>) -> bool {
     user_participates_in_guild_scores(value)
 }


### PR DESCRIPTION
## Summary

Add configurable guild score controls so servers can disable guild score display and users can opt out of participating in guild score features.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 6cab1ffdcf4e3cda215c37f057d910a568249f8d: Added the `guild_scores` setting, allowed values, explicit defaults, precedence helpers, and unit coverage for enabled/disabled/opt-out/no-config semantics.
- 3b76098e5fc04f78d2f6e001f9070427a33be3a3: Applied guild score settings to anime and manga guild score fetching, including guild-level disable checks and user opt-out filtering before AniList aggregation.
- 6b0e0f1f208daa0fb336807bb1cc0512b5162e9a: Bumped the crate version to 3.2.0 and updated Cargo.lock.

### Notes

Guild score settings preserve current behavior when unset: guild score display remains enabled and linked users participate unless they explicitly opt out. If the bot cannot resolve guild score settings, guild score display is disabled for privacy.

## Validation
- [x] cargo fmt
- [x] cargo check
- [x] cargo test
- [x] cargo clippy -- -D warnings

---

This PR description was written by GPT-5 Codex.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->