### PR TITLE
[ANNIE-191]/expose-bot-version-in-logs-cli-and-deploy-marker

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -203,24 +203,26 @@ jobs:
               echo "Missing mei.jpg"
               exit 1
             fi
-            # Backup current binary
+            # Backup current binary and version marker
             cp annie-mei annie-mei.backup || true
+            cp VERSION VERSION.backup || true
             # Stop, replace, start
             sudo systemctl stop annie-mei
             mv annie-mei.new/annie-mei annie-mei
             cp annie-mei.new/mei.jpg mei.jpg
             rm -rf annie-mei.new
+            printf '%s\t%s\n' "${{ needs.build.outputs.tag_name }}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > VERSION
             sudo systemctl start annie-mei
             # Verify service started
             sleep 2
             sudo systemctl is-active annie-mei || {
               echo "Service failed to start, rolling back"
               mv annie-mei.backup annie-mei
+              cp VERSION.backup VERSION || true
               sudo systemctl start annie-mei
               exit 1
             }
-            rm -f annie-mei.backup
-            printf '%s\t%s\n' "${{ needs.build.outputs.tag_name }}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > VERSION
+            rm -f annie-mei.backup VERSION.backup
           EOF
       - name: Verify /healthz over Cloudflare
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,6 +23,7 @@ jobs:
     container: rust:1-bullseye
     outputs:
       is_release: ${{ steps.release-meta.outputs.is_release }}
+      tag_name: ${{ steps.release-meta.outputs.tag_name }}
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -219,6 +220,7 @@ jobs:
               exit 1
             }
             rm -f annie-mei.backup
+            printf '%s\t%s\n' "${{ needs.build.outputs.tag_name }}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > VERSION
           EOF
       - name: Verify /healthz over Cloudflare
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use utils::{
 /// Annie Mei Discord Bot
 #[derive(Parser)]
 #[command(name = "annie-mei")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "A Discord bot for anime and manga information", long_about = None)]
 struct Cli {
     #[command(subcommand)]
@@ -184,6 +185,8 @@ async fn main() {
     }
 
     // Default: run the bot
+    info!(version = env!("CARGO_PKG_VERSION"), "Annie Mei starting");
+
     install_rustls_crypto_provider();
 
     let environment = env::var(ENV).expect("Expected an environment in the environment");

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,8 +185,6 @@ async fn main() {
     }
 
     // Default: run the bot
-    info!(version = env!("CARGO_PKG_VERSION"), "Annie Mei starting");
-
     install_rustls_crypto_provider();
 
     let environment = env::var(ENV).expect("Expected an environment in the environment");
@@ -247,6 +245,7 @@ async fn main() {
 
     subscriber.with(sentry_tracing::layer()).init();
 
+    info!(version = env!("CARGO_PKG_VERSION"), "Annie Mei starting");
     info!(model = %configured_model_name(), "LLM model configured");
     let posthog_client = PostHogClient::from_env().map(Arc::new);
     let gemini_client = match GeminiClient::from_env_with_system_prompt(


### PR DESCRIPTION
## Summary

Add clear runtime/deploy version reporting for Annie Mei so we can quickly tell which binary is running on a server.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 49f915f: feat(bot): log version on startup and add --version CLI flag
- 0588b08: chore(ci): write deploy VERSION marker on release deploy
- 8c27bbc: chore(release): bump version to 3.3.0

## Validation
- [x] cargo check
- [x] cargo clippy
- [x] cargo fmt
- [x] Verified --version prints correct version

---

This PR description was written by claude-sonnet-4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->