### PR TITLE
[ANNIE-187]/add configurable analytics privacy opt-out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -25,9 +25,11 @@ If you choose to link your AniList account with `/register`, Annie Mei and its a
 
 AniList linking is optional. Commands that do not require an AniList link can still be used without linking an account.
 
-### Logs, diagnostics, and error reports
+### Logs, diagnostics, analytics, and error reports
 
-Annie Mei may collect operational logs, diagnostics, and error reports to keep the service reliable and investigate failures. Discord user IDs are hashed or fingerprinted before being attached to application logs or Sentry diagnostics. Error reports may include command names, high-level execution context, and sanitized error details. Credential-bearing URLs are redacted before being sent to application logs or Sentry.
+Annie Mei may collect operational logs, diagnostics, analytics, and error reports to keep the service reliable, understand feature usage, and investigate failures. Discord user IDs and guild IDs are hashed or fingerprinted before being attached to application logs, Sentry diagnostics, or analytics events. Error reports and analytics events may include command names, high-level execution context, bot version, environment, latency, success or failure status, model names, and token counts.
+
+Some features, such as `/search`, use an LLM provider to interpret user-provided search text. When LLM analytics content capture is enabled, analytics events may include the LLM input or output needed to debug and improve that feature, such as the search query, prompt payload, or model response.
 
 ### Cache and infrastructure data
 
@@ -51,7 +53,9 @@ Annie Mei uses third-party services to operate and provide features, including:
 - Discord for bot interactions.
 - AniList for anime, manga, character, user, and OAuth data.
 - MyAnimeList and Spotify for theme song metadata and links.
+- Gemini or another configured LLM provider for natural-language search interpretation.
 - Sentry for error reporting and diagnostics.
+- PostHog for product and LLM analytics when configured.
 - Postgres hosting, Redis hosting, secret management, and deployment providers for infrastructure operations.
 
 These services process data under their own terms and privacy policies.
@@ -70,7 +74,9 @@ Annie Mei does not sell personal information. Information is shared only as need
 
 You can avoid optional AniList account processing by not using `/register`. If you have linked an AniList account, you can use `/unregister confirmation:Confirm unlink` in Discord to unlink your AniList account from Annie Mei's bot features and delete active stored AniList OAuth credentials associated with your Discord account. You may also revoke Annie Mei's access from AniList where supported.
 
-Unlinking in Discord may not remove retained operational logs, diagnostics, caches, or backups. To request deletion of any remaining stored Annie Mei account-link data, open an issue at:
+You can use `/settings` to view or update your user-level `analytics_privacy` preference. The default `standard` setting allows supported analytics to include raw user-provided content, such as LLM search queries, prompt payloads, or model outputs, when content capture is enabled. Setting `analytics_privacy` to `opted_out` disables raw query, prompt, and LLM output capture in supported analytics and observability paths. Annie Mei may still collect pseudonymous operational telemetry for opted-out users, including hashed Discord user or guild IDs, command names, success or failure status, latency, model names, token counts, bot version, and environment.
+
+Unlinking in Discord or opting out of analytics content capture may not remove retained operational logs, diagnostics, analytics events, caches, or backups. To request deletion of any remaining stored Annie Mei account-link data, open an issue at:
 
 https://github.com/annie-mei/annie-mei/issues
 

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -16,7 +16,7 @@ use crate::{
         llm::{LlmError, get_gemini_client_from_context},
         posthog::LlmTelemetryContext,
         privacy::{configure_sentry_scope, hash_discord_id, hash_user_id},
-        settings::resolve_title_display_preference,
+        settings::{resolve_analytics_privacy_preference, resolve_title_display_preference},
         statics::ENV,
         statics::NSFW_NOT_ALLOWED,
     },
@@ -316,17 +316,27 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let search_result_future = async {
         let intent = match get_gemini_client_from_context(ctx).await {
             Some(client) => {
+                let analytics_privacy = resolve_analytics_privacy_preference(ctx, user.id).await;
+                let analytics_opted_out = analytics_privacy.opted_out();
                 let telemetry_context = LlmTelemetryContext {
-                    distinct_id: Some(hash_user_id(user.id.get()).to_string()),
-                    guild_id: interaction
-                        .guild_id
-                        .map(|guild_id| hash_discord_id(guild_id.get()).to_string()),
+                    distinct_id: (!analytics_opted_out)
+                        .then(|| hash_user_id(user.id.get()).to_string()),
+                    guild_id: (!analytics_opted_out)
+                        .then(|| {
+                            interaction
+                                .guild_id
+                                .map(|guild_id| hash_discord_id(guild_id.get()).to_string())
+                        })
+                        .flatten(),
                     command: Some("search".to_string()),
                     environment: std::env::var(ENV).ok(),
-                    input: Some(json!([
-                        { "role": "system", "content": SEARCH_SYSTEM_PROMPT },
-                        { "role": "user", "content": query },
-                    ])),
+                    input: (!analytics_opted_out).then(|| {
+                        json!([
+                            { "role": "system", "content": SEARCH_SYSTEM_PROMPT },
+                            { "role": "user", "content": query },
+                        ])
+                    }),
+                    capture_content: !analytics_opted_out,
                 };
                 let user_message = format_intent_user_message(&query);
 

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -309,25 +309,25 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         return;
     }
 
-    configure_sentry_scope("Search", user.id.get(), Some(json!(query.clone())));
+    let analytics_privacy = resolve_analytics_privacy_preference(ctx, user.id).await;
+    let analytics_opted_out = analytics_privacy.opted_out();
+
+    configure_sentry_scope(
+        "Search",
+        user.id.get(),
+        (!analytics_opted_out).then(|| json!(query.clone())),
+    );
 
     info!("Got command 'search'");
 
     let search_result_future = async {
         let intent = match get_gemini_client_from_context(ctx).await {
             Some(client) => {
-                let analytics_privacy = resolve_analytics_privacy_preference(ctx, user.id).await;
-                let analytics_opted_out = analytics_privacy.opted_out();
                 let telemetry_context = LlmTelemetryContext {
-                    distinct_id: (!analytics_opted_out)
-                        .then(|| hash_user_id(user.id.get()).to_string()),
-                    guild_id: (!analytics_opted_out)
-                        .then(|| {
-                            interaction
-                                .guild_id
-                                .map(|guild_id| hash_discord_id(guild_id.get()).to_string())
-                        })
-                        .flatten(),
+                    distinct_id: Some(hash_user_id(user.id.get()).to_string()),
+                    guild_id: interaction
+                        .guild_id
+                        .map(|guild_id| hash_discord_id(guild_id.get()).to_string()),
                     command: Some("search".to_string()),
                     environment: std::env::var(ENV).ok(),
                     input: (!analytics_opted_out).then(|| {

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -454,6 +454,10 @@ fn validate_value_for_scope(scope: SettingScope, value: SettingValue) -> Result<
             "Use `opted_out` to exclude yourself from guild scores, or `enabled` to participate. `disabled` is only for guild settings."
                 .to_string(),
         ),
+        (SettingScope::Guild, SettingValue::AnalyticsPrivacy(_)) => Err(
+            "Analytics privacy is a user-level setting. Choose the `user` scope to update your own analytics preference."
+                .to_string(),
+        ),
         (SettingScope::Guild, SettingValue::GuildScores(GuildScoresPreference::OptedOut)) => Err(
             "Use `disabled` to turn guild scores off for the server, or `enabled` to allow participating users. `opted_out` is only for user settings."
                 .to_string(),
@@ -697,9 +701,9 @@ mod tests {
     fn allows_guild_write_with_manage_guild_permission() {
         let options = SettingsCommandOptions {
             action: SettingsAction::Set,
-            key: SettingKey::AnalyticsPrivacy,
+            key: SettingKey::TitleDisplay,
             scope: SettingScope::Guild,
-            value: Some("opted_out".to_string()),
+            value: Some("romaji".to_string()),
         };
         let context = SettingsContext {
             user_id: UserId::new(42),
@@ -714,9 +718,7 @@ mod tests {
         assert_eq!(request.target, SettingsWriteTarget::Guild(GuildId::new(7)));
         assert_eq!(
             request.value,
-            SettingKey::AnalyticsPrivacy
-                .parse_value("opted_out")
-                .unwrap()
+            SettingKey::TitleDisplay.parse_value("romaji").unwrap()
         );
     }
 
@@ -724,9 +726,9 @@ mod tests {
     fn allows_guild_write_with_administrator_permission() {
         let options = SettingsCommandOptions {
             action: SettingsAction::Set,
-            key: SettingKey::AnalyticsPrivacy,
+            key: SettingKey::TitleDisplay,
             scope: SettingScope::Guild,
-            value: Some("opted_out".to_string()),
+            value: Some("romaji".to_string()),
         };
         let context = SettingsContext {
             user_id: UserId::new(42),
@@ -739,6 +741,27 @@ mod tests {
         };
 
         assert_eq!(request.target, SettingsWriteTarget::Guild(GuildId::new(7)));
+    }
+
+    #[test]
+    fn rejects_guild_analytics_privacy_value() {
+        let options = SettingsCommandOptions {
+            action: SettingsAction::Set,
+            key: SettingKey::AnalyticsPrivacy,
+            scope: SettingScope::Guild,
+            value: Some("opted_out".to_string()),
+        };
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: Some(Permissions::MANAGE_GUILD),
+        };
+
+        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
+            panic!("expected response")
+        };
+
+        assert!(response.unwrap_content().contains("user-level setting"));
     }
 
     #[test]

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -196,6 +196,14 @@ pub fn plan_settings_command(
     context: SettingsContext,
 ) -> SettingsCommandPlan {
     match options.action {
+        SettingsAction::Get
+            if options.key == SettingKey::AnalyticsPrivacy
+                && options.scope == SettingScope::Guild =>
+        {
+            SettingsCommandPlan::Respond(CommandResponse::Content(
+                analytics_privacy_user_scope_message().to_string(),
+            ))
+        }
         SettingsAction::Get => SettingsCommandPlan::Read(SettingsReadRequest {
             user_id: context.user_id,
             guild_id: context.guild_id,
@@ -447,6 +455,11 @@ fn plan_settings_write(
     }
 }
 
+#[instrument(name = "command.settings.analytics_privacy_user_scope_message")]
+fn analytics_privacy_user_scope_message() -> &'static str {
+    "Analytics privacy is a user-level setting. Choose the `user` scope to view or update your own analytics preference."
+}
+
 #[instrument(name = "command.settings.validate_value_for_scope", skip(value))]
 fn validate_value_for_scope(scope: SettingScope, value: SettingValue) -> Result<(), String> {
     match (scope, value) {
@@ -454,10 +467,9 @@ fn validate_value_for_scope(scope: SettingScope, value: SettingValue) -> Result<
             "Use `opted_out` to exclude yourself from guild scores, or `enabled` to participate. `disabled` is only for guild settings."
                 .to_string(),
         ),
-        (SettingScope::Guild, SettingValue::AnalyticsPrivacy(_)) => Err(
-            "Analytics privacy is a user-level setting. Choose the `user` scope to update your own analytics preference."
-                .to_string(),
-        ),
+        (SettingScope::Guild, SettingValue::AnalyticsPrivacy(_)) => {
+            Err(analytics_privacy_user_scope_message().to_string())
+        }
         (SettingScope::Guild, SettingValue::GuildScores(GuildScoresPreference::OptedOut)) => Err(
             "Use `disabled` to turn guild scores off for the server, or `enabled` to allow participating users. `opted_out` is only for user settings."
                 .to_string(),
@@ -626,6 +638,29 @@ mod tests {
         assert!(content.contains("User: `romaji`"));
         assert!(!content.contains("Guild: `english`"));
         assert!(!content.contains("Effective: `romaji`"));
+    }
+
+    #[test]
+    fn rejects_guild_analytics_privacy_read() {
+        let options = SettingsCommandOptions {
+            action: SettingsAction::Get,
+            key: SettingKey::AnalyticsPrivacy,
+            scope: SettingScope::Guild,
+            value: None,
+        };
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: Some(Permissions::MANAGE_GUILD),
+        };
+
+        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
+            panic!("expected response")
+        };
+
+        let content = response.unwrap_content();
+        assert!(content.contains("user-level setting"));
+        assert!(content.contains("view or update"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use utils::{
     oauth::{OAuthContextConfigKey, load_context_config},
     posthog::{CommandTelemetryContext, PostHogClient},
     privacy::{hash_discord_id, hash_user_id, redact_url_credentials},
+    settings::resolve_analytics_privacy_preference,
     statics::{DISCORD_TOKEN, ENV, SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE},
     tls::install_rustls_crypto_provider,
 };
@@ -142,10 +143,8 @@ impl Handler {
         };
 
         let ctx = ctx.clone();
-        let distinct_id = Some(hash_user_id(command.user.id.get()).to_string());
-        let guild_id = command
-            .guild_id
-            .map(|guild_id| hash_discord_id(guild_id.get()).to_string());
+        let user_id = command.user.id;
+        let raw_guild_id = command.guild_id;
         let command_name = command.data.name.clone();
         let environment = self.environment.clone();
         let is_dm = command.guild_id.is_none();
@@ -154,6 +153,16 @@ impl Handler {
 
         tokio::spawn(
             async move {
+                let analytics_privacy = resolve_analytics_privacy_preference(&ctx, user_id).await;
+                let analytics_opted_out = analytics_privacy.opted_out();
+                let distinct_id =
+                    (!analytics_opted_out).then(|| hash_user_id(user_id.get()).to_string());
+                let guild_id = (!analytics_opted_out)
+                    .then(|| {
+                        raw_guild_id.map(|guild_id| hash_discord_id(guild_id.get()).to_string())
+                    })
+                    .flatten();
+
                 let event = posthog.build_command_hit_event(&CommandTelemetryContext {
                     distinct_id,
                     guild_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ use utils::{
     oauth::{OAuthContextConfigKey, load_context_config},
     posthog::{CommandTelemetryContext, PostHogClient},
     privacy::{hash_discord_id, hash_user_id, redact_url_credentials},
-    settings::resolve_analytics_privacy_preference,
     statics::{DISCORD_TOKEN, ENV, SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE},
     tls::install_rustls_crypto_provider,
 };
@@ -143,8 +142,10 @@ impl Handler {
         };
 
         let ctx = ctx.clone();
-        let user_id = command.user.id;
-        let raw_guild_id = command.guild_id;
+        let distinct_id = Some(hash_user_id(command.user.id.get()).to_string());
+        let guild_id = command
+            .guild_id
+            .map(|guild_id| hash_discord_id(guild_id.get()).to_string());
         let command_name = command.data.name.clone();
         let environment = self.environment.clone();
         let is_dm = command.guild_id.is_none();
@@ -153,16 +154,6 @@ impl Handler {
 
         tokio::spawn(
             async move {
-                let analytics_privacy = resolve_analytics_privacy_preference(&ctx, user_id).await;
-                let analytics_opted_out = analytics_privacy.opted_out();
-                let distinct_id =
-                    (!analytics_opted_out).then(|| hash_user_id(user_id.get()).to_string());
-                let guild_id = (!analytics_opted_out)
-                    .then(|| {
-                        raw_guild_id.map(|guild_id| hash_discord_id(guild_id.get()).to_string())
-                    })
-                    .flatten();
-
                 let event = posthog.build_command_hit_event(&CommandTelemetryContext {
                     distinct_id,
                     guild_id,

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -104,7 +104,7 @@ impl SettingKey {
         match self {
             Self::TitleDisplay => "Which AniList title variant Annie Mei should prefer.",
             Self::AnalyticsPrivacy => {
-                "Whether user-level analytics use the standard telemetry path. The default is `standard`; `opted_out` disables raw prompt/output capture and stable user correlation in supported analytics while keeping aggregate operational telemetry."
+                "Whether user-level analytics may include raw user-provided content. The default is `standard`; `opted_out` disables raw query, prompt, and output capture in supported analytics/observability while keeping pseudonymous operational telemetry."
             }
             Self::GuildScores => {
                 "Whether guild score displays are enabled for a server and whether a user participates. Guild disabled wins over user participation; users who opt out are excluded."

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -104,7 +104,7 @@ impl SettingKey {
         match self {
             Self::TitleDisplay => "Which AniList title variant Annie Mei should prefer.",
             Self::AnalyticsPrivacy => {
-                "Whether analytics should use the standard telemetry path or opt out where supported."
+                "Whether user-level analytics use the standard telemetry path. The default is `standard`; `opted_out` disables raw prompt/output capture and stable user correlation in supported analytics while keeping aggregate operational telemetry."
             }
             Self::GuildScores => {
                 "Whether guild score displays are enabled for a server and whether a user participates. Guild disabled wins over user participation; users who opt out are excluded."
@@ -185,6 +185,12 @@ pub enum TitleDisplayPreference {
 pub enum AnalyticsPrivacyPreference {
     Standard,
     OptedOut,
+}
+
+impl AnalyticsPrivacyPreference {
+    pub fn opted_out(self) -> bool {
+        matches!(self, Self::OptedOut)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -295,6 +301,10 @@ pub fn resolve_setting(key: SettingKey, values: ScopedSettingValues) -> Resolved
         return resolve_guild_scores_setting(values);
     }
 
+    if key == SettingKey::AnalyticsPrivacy {
+        return resolve_user_only_setting(key, values.user);
+    }
+
     if let Some(value) = values.user {
         return ResolvedSetting {
             key,
@@ -308,6 +318,23 @@ pub fn resolve_setting(key: SettingKey, values: ScopedSettingValues) -> Resolved
             key,
             value,
             source: SettingSource::Guild,
+        };
+    }
+
+    ResolvedSetting {
+        key,
+        value: key.default_value(),
+        source: SettingSource::Default,
+    }
+}
+
+#[instrument(name = "settings.resolve_user_only", skip(user))]
+fn resolve_user_only_setting(key: SettingKey, user: Option<SettingValue>) -> ResolvedSetting {
+    if let Some(value) = user {
+        return ResolvedSetting {
+            key,
+            value,
+            source: SettingSource::User,
         };
     }
 
@@ -470,6 +497,38 @@ mod tests {
             default_resolved.value,
             SettingKey::TitleDisplay.default_value()
         );
+    }
+
+    #[test]
+    fn resolve_analytics_privacy_uses_user_value_or_explicit_default() {
+        let guild = SettingKey::AnalyticsPrivacy.parse_value("opted_out").ok();
+        let user = SettingKey::AnalyticsPrivacy.parse_value("standard").ok();
+
+        let user_resolved = resolve_setting(
+            SettingKey::AnalyticsPrivacy,
+            ScopedSettingValues { user, guild },
+        );
+        assert_eq!(user_resolved.source, SettingSource::User);
+        assert_eq!(
+            user_resolved.value,
+            SettingValue::AnalyticsPrivacy(AnalyticsPrivacyPreference::Standard)
+        );
+
+        let default_resolved = resolve_setting(
+            SettingKey::AnalyticsPrivacy,
+            ScopedSettingValues { user: None, guild },
+        );
+        assert_eq!(default_resolved.source, SettingSource::Default);
+        assert_eq!(
+            default_resolved.value,
+            SettingValue::AnalyticsPrivacy(AnalyticsPrivacyPreference::Standard)
+        );
+    }
+
+    #[test]
+    fn analytics_privacy_opted_out_helper_identifies_opt_out() {
+        assert!(!AnalyticsPrivacyPreference::Standard.opted_out());
+        assert!(AnalyticsPrivacyPreference::OptedOut.opted_out());
     }
 
     #[test]

--- a/src/utils/llm/mod.rs
+++ b/src/utils/llm/mod.rs
@@ -490,8 +490,8 @@ impl GeminiClient {
             return;
         };
 
-        let capture_content = context.is_some();
         let context = context.unwrap_or_default();
+        let capture_content = context.capture_content;
         let display_input = context.input.clone();
         let trace_id = Uuid::new_v4().to_string();
         let input = capture_content.then(|| {

--- a/src/utils/posthog.rs
+++ b/src/utils/posthog.rs
@@ -33,6 +33,8 @@ pub struct LlmTelemetryContext {
     pub environment: Option<String>,
     /// Optional display-friendly input for LLM Analytics when content capture is enabled.
     pub input: Option<Value>,
+    /// Whether this call may send raw prompt/output content when global content capture is enabled.
+    pub capture_content: bool,
 }
 
 /// Per-command context that is safe to send to PostHog.
@@ -346,7 +348,7 @@ pub fn build_ai_generation_event(
         properties.insert("success".to_string(), json!(true));
     }
 
-    if capture_content {
+    if capture_content && context.capture_content {
         if let Some(input) = input {
             properties.insert("$ai_input".to_string(), input);
         }

--- a/src/utils/posthog.rs
+++ b/src/utils/posthog.rs
@@ -329,6 +329,19 @@ pub fn build_ai_generation_event(
         properties.insert("guild_id".to_string(), json!(guild_id));
     }
 
+    properties.insert(
+        "analytics_privacy".to_string(),
+        json!(if context.capture_content {
+            "standard"
+        } else {
+            "opted_out"
+        }),
+    );
+    properties.insert(
+        "llm_content_captured".to_string(),
+        json!(capture_content && context.capture_content),
+    );
+
     if let Some(tokens) = input_tokens {
         properties.insert("$ai_input_tokens".to_string(), json!(tokens));
     }

--- a/src/utils/posthog/tests.rs
+++ b/src/utils/posthog/tests.rs
@@ -39,6 +39,8 @@ fn ai_generation_payload_excludes_content_by_default() {
     assert_eq!(properties["environment"], "test");
     assert_eq!(properties["$ai_model"], "gemini-2.0-flash");
     assert_eq!(properties["$ai_provider"], "gemini");
+    assert_eq!(properties["analytics_privacy"], "opted_out");
+    assert!(!properties["llm_content_captured"].as_bool().unwrap());
     assert_eq!(properties["$ai_input_tokens"], 10);
     assert_eq!(properties["$ai_output_tokens"], 20);
     assert_eq!(properties["$ai_total_tokens"], 30);
@@ -68,6 +70,8 @@ fn ai_generation_payload_includes_content_when_enabled() {
     );
 
     let properties = event["properties"].as_object().unwrap();
+    assert_eq!(properties["analytics_privacy"], "standard");
+    assert!(properties["llm_content_captured"].as_bool().unwrap());
     assert_eq!(properties["$ai_input"][0]["content"], "raw prompt");
     assert_eq!(properties["$ai_output_choices"][0]["content"], "raw output");
 }
@@ -99,8 +103,8 @@ fn ai_generation_payload_records_errors_without_content() {
 #[test]
 fn ai_generation_payload_respects_context_privacy_opt_out() {
     let context = LlmTelemetryContext {
-        distinct_id: None,
-        guild_id: None,
+        distinct_id: Some("user_hash".to_string()),
+        guild_id: Some("guild_hash".to_string()),
         command: Some("search".to_string()),
         environment: Some("test".to_string()),
         input: Some(json!([{ "role": "user", "content": "raw prompt" }])),
@@ -124,9 +128,11 @@ fn ai_generation_payload_respects_context_privacy_opt_out() {
     );
 
     let properties = event["properties"].as_object().unwrap();
-    assert_eq!(event["distinct_id"], "annie-mei-unknown-user");
-    assert_eq!(properties["distinct_id"], "annie-mei-unknown-user");
-    assert!(!properties.contains_key("guild_id"));
+    assert_eq!(event["distinct_id"], "user_hash");
+    assert_eq!(properties["distinct_id"], "user_hash");
+    assert_eq!(properties["guild_id"], "guild_hash");
+    assert_eq!(properties["analytics_privacy"], "opted_out");
+    assert!(!properties["llm_content_captured"].as_bool().unwrap());
     assert!(!properties.contains_key("$ai_input"));
     assert!(!properties.contains_key("$ai_output_choices"));
 }

--- a/src/utils/posthog/tests.rs
+++ b/src/utils/posthog/tests.rs
@@ -10,6 +10,7 @@ fn ai_generation_payload_excludes_content_by_default() {
         command: Some("search".to_string()),
         environment: Some("test".to_string()),
         input: None,
+        capture_content: false,
     };
 
     let event = build_ai_generation_event(
@@ -50,7 +51,10 @@ fn ai_generation_payload_includes_content_when_enabled() {
     let event = build_ai_generation_event(
         "ph_key",
         true,
-        &LlmTelemetryContext::default(),
+        &LlmTelemetryContext {
+            capture_content: true,
+            ..LlmTelemetryContext::default()
+        },
         "trace-id",
         "gemini-2.0-flash",
         "gemini",
@@ -93,6 +97,41 @@ fn ai_generation_payload_records_errors_without_content() {
 }
 
 #[test]
+fn ai_generation_payload_respects_context_privacy_opt_out() {
+    let context = LlmTelemetryContext {
+        distinct_id: None,
+        guild_id: None,
+        command: Some("search".to_string()),
+        environment: Some("test".to_string()),
+        input: Some(json!([{ "role": "user", "content": "raw prompt" }])),
+        capture_content: false,
+    };
+
+    let event = build_ai_generation_event(
+        "ph_key",
+        true,
+        &context,
+        "trace-id",
+        "gemini-2.0-flash",
+        "gemini",
+        1.25,
+        Some(json!([{ "role": "user", "content": "raw prompt" }])),
+        Some(json!([{ "role": "assistant", "content": "raw output" }])),
+        None,
+        None,
+        None,
+        None,
+    );
+
+    let properties = event["properties"].as_object().unwrap();
+    assert_eq!(event["distinct_id"], "annie-mei-unknown-user");
+    assert_eq!(properties["distinct_id"], "annie-mei-unknown-user");
+    assert!(!properties.contains_key("guild_id"));
+    assert!(!properties.contains_key("$ai_input"));
+    assert!(!properties.contains_key("$ai_output_choices"));
+}
+
+#[test]
 fn command_hit_payload_includes_safe_command_context() {
     let context = CommandTelemetryContext {
         distinct_id: Some("user_hash".to_string()),
@@ -118,4 +157,25 @@ fn command_hit_payload_includes_safe_command_context() {
     assert_eq!(properties["interaction_type"], "slash_command");
     assert!(!properties["is_dm"].as_bool().unwrap());
     assert!(properties["channel_nsfw"].as_bool().unwrap());
+}
+
+#[test]
+fn command_hit_payload_allows_anonymous_aggregate_context() {
+    let context = CommandTelemetryContext {
+        distinct_id: None,
+        guild_id: None,
+        command: "search".to_string(),
+        environment: Some("test".to_string()),
+        is_dm: true,
+        channel_nsfw: false,
+    };
+
+    let event = build_command_hit_event("ph_key", &context);
+    let properties = event["properties"].as_object().unwrap();
+
+    assert_eq!(event["distinct_id"], "annie-mei-unknown-user");
+    assert_eq!(properties["distinct_id"], "annie-mei-unknown-user");
+    assert!(!properties.contains_key("guild_id"));
+    assert_eq!(properties["command"], "search");
+    assert!(properties["is_dm"].as_bool().unwrap());
 }

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -3,10 +3,10 @@ use tracing::{instrument, warn};
 
 use crate::{
     models::{
-        db::settings::{get_guild_setting, resolve_setting_layers},
+        db::settings::{get_guild_setting, get_user_setting, resolve_setting_layers},
         settings::{
-            SettingKey, SettingValue, TitleDisplayPreference, guild_scores_enabled,
-            user_participates_in_guild_scores,
+            AnalyticsPrivacyPreference, SettingKey, SettingValue, TitleDisplayPreference,
+            guild_scores_enabled, user_participates_in_guild_scores,
         },
     },
     utils::database::{DbPool, get_pool_from_context},
@@ -38,12 +38,46 @@ pub async fn resolve_title_display_preference(
     }
 }
 
+#[instrument(name = "settings.resolve_analytics_privacy", skip(ctx, user_id))]
+pub async fn resolve_analytics_privacy_preference(
+    ctx: &Context,
+    user_id: UserId,
+) -> AnalyticsPrivacyPreference {
+    let Some(pool) = get_pool_from_context(ctx).await else {
+        warn!("Database pool unavailable; using opt-out analytics privacy mode");
+        return AnalyticsPrivacyPreference::OptedOut;
+    };
+
+    match get_user_setting(&pool, user_id, SettingKey::AnalyticsPrivacy).await {
+        Ok(Some(SettingValue::AnalyticsPrivacy(preference))) => preference,
+        Ok(Some(_)) => {
+            warn!("Unexpected non-analytics value for analytics privacy key; using opt-out mode");
+            AnalyticsPrivacyPreference::OptedOut
+        }
+        Ok(None) => default_analytics_privacy_preference(),
+        Err(error) => {
+            warn!(error = %error, "Failed to resolve analytics privacy preference; using opt-out mode");
+            AnalyticsPrivacyPreference::OptedOut
+        }
+    }
+}
+
 #[instrument(name = "settings.default_title_display")]
 fn default_title_display_preference() -> TitleDisplayPreference {
     match SettingKey::TitleDisplay.default_value() {
         SettingValue::TitleDisplay(preference) => preference,
         SettingValue::AnalyticsPrivacy(_) | SettingValue::GuildScores(_) => {
             TitleDisplayPreference::Matched
+        }
+    }
+}
+
+#[instrument(name = "settings.default_analytics_privacy")]
+pub fn default_analytics_privacy_preference() -> AnalyticsPrivacyPreference {
+    match SettingKey::AnalyticsPrivacy.default_value() {
+        SettingValue::AnalyticsPrivacy(preference) => preference,
+        SettingValue::TitleDisplay(_) | SettingValue::GuildScores(_) => {
+            AnalyticsPrivacyPreference::OptedOut
         }
     }
 }
@@ -72,4 +106,17 @@ pub async fn resolve_guild_scores_enabled_with_pool(
 #[instrument(name = "settings.participates_in_guild_scores", skip(value))]
 pub fn participates_in_guild_scores(value: Option<SettingValue>) -> bool {
     user_participates_in_guild_scores(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn analytics_privacy_default_is_standard_participation() {
+        assert_eq!(
+            default_analytics_privacy_preference(),
+            AnalyticsPrivacyPreference::Standard
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds a user-level analytics privacy preference for private analytics mode: users can opt out of raw query, prompt, and LLM output capture while Annie Mei continues to collect pseudonymous operational telemetry.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore

## Changes
- f3776452289d53b91da7078ac26a25774b5ed1b3: add analytics privacy setting support, wire opt-out behavior into PostHog LLM telemetry, and add coverage for defaults plus opted-in/opted-out behavior
- e15e3c6f376d20d6897fdd52c6aad01228c0848a: bump package version to 3.4.0 and update Cargo.lock
- 4eb2e31e34b47d237d9fd2583e219a6d685755a0: reject guild-scope reads for the user-only analytics privacy setting
- c8ded2f5f3245d82c628e2d19ae4e0deefdcfaa2: label LLM analytics events with analytics privacy/content-capture metadata
- 23ee8fd0bf17855586cac275eda824985f764ff5: keep hashed Discord user and guild identifiers in opted-out operational telemetry while suppressing raw content capture
- 1f452ef8f979e287a7a845d6e4c5afd996aed222: document analytics privacy behavior, LLM provider usage, and PostHog analytics in the privacy policy

### Notes

The `opted_out` analytics privacy setting disables raw user-provided content capture in supported analytics/observability paths. It does not disable all telemetry: command and LLM operational events may still include pseudonymous hashed Discord identifiers, command names, latency, token counts, model names, bot version, environment, and success/failure status.

## Validation
- [x] cargo fmt --check
- [x] cargo test
- [x] cargo clippy -- -D warnings

---

This PR description was written by GPT-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
