### PR TITLE
[ANNIE-192]/add settings panel entrypoint and component routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -21,7 +21,7 @@ use serenity::{
     builder::CreateCommand,
     client::Context,
 };
-use tracing::{error, instrument};
+use tracing::{error, instrument, warn};
 
 const SETTINGS_COMPONENT_PREFIX: &str = "settings";
 const SETTINGS_COMPONENT_ID_PREFIX: &str = "settings:";
@@ -235,11 +235,15 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
         return;
     };
 
-    if interaction
+    if let Err(error) = interaction
         .create_response(&ctx.http, CreateInteractionResponse::Acknowledge)
         .await
-        .is_err()
     {
+        warn!(
+            error = %error,
+            custom_id = %interaction.data.custom_id,
+            "Failed to acknowledge settings component interaction"
+        );
         return;
     }
 

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -1,14 +1,7 @@
 use crate::{
-    commands::response::CommandResponse,
     models::{
-        db::settings::{
-            ResolvedSettingLayers, SettingsStorageError, get_guild_setting, get_user_setting,
-            resolve_setting_layers, set_guild_setting, set_user_setting,
-        },
-        settings::{
-            ALL_SETTING_KEYS, ALL_SETTING_SCOPES, GuildScoresPreference, SettingKey, SettingScope,
-            SettingValue,
-        },
+        db::settings::{ResolvedSettingLayers, SettingsStorageError, resolve_setting_layers},
+        settings::{ALL_SETTING_KEYS, SettingKey, SettingValue},
     },
     utils::{
         database::{DbPool, get_pool_from_context},
@@ -19,244 +12,106 @@ use crate::{
 
 use serenity::{
     all::{
-        CommandDataOption, CommandDataOptionValue, CommandInteraction, CreateCommandOption,
-        EditInteractionResponse, GuildId, Permissions, UserId,
+        ButtonStyle, CommandInteraction, ComponentInteraction, CreateActionRow, CreateButton,
+        CreateInteractionResponse, CreateInteractionResponseMessage, EditInteractionResponse,
+        GuildId, UserId,
     },
     builder::CreateCommand,
     client::Context,
-    model::application::CommandOptionType,
 };
 use tracing::{error, instrument};
 
-const ACTION_OPTION: &str = "action";
-const KEY_OPTION: &str = "key";
-const SCOPE_OPTION: &str = "scope";
-const VALUE_OPTION: &str = "value";
-
-const ACTION_GET: &str = "get";
-const ACTION_SET: &str = "set";
+const SETTINGS_COMPONENT_PREFIX: &str = "settings";
+const OVERVIEW_COMPONENT: &str = "overview";
+const CATEGORY_COMPONENT: &str = "category";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SettingsAction {
-    Get,
-    Set,
+pub enum SettingsPanelCategory {
+    Overview,
+    Setting(SettingKey),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SettingsCommandOptions {
-    action: SettingsAction,
-    key: SettingKey,
-    scope: SettingScope,
-    value: Option<String>,
+pub struct SettingSummary {
+    pub layers: ResolvedSettingLayers,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SettingsContext {
-    pub user_id: UserId,
-    pub guild_id: Option<GuildId>,
-    pub member_permissions: Option<Permissions>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsPanel {
+    pub category: SettingsPanelCategory,
+    pub guild_available: bool,
+    pub summaries: Vec<SettingSummary>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SettingsWriteTarget {
-    User(UserId),
-    Guild(GuildId),
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsComponentId {
+    Overview,
+    Category(SettingKey),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SettingsWriteRequest {
-    pub target: SettingsWriteTarget,
-    pub value: SettingValue,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SettingsReadRequest {
-    pub user_id: UserId,
-    pub guild_id: Option<GuildId>,
-    pub key: SettingKey,
-    pub scope: SettingScope,
-}
-
-#[derive(Debug)]
-pub enum SettingsCommandPlan {
-    Read(SettingsReadRequest),
-    Write(SettingsWriteRequest),
-    Respond(CommandResponse),
+impl SettingsComponentId {
+    fn panel_category(&self) -> SettingsPanelCategory {
+        match self {
+            Self::Overview => SettingsPanelCategory::Overview,
+            Self::Category(key) => SettingsPanelCategory::Setting(*key),
+        }
+    }
 }
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("settings")
-        .description("View or update Annie Mei preferences")
-        .add_option(
-            CreateCommandOption::new(
-                CommandOptionType::String,
-                ACTION_OPTION,
-                "View or update a setting",
-            )
-            .add_string_choice("Get", ACTION_GET)
-            .add_string_choice("Set", ACTION_SET)
-            .required(true),
-        )
-        .add_option(setting_key_option())
-        .add_option(setting_scope_option())
-        .add_option(setting_value_option())
+    CreateCommand::new("settings").description("Open your Annie Mei settings panel")
 }
 
-#[instrument(name = "command.settings.key_option")]
-fn setting_key_option() -> CreateCommandOption {
-    ALL_SETTING_KEYS
-        .iter()
-        .fold(
-            CreateCommandOption::new(
-                CommandOptionType::String,
-                KEY_OPTION,
-                "The setting to view or update",
-            ),
-            |option, key| option.add_string_choice(key.label(), key.as_str()),
-        )
-        .required(true)
+#[instrument(name = "command.settings.is_component")]
+pub fn is_settings_component(custom_id: &str) -> bool {
+    custom_id.starts_with(&format!("{SETTINGS_COMPONENT_PREFIX}:"))
 }
 
-#[instrument(name = "command.settings.scope_option")]
-fn setting_scope_option() -> CreateCommandOption {
-    ALL_SETTING_SCOPES
-        .iter()
-        .fold(
-            CreateCommandOption::new(
-                CommandOptionType::String,
-                SCOPE_OPTION,
-                "Which setting layer to use",
-            ),
-            |option, scope| option.add_string_choice(scope.label(), scope.as_str()),
-        )
-        .required(true)
+#[instrument(name = "command.settings.overview_custom_id")]
+pub fn settings_overview_custom_id() -> String {
+    format!("{SETTINGS_COMPONENT_PREFIX}:{OVERVIEW_COMPONENT}")
 }
 
-#[instrument(name = "command.settings.value_option")]
-fn setting_value_option() -> CreateCommandOption {
-    let option = CreateCommandOption::new(
-        CommandOptionType::String,
-        VALUE_OPTION,
-        "The new value when action is Set",
-    );
-
-    setting_value_choices()
-        .into_iter()
-        .fold(option, |option, value| {
-            option.add_string_choice(value, value)
-        })
-        .required(false)
+#[instrument(name = "command.settings.category_custom_id", fields(setting_key = %key.as_str()))]
+pub fn settings_category_custom_id(key: SettingKey) -> String {
+    format!(
+        "{SETTINGS_COMPONENT_PREFIX}:{CATEGORY_COMPONENT}:{}",
+        key.as_str()
+    )
 }
 
-#[instrument(name = "command.settings.value_choices")]
-fn setting_value_choices() -> Vec<&'static str> {
-    let mut values = Vec::new();
+#[instrument(name = "command.settings.parse_component_id")]
+pub fn parse_settings_component_id(custom_id: &str) -> Option<SettingsComponentId> {
+    let parts = custom_id.split(':').collect::<Vec<_>>();
 
-    for value in ALL_SETTING_KEYS
-        .iter()
-        .flat_map(|key| key.allowed_values().iter().copied())
-    {
-        if !values.contains(&value) {
-            values.push(value);
+    match parts.as_slice() {
+        [SETTINGS_COMPONENT_PREFIX, OVERVIEW_COMPONENT] => Some(SettingsComponentId::Overview),
+        [SETTINGS_COMPONENT_PREFIX, CATEGORY_COMPONENT, raw_key] => {
+            SettingKey::parse(raw_key).map(SettingsComponentId::Category)
         }
-    }
-
-    values
-}
-
-#[instrument(name = "command.settings.parse_options", skip(options))]
-pub fn parse_settings_options(
-    options: &[CommandDataOption],
-) -> Result<SettingsCommandOptions, String> {
-    let action = optional_string_option(options, ACTION_OPTION)
-        .and_then(parse_action)
-        .ok_or_else(|| "Choose whether to `get` or `set` a setting.".to_string())?;
-
-    let key = optional_string_option(options, KEY_OPTION)
-        .and_then(SettingKey::parse)
-        .ok_or_else(|| settings_help_message("Choose a valid setting key."))?;
-
-    let scope = optional_string_option(options, SCOPE_OPTION)
-        .and_then(SettingScope::parse)
-        .ok_or_else(|| "Choose a valid scope: `effective`, `user`, or `guild`.".to_string())?;
-
-    let value = optional_string_option(options, VALUE_OPTION).map(ToOwned::to_owned);
-
-    Ok(SettingsCommandOptions {
-        action,
-        key,
-        scope,
-        value,
-    })
-}
-
-#[instrument(name = "command.settings.plan", skip(options, context))]
-pub fn plan_settings_command(
-    options: SettingsCommandOptions,
-    context: SettingsContext,
-) -> SettingsCommandPlan {
-    match options.action {
-        SettingsAction::Get
-            if options.key == SettingKey::AnalyticsPrivacy
-                && options.scope == SettingScope::Guild =>
-        {
-            SettingsCommandPlan::Respond(CommandResponse::Content(
-                analytics_privacy_user_scope_message().to_string(),
-            ))
-        }
-        SettingsAction::Get => SettingsCommandPlan::Read(SettingsReadRequest {
-            user_id: context.user_id,
-            guild_id: context.guild_id,
-            key: options.key,
-            scope: options.scope,
-        }),
-        SettingsAction::Set => plan_settings_write(options, context),
+        _ => None,
     }
 }
 
-#[instrument(name = "command.settings.format_effective", skip(layers))]
-pub fn format_effective_setting(layers: ResolvedSettingLayers) -> String {
-    let key = layers.effective.key;
-    format_setting_read(
-        key,
-        format!(
-            "Effective: {} ({})",
-            code(layers.effective.value.as_storage_value()),
-            layers.effective.source
-        ),
-    )
+#[instrument(name = "command.settings.plan_panel", skip(summaries))]
+pub fn plan_settings_panel(
+    category: SettingsPanelCategory,
+    guild_available: bool,
+    summaries: Vec<SettingSummary>,
+) -> SettingsPanel {
+    SettingsPanel {
+        category,
+        guild_available,
+        summaries,
+    }
 }
 
-#[instrument(name = "command.settings.format_scoped", skip(value))]
-pub fn format_scoped_setting(key: SettingKey, label: &str, value: Option<SettingValue>) -> String {
-    format_setting_read(key, format_layer_value(label, value))
-}
-
-#[instrument(name = "command.settings.format_read")]
-fn format_setting_read(key: SettingKey, selected_layer: String) -> String {
-    format!(
-        "{}\n{}\n\n{}\nAllowed values: {}",
-        bold(key.label()),
-        selected_layer,
-        key.description(),
-        format_allowed_values(key),
-    )
-}
-
-#[instrument(name = "command.settings.format_saved", skip(target, value))]
-pub fn format_saved_setting(target: SettingsWriteTarget, value: SettingValue) -> String {
-    let scope = match target {
-        SettingsWriteTarget::User(_) => "user",
-        SettingsWriteTarget::Guild(_) => "guild",
-    };
-
-    format!(
-        "Saved {} for the {} scope as {} ({}).",
-        value.key().label(),
-        scope,
-        code(value.as_storage_value()),
-        value.display_label(),
-    )
+#[instrument(name = "command.settings.render_panel", skip(panel))]
+pub fn render_settings_panel(panel: &SettingsPanel) -> String {
+    match panel.category {
+        SettingsPanelCategory::Overview => render_overview_panel(panel),
+        SettingsPanelCategory::Setting(key) => render_category_panel(panel, key),
+    }
 }
 
 #[instrument(name = "command.settings.run", skip(ctx, interaction))]
@@ -266,256 +121,234 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let user = &interaction.user;
     configure_sentry_scope("Settings", user.id.get(), None);
 
-    let options = match parse_settings_options(&interaction.data.options) {
-        Ok(options) => options,
-        Err(message) => {
-            respond(interaction, ctx, CommandResponse::Content(message)).await;
-            return;
-        }
-    };
-
-    let context = SettingsContext {
-        user_id: user.id,
-        guild_id: interaction.guild_id,
-        member_permissions: interaction
-            .member
-            .as_ref()
-            .and_then(|member| member.permissions),
-    };
-
-    let plan = match plan_settings_command(options, context) {
-        SettingsCommandPlan::Respond(response) => {
-            respond(interaction, ctx, response).await;
-            return;
-        }
-        plan => plan,
-    };
-
     let Some(database_pool) = get_pool_from_context(ctx).await else {
-        respond(
+        respond_to_command(
             interaction,
             ctx,
-            CommandResponse::Content(
-                "Database is not initialized. Please try again later.".to_string(),
-            ),
+            "Database is not initialized. Please try again later.".to_string(),
+            Vec::new(),
         )
         .await;
         return;
     };
 
-    let response = match plan {
-        SettingsCommandPlan::Respond(response) => response,
-        SettingsCommandPlan::Read(request) => {
-            match read_settings_response(&database_pool, request).await {
-                Ok(response) => response,
-                Err(error) => {
-                    log_settings_storage_error("read", request.user_id, request.guild_id, &error);
-                    CommandResponse::Content(
-                        "I hit an internal error while reading that setting. Please try again later."
-                            .to_string(),
-                    )
-                }
-            }
-        }
-        SettingsCommandPlan::Write(request) => match request.target {
-            SettingsWriteTarget::User(user_id) => {
-                match set_user_setting(&database_pool, user_id, request.value).await {
-                    Ok(()) => CommandResponse::Content(format_saved_setting(
-                        request.target,
-                        request.value,
-                    )),
-                    Err(error) => {
-                        error!(
-                            error = %error,
-                            discord_user_id = %hash_user_id(user.id.get()),
-                            setting_key = %request.value.key().as_str(),
-                            "Failed to save user setting"
-                        );
-                        CommandResponse::Content(
-                            "I hit an internal error while saving that setting. Please try again later."
-                                .to_string(),
-                        )
-                    }
-                }
-            }
-            SettingsWriteTarget::Guild(guild_id) => {
-                match set_guild_setting(&database_pool, guild_id, request.value).await {
-                    Ok(()) => CommandResponse::Content(format_saved_setting(
-                        request.target,
-                        request.value,
-                    )),
-                    Err(error) => {
-                        error!(
-                            error = %error,
-                            guild_id = %hash_discord_id(guild_id.get()),
-                            setting_key = %request.value.key().as_str(),
-                            "Failed to save guild setting"
-                        );
-                        CommandResponse::Content(
-                            "I hit an internal error while saving that setting. Please try again later."
-                                .to_string(),
-                        )
-                    }
-                }
-            }
-        },
-    };
-
-    respond(interaction, ctx, response).await;
-}
-
-#[instrument(name = "command.settings.read_response", skip(pool, request))]
-async fn read_settings_response(
-    pool: &DbPool,
-    request: SettingsReadRequest,
-) -> Result<CommandResponse, SettingsStorageError> {
-    let content = match request.scope {
-        SettingScope::Effective => {
-            let layers =
-                resolve_setting_layers(pool, request.user_id, request.guild_id, request.key)
-                    .await?;
-            format_effective_setting(layers)
-        }
-        SettingScope::User => {
-            let value = get_user_setting(pool, request.user_id, request.key).await?;
-            format_scoped_setting(request.key, "User", value)
-        }
-        SettingScope::Guild => {
-            let Some(guild_id) = request.guild_id else {
-                return Ok(CommandResponse::Content(
-                    "Guild settings are not available in DMs.".to_string(),
-                ));
-            };
-
-            let value = get_guild_setting(pool, guild_id, request.key).await?;
-            format_scoped_setting(request.key, "Guild", value)
-        }
-    };
-
-    Ok(CommandResponse::Content(content))
-}
-
-#[instrument(name = "command.settings.plan_write", skip(options, context))]
-fn plan_settings_write(
-    options: SettingsCommandOptions,
-    context: SettingsContext,
-) -> SettingsCommandPlan {
-    let Some(raw_value) = options.value.as_deref() else {
-        return SettingsCommandPlan::Respond(CommandResponse::Content(format!(
-            "Provide a `value` when setting {}. Allowed values: {}.",
-            options.key.label(),
-            format_allowed_values(options.key),
-        )));
-    };
-
-    let value = match options.key.parse_value(raw_value) {
-        Ok(value) => value,
+    let response = match load_settings_panel(
+        &database_pool,
+        user.id,
+        interaction.guild_id,
+        SettingsPanelCategory::Overview,
+    )
+    .await
+    {
+        Ok(panel) => panel,
         Err(error) => {
-            return SettingsCommandPlan::Respond(CommandResponse::Content(error.to_string()));
+            log_settings_storage_error("panel", user.id, interaction.guild_id, &error);
+            respond_to_command(
+                interaction,
+                ctx,
+                "I hit an internal error while reading your settings. Please try again later."
+                    .to_string(),
+                Vec::new(),
+            )
+            .await;
+            return;
         }
     };
 
-    match options.scope {
-        SettingScope::Effective => SettingsCommandPlan::Respond(CommandResponse::Content(
-            "`effective` is read-only because it is resolved from user, guild, and default settings. Choose `user` or `guild` when setting a value."
-                .to_string(),
-        )),
-        SettingScope::User => {
-            if let Err(message) = validate_value_for_scope(options.scope, value) {
-                return SettingsCommandPlan::Respond(CommandResponse::Content(message));
-            }
+    respond_to_command(
+        interaction,
+        ctx,
+        render_settings_panel(&response),
+        settings_panel_components(response.category),
+    )
+    .await;
+}
 
-            SettingsCommandPlan::Write(SettingsWriteRequest {
-                target: SettingsWriteTarget::User(context.user_id),
-                value,
-            })
-        },
-        SettingScope::Guild => {
-            if let Err(message) = validate_value_for_scope(options.scope, value) {
-                return SettingsCommandPlan::Respond(CommandResponse::Content(message));
-            }
+#[instrument(name = "command.settings.handle_component", skip(ctx, interaction))]
+pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteraction) {
+    configure_sentry_scope("Settings", interaction.user.id.get(), None);
 
-            let Some(guild_id) = context.guild_id else {
-                return SettingsCommandPlan::Respond(CommandResponse::Content(
-                    "Guild settings can only be changed from inside a server.".to_string(),
-                ));
-            };
+    let Some(component_id) = parse_settings_component_id(&interaction.data.custom_id) else {
+        let builder = CreateInteractionResponse::Message(
+            CreateInteractionResponseMessage::new()
+                .content("I don't recognize that settings control. Please run `/settings` again.")
+                .ephemeral(true),
+        );
+        let _ = interaction.create_response(&ctx.http, builder).await;
+        return;
+    };
 
-            if !can_manage_guild_settings(context.member_permissions) {
-                return SettingsCommandPlan::Respond(CommandResponse::Content(
-                    "You need the Manage Server permission to change guild settings.".to_string(),
-                ));
-            }
-
-            SettingsCommandPlan::Write(SettingsWriteRequest {
-                target: SettingsWriteTarget::Guild(guild_id),
-                value,
-            })
-        }
+    if interaction
+        .create_response(&ctx.http, CreateInteractionResponse::Acknowledge)
+        .await
+        .is_err()
+    {
+        return;
     }
-}
 
-#[instrument(name = "command.settings.analytics_privacy_user_scope_message")]
-fn analytics_privacy_user_scope_message() -> &'static str {
-    "Analytics privacy is a user-level setting. Choose the `user` scope to view or update your own analytics preference."
-}
+    let Some(database_pool) = get_pool_from_context(ctx).await else {
+        respond_to_component(
+            interaction,
+            ctx,
+            "Database is not initialized. Please try again later.".to_string(),
+            Vec::new(),
+        )
+        .await;
+        return;
+    };
 
-#[instrument(name = "command.settings.validate_value_for_scope", skip(value))]
-fn validate_value_for_scope(scope: SettingScope, value: SettingValue) -> Result<(), String> {
-    match (scope, value) {
-        (SettingScope::User, SettingValue::GuildScores(GuildScoresPreference::Disabled)) => Err(
-            "Use `opted_out` to exclude yourself from guild scores, or `enabled` to participate. `disabled` is only for guild settings."
-                .to_string(),
-        ),
-        (SettingScope::Guild, SettingValue::AnalyticsPrivacy(_)) => {
-            Err(analytics_privacy_user_scope_message().to_string())
+    let category = component_id.panel_category();
+    let response = match load_settings_panel(
+        &database_pool,
+        interaction.user.id,
+        interaction.guild_id,
+        category,
+    )
+    .await
+    {
+        Ok(panel) => panel,
+        Err(error) => {
+            log_settings_storage_error(
+                "component",
+                interaction.user.id,
+                interaction.guild_id,
+                &error,
+            );
+            respond_to_component(
+                interaction,
+                ctx,
+                "I hit an internal error while reading your settings. Please try again later."
+                    .to_string(),
+                Vec::new(),
+            )
+            .await;
+            return;
         }
-        (SettingScope::Guild, SettingValue::GuildScores(GuildScoresPreference::OptedOut)) => Err(
-            "Use `disabled` to turn guild scores off for the server, or `enabled` to allow participating users. `opted_out` is only for user settings."
-                .to_string(),
-        ),
-        _ => Ok(()),
-    }
+    };
+
+    respond_to_component(
+        interaction,
+        ctx,
+        render_settings_panel(&response),
+        settings_panel_components(response.category),
+    )
+    .await;
 }
 
-#[instrument(name = "command.settings.optional_string_option", skip(options))]
-fn optional_string_option<'a>(options: &'a [CommandDataOption], name: &str) -> Option<&'a str> {
-    options
+#[instrument(name = "command.settings.load_panel", skip(pool, user_id, guild_id))]
+async fn load_settings_panel(
+    pool: &DbPool,
+    user_id: UserId,
+    guild_id: Option<GuildId>,
+    category: SettingsPanelCategory,
+) -> Result<SettingsPanel, SettingsStorageError> {
+    let mut summaries = Vec::with_capacity(ALL_SETTING_KEYS.len());
+
+    for key in ALL_SETTING_KEYS {
+        summaries.push(SettingSummary {
+            layers: resolve_setting_layers(pool, user_id, guild_id, key).await?,
+        });
+    }
+
+    Ok(plan_settings_panel(category, guild_id.is_some(), summaries))
+}
+
+#[instrument(name = "command.settings.render_overview", skip(panel))]
+fn render_overview_panel(panel: &SettingsPanel) -> String {
+    let mut sections = vec![
+        format!("{}", bold("Settings")),
+        "Read-only summary of your current Annie Mei preferences. Use the buttons below to inspect each category; changing values will be added in a later update.".to_string(),
+    ];
+
+    sections.extend(
+        panel
+            .summaries
+            .iter()
+            .map(|summary| format_summary(summary, panel.guild_available, false)),
+    );
+
+    sections.join("\n\n")
+}
+
+#[instrument(name = "command.settings.render_category", skip(panel))]
+fn render_category_panel(panel: &SettingsPanel, key: SettingKey) -> String {
+    let Some(summary) = panel
+        .summaries
         .iter()
-        .find(|option| option.name == name)
-        .and_then(|option| match &option.value {
-            CommandDataOptionValue::String(value) => Some(value.as_str()),
-            _ => None,
-        })
+        .find(|summary| summary.layers.effective.key == key)
+    else {
+        return render_overview_panel(panel);
+    };
+
+    format!(
+        "{}\n{}\n\n{}",
+        bold("Settings"),
+        "Read-only category details. Use Overview to return to the full settings summary.",
+        format_summary(summary, panel.guild_available, true),
+    )
 }
 
-#[instrument(name = "command.settings.parse_action")]
-fn parse_action(raw: &str) -> Option<SettingsAction> {
-    match raw {
-        ACTION_GET => Some(SettingsAction::Get),
-        ACTION_SET => Some(SettingsAction::Set),
-        _ => None,
-    }
-}
-
-#[instrument(name = "command.settings.can_manage_guild_settings")]
-fn can_manage_guild_settings(permissions: Option<Permissions>) -> bool {
-    permissions.is_some_and(|permissions| {
-        permissions.contains(Permissions::MANAGE_GUILD)
-            || permissions.contains(Permissions::ADMINISTRATOR)
-    })
-}
-
-#[instrument(name = "command.settings.format_layer_value", skip(value))]
-fn format_layer_value(label: &str, value: Option<SettingValue>) -> String {
-    match value {
-        Some(value) => format!(
-            "{label}: {} ({})",
-            code(value.as_storage_value()),
-            value.display_label()
+#[instrument(name = "command.settings.format_summary", skip(summary))]
+fn format_summary(
+    summary: &SettingSummary,
+    guild_available: bool,
+    include_details: bool,
+) -> String {
+    let key = summary.layers.effective.key;
+    let mut lines = vec![
+        bold(key.label()),
+        format!(
+            "Effective: {} ({})",
+            format_setting_value(summary.layers.effective.value),
+            summary.layers.effective.source
         ),
-        None => format!("{label}: not set"),
+        format!("User: {}", format_optional_layer(summary.layers.user)),
+        format!(
+            "Guild: {}",
+            format_guild_layer(key, summary.layers.guild, guild_available)
+        ),
+        format!("Default: {}", format_setting_value(key.default_value())),
+    ];
+
+    if include_details {
+        lines.push(key.description().to_string());
+        lines.push(format!("Allowed values: {}", format_allowed_values(key)));
     }
+
+    lines.join("\n")
+}
+
+#[instrument(name = "command.settings.format_optional_layer", skip(value))]
+fn format_optional_layer(value: Option<SettingValue>) -> String {
+    value
+        .map(format_setting_value)
+        .unwrap_or_else(|| "not set".to_string())
+}
+
+#[instrument(name = "command.settings.format_guild_layer", skip(value))]
+fn format_guild_layer(
+    key: SettingKey,
+    value: Option<SettingValue>,
+    guild_available: bool,
+) -> String {
+    if key == SettingKey::AnalyticsPrivacy {
+        return "not applicable".to_string();
+    }
+
+    if !guild_available {
+        return "not available in DMs".to_string();
+    }
+
+    format_optional_layer(value)
+}
+
+#[instrument(name = "command.settings.format_value", skip(value))]
+fn format_setting_value(value: SettingValue) -> String {
+    format!(
+        "{} ({})",
+        code(value.as_storage_value()),
+        value.display_label()
+    )
 }
 
 #[instrument(name = "command.settings.format_allowed_values")]
@@ -527,15 +360,88 @@ fn format_allowed_values(key: SettingKey) -> String {
         .join(", ")
 }
 
-#[instrument(name = "command.settings.help_message")]
-fn settings_help_message(prefix: &str) -> String {
-    let settings = ALL_SETTING_KEYS
-        .iter()
-        .map(|key| code(key.as_str()))
-        .collect::<Vec<_>>()
-        .join(", ");
+#[instrument(name = "command.settings.components")]
+fn settings_panel_components(active: SettingsPanelCategory) -> Vec<CreateActionRow> {
+    vec![CreateActionRow::Buttons(vec![
+        panel_button(
+            SettingsPanelCategory::Overview,
+            "Overview",
+            settings_overview_custom_id(),
+            active,
+        ),
+        panel_button(
+            SettingsPanelCategory::Setting(SettingKey::TitleDisplay),
+            "Title display",
+            settings_category_custom_id(SettingKey::TitleDisplay),
+            active,
+        ),
+        panel_button(
+            SettingsPanelCategory::Setting(SettingKey::AnalyticsPrivacy),
+            "Analytics privacy",
+            settings_category_custom_id(SettingKey::AnalyticsPrivacy),
+            active,
+        ),
+        panel_button(
+            SettingsPanelCategory::Setting(SettingKey::GuildScores),
+            "Guild scores",
+            settings_category_custom_id(SettingKey::GuildScores),
+            active,
+        ),
+    ])]
+}
 
-    format!("{prefix} Available settings: {settings}.")
+#[instrument(name = "command.settings.panel_button")]
+fn panel_button(
+    category: SettingsPanelCategory,
+    label: &str,
+    custom_id: String,
+    active: SettingsPanelCategory,
+) -> CreateButton {
+    let is_active = category == active;
+    let style = if is_active {
+        ButtonStyle::Secondary
+    } else {
+        ButtonStyle::Primary
+    };
+
+    CreateButton::new(custom_id)
+        .label(label)
+        .style(style)
+        .disabled(is_active)
+}
+
+#[instrument(
+    name = "command.settings.respond_command",
+    skip(interaction, ctx, components)
+)]
+async fn respond_to_command(
+    interaction: &mut CommandInteraction,
+    ctx: &Context,
+    content: String,
+    components: Vec<CreateActionRow>,
+) {
+    let builder = EditInteractionResponse::new()
+        .content(content)
+        .components(components);
+
+    let _ = interaction.edit_response(&ctx.http, builder).await;
+}
+
+#[instrument(
+    name = "command.settings.respond_component",
+    skip(interaction, ctx, components)
+)]
+async fn respond_to_component(
+    interaction: &mut ComponentInteraction,
+    ctx: &Context,
+    content: String,
+    components: Vec<CreateActionRow>,
+) {
+    let builder = EditInteractionResponse::new()
+        .content(content)
+        .components(components);
+
+    let _ = interaction.edit_response(&ctx.http, builder).await;
 }
 
 #[instrument(
@@ -557,335 +463,134 @@ fn log_settings_storage_error(
     );
 }
 
-#[instrument(name = "command.settings.respond", skip(interaction, ctx, response))]
-async fn respond(interaction: &mut CommandInteraction, ctx: &Context, response: CommandResponse) {
-    let builder = match response {
-        CommandResponse::Content(content) => EditInteractionResponse::new().content(content),
-        CommandResponse::Message(content) => EditInteractionResponse::new().content(content),
-        CommandResponse::Embed(embed) => EditInteractionResponse::new().embed(*embed),
-    };
-
-    let _ = interaction.edit_response(&ctx.http, builder).await;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::settings::{
+        AnalyticsPrivacyPreference, GuildScoresPreference, ResolvedSetting, SettingSource,
+        TitleDisplayPreference,
+    };
 
-    fn string_options(pairs: &[(&str, &str)]) -> Vec<CommandDataOption> {
-        let values = pairs
-            .iter()
-            .map(|(name, value)| {
-                serde_json::json!({
-                    "name": name,
-                    "type": 3,
-                    "value": value,
-                })
-            })
-            .collect::<Vec<_>>();
+    fn layers(
+        key: SettingKey,
+        user: Option<SettingValue>,
+        guild: Option<SettingValue>,
+        effective: SettingValue,
+        source: SettingSource,
+    ) -> ResolvedSettingLayers {
+        ResolvedSettingLayers {
+            user,
+            guild,
+            effective: ResolvedSetting {
+                key,
+                value: effective,
+                source,
+            },
+        }
+    }
 
-        serde_json::from_value(serde_json::Value::Array(values)).expect("options deserialize")
+    fn test_summaries() -> Vec<SettingSummary> {
+        vec![
+            SettingSummary {
+                layers: layers(
+                    SettingKey::TitleDisplay,
+                    Some(SettingValue::TitleDisplay(TitleDisplayPreference::Romaji)),
+                    Some(SettingValue::TitleDisplay(TitleDisplayPreference::English)),
+                    SettingValue::TitleDisplay(TitleDisplayPreference::Romaji),
+                    SettingSource::User,
+                ),
+            },
+            SettingSummary {
+                layers: layers(
+                    SettingKey::AnalyticsPrivacy,
+                    None,
+                    None,
+                    SettingValue::AnalyticsPrivacy(AnalyticsPrivacyPreference::Standard),
+                    SettingSource::Default,
+                ),
+            },
+            SettingSummary {
+                layers: layers(
+                    SettingKey::GuildScores,
+                    Some(SettingValue::GuildScores(GuildScoresPreference::OptedOut)),
+                    Some(SettingValue::GuildScores(GuildScoresPreference::Enabled)),
+                    SettingValue::GuildScores(GuildScoresPreference::OptedOut),
+                    SettingSource::User,
+                ),
+            },
+        ]
     }
 
     #[test]
-    fn parses_get_options() {
-        let options = string_options(&[
-            (ACTION_OPTION, ACTION_GET),
-            (KEY_OPTION, "title_display"),
-            (SCOPE_OPTION, "effective"),
-        ]);
+    fn register_has_no_options() {
+        let value = serde_json::to_value(register()).expect("command serializes");
 
-        let parsed = parse_settings_options(&options).expect("options should parse");
-
-        assert_eq!(parsed.action, SettingsAction::Get);
-        assert_eq!(parsed.key, SettingKey::TitleDisplay);
-        assert_eq!(parsed.scope, SettingScope::Effective);
-        assert_eq!(parsed.value, None);
+        assert_eq!(value["name"], "settings");
+        assert!(value["options"].as_array().is_none_or(Vec::is_empty));
     }
 
     #[test]
-    fn plans_read_with_requested_scope() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Get,
-            key: SettingKey::TitleDisplay,
-            scope: SettingScope::User,
-            value: None,
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: None,
-        };
-
-        let SettingsCommandPlan::Read(request) = plan_settings_command(options, context) else {
-            panic!("expected read request")
-        };
-
-        assert_eq!(request.user_id, UserId::new(42));
-        assert_eq!(request.guild_id, Some(GuildId::new(7)));
-        assert_eq!(request.key, SettingKey::TitleDisplay);
-        assert_eq!(request.scope, SettingScope::User);
-    }
-
-    #[test]
-    fn formats_only_requested_read_scope() {
-        let content = format_scoped_setting(
-            SettingKey::TitleDisplay,
-            "User",
-            SettingKey::TitleDisplay.parse_value("romaji").ok(),
-        );
-
-        assert!(content.contains("User: `romaji`"));
-        assert!(!content.contains("Guild: `english`"));
-        assert!(!content.contains("Effective: `romaji`"));
-    }
-
-    #[test]
-    fn rejects_guild_analytics_privacy_read() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Get,
-            key: SettingKey::AnalyticsPrivacy,
-            scope: SettingScope::Guild,
-            value: None,
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: Some(Permissions::MANAGE_GUILD),
-        };
-
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        let content = response.unwrap_content();
-        assert!(content.contains("user-level setting"));
-        assert!(content.contains("view or update"));
-    }
-
-    #[test]
-    fn plans_user_write_with_valid_value() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::AnalyticsPrivacy,
-            scope: SettingScope::User,
-            value: Some("opted_out".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: None,
-            member_permissions: None,
-        };
-
-        let SettingsCommandPlan::Write(request) = plan_settings_command(options, context) else {
-            panic!("expected write request")
-        };
-
-        assert_eq!(request.target, SettingsWriteTarget::User(UserId::new(42)));
+    fn parses_stable_component_ids() {
         assert_eq!(
-            request.value,
-            SettingKey::AnalyticsPrivacy
-                .parse_value("opted_out")
-                .unwrap()
+            parse_settings_component_id(&settings_overview_custom_id()),
+            Some(SettingsComponentId::Overview)
         );
-    }
-
-    #[test]
-    fn rejects_guild_write_in_dm() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::TitleDisplay,
-            scope: SettingScope::Guild,
-            value: Some("romaji".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: None,
-            member_permissions: None,
-        };
-
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        assert!(response.unwrap_content().contains("inside a server"));
-    }
-
-    #[test]
-    fn rejects_guild_write_without_manage_guild_permission() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::TitleDisplay,
-            scope: SettingScope::Guild,
-            value: Some("romaji".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: Some(Permissions::VIEW_CHANNEL),
-        };
-
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        assert!(response.unwrap_content().contains("Manage Server"));
-    }
-
-    #[test]
-    fn allows_guild_write_with_manage_guild_permission() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::TitleDisplay,
-            scope: SettingScope::Guild,
-            value: Some("romaji".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: Some(Permissions::MANAGE_GUILD),
-        };
-
-        let SettingsCommandPlan::Write(request) = plan_settings_command(options, context) else {
-            panic!("expected write request")
-        };
-
-        assert_eq!(request.target, SettingsWriteTarget::Guild(GuildId::new(7)));
         assert_eq!(
-            request.value,
-            SettingKey::TitleDisplay.parse_value("romaji").unwrap()
+            parse_settings_component_id(&settings_category_custom_id(SettingKey::GuildScores)),
+            Some(SettingsComponentId::Category(SettingKey::GuildScores))
+        );
+        assert_eq!(
+            parse_settings_component_id("settings:category:unknown"),
+            None
+        );
+        assert_eq!(
+            parse_settings_component_id("search:category:guild_scores"),
+            None
         );
     }
 
     #[test]
-    fn allows_guild_write_with_administrator_permission() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::TitleDisplay,
-            scope: SettingScope::Guild,
-            value: Some("romaji".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: Some(Permissions::ADMINISTRATOR),
-        };
-
-        let SettingsCommandPlan::Write(request) = plan_settings_command(options, context) else {
-            panic!("expected write request")
-        };
-
-        assert_eq!(request.target, SettingsWriteTarget::Guild(GuildId::new(7)));
+    fn detects_settings_components_without_matching_other_prefixes() {
+        assert!(is_settings_component("settings:overview"));
+        assert!(!is_settings_component("search:settings:overview"));
+        assert!(!is_settings_component("settings-panel:overview"));
     }
 
     #[test]
-    fn rejects_guild_analytics_privacy_value() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::AnalyticsPrivacy,
-            scope: SettingScope::Guild,
-            value: Some("opted_out".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: Some(Permissions::MANAGE_GUILD),
-        };
+    fn overview_renders_current_effective_settings() {
+        let panel = plan_settings_panel(SettingsPanelCategory::Overview, true, test_summaries());
+        let content = render_settings_panel(&panel);
 
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        assert!(response.unwrap_content().contains("user-level setting"));
+        assert!(content.contains("**Settings**"));
+        assert!(content.contains("**Title display**"));
+        assert!(content.contains("Effective: `romaji` (Romaji title) (user override)"));
+        assert!(content.contains("User: `romaji` (Romaji title)"));
+        assert!(content.contains("Guild: `english` (English title)"));
+        assert!(content.contains("**Analytics privacy**"));
+        assert!(content.contains("Guild: not applicable"));
+        assert!(content.contains("**Guild scores**"));
     }
 
     #[test]
-    fn rejects_user_guild_scores_disabled_value() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::GuildScores,
-            scope: SettingScope::User,
-            value: Some("disabled".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: None,
-        };
+    fn overview_marks_guild_settings_unavailable_in_dms() {
+        let panel = plan_settings_panel(SettingsPanelCategory::Overview, false, test_summaries());
+        let content = render_settings_panel(&panel);
 
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        let content = response.unwrap_content();
-        assert!(content.contains("opted_out"));
-        assert!(content.contains("only for guild settings"));
+        assert!(content.contains("Guild: not available in DMs"));
     }
 
     #[test]
-    fn rejects_guild_guild_scores_opted_out_value() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::GuildScores,
-            scope: SettingScope::Guild,
-            value: Some("opted_out".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: Some(Permissions::MANAGE_GUILD),
-        };
+    fn category_panel_renders_selected_details() {
+        let panel = plan_settings_panel(
+            SettingsPanelCategory::Setting(SettingKey::GuildScores),
+            true,
+            test_summaries(),
+        );
+        let content = render_settings_panel(&panel);
 
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        let content = response.unwrap_content();
-        assert!(content.contains("disabled"));
-        assert!(content.contains("only for user settings"));
-    }
-
-    #[test]
-    fn rejects_writing_effective_scope() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::TitleDisplay,
-            scope: SettingScope::Effective,
-            value: Some("english".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: Some(GuildId::new(7)),
-            member_permissions: Some(Permissions::MANAGE_GUILD),
-        };
-
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        assert!(response.unwrap_content().contains("read-only"));
-    }
-
-    #[test]
-    fn invalid_value_returns_validation_message() {
-        let options = SettingsCommandOptions {
-            action: SettingsAction::Set,
-            key: SettingKey::TitleDisplay,
-            scope: SettingScope::User,
-            value: Some("kana".to_string()),
-        };
-        let context = SettingsContext {
-            user_id: UserId::new(42),
-            guild_id: None,
-            member_permissions: None,
-        };
-
-        let SettingsCommandPlan::Respond(response) = plan_settings_command(options, context) else {
-            panic!("expected response")
-        };
-
-        let content = response.unwrap_content();
-        assert!(content.contains("kana"));
-        assert!(content.contains("matched, romaji, english, native"));
+        assert!(content.contains("Read-only category details"));
+        assert!(content.contains("**Guild scores**"));
+        assert!(content.contains("Allowed values: `enabled`, `disabled`, `opted_out`"));
+        assert!(!content.contains("**Title display**"));
     }
 }

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -24,6 +24,7 @@ use serenity::{
 use tracing::{error, instrument};
 
 const SETTINGS_COMPONENT_PREFIX: &str = "settings";
+const SETTINGS_COMPONENT_ID_PREFIX: &str = "settings:";
 const OVERVIEW_COMPONENT: &str = "overview";
 const CATEGORY_COMPONENT: &str = "category";
 
@@ -88,7 +89,7 @@ pub fn register() -> CreateCommand {
 
 #[instrument(name = "command.settings.is_component")]
 pub fn is_settings_component(custom_id: &str) -> bool {
-    custom_id.starts_with(concat!("settings", ":"))
+    custom_id.starts_with(SETTINGS_COMPONENT_ID_PREFIX)
 }
 
 #[instrument(name = "command.settings.overview_custom_id")]

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::{
-        db::settings::{ResolvedSettingLayers, SettingsStorageError, resolve_setting_layers},
+        db::settings::{ResolvedSettingLayers, SettingsStorageError, resolve_all_setting_layers},
         settings::{
             ALL_SETTING_KEYS, GuildScoresPreference, SettingKey, SettingScope, SettingValue,
         },
@@ -298,13 +298,11 @@ async fn load_settings_panel(
     guild_id: Option<GuildId>,
     category: SettingsPanelCategory,
 ) -> Result<SettingsPanel, SettingsStorageError> {
-    let mut summaries = Vec::with_capacity(ALL_SETTING_KEYS.len());
-
-    for key in ALL_SETTING_KEYS {
-        summaries.push(SettingSummary {
-            layers: resolve_setting_layers(pool, user_id, guild_id, key).await?,
-        });
-    }
+    let summaries = resolve_all_setting_layers(pool, user_id, guild_id, &ALL_SETTING_KEYS)
+        .await?
+        .into_iter()
+        .map(|layers| SettingSummary { layers })
+        .collect();
 
     Ok(plan_settings_panel(category, guild_id.is_some(), summaries))
 }

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -88,7 +88,7 @@ pub fn register() -> CreateCommand {
 
 #[instrument(name = "command.settings.is_component")]
 pub fn is_settings_component(custom_id: &str) -> bool {
-    custom_id.starts_with(&format!("{SETTINGS_COMPONENT_PREFIX}:"))
+    custom_id.starts_with(concat!("settings", ":"))
 }
 
 #[instrument(name = "command.settings.overview_custom_id")]

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -1,7 +1,9 @@
 use crate::{
     models::{
         db::settings::{ResolvedSettingLayers, SettingsStorageError, resolve_setting_layers},
-        settings::{ALL_SETTING_KEYS, SettingKey, SettingValue},
+        settings::{
+            ALL_SETTING_KEYS, GuildScoresPreference, SettingKey, SettingScope, SettingValue,
+        },
     },
     utils::{
         database::{DbPool, get_pool_from_context},
@@ -14,7 +16,7 @@ use serenity::{
     all::{
         ButtonStyle, CommandInteraction, ComponentInteraction, CreateActionRow, CreateButton,
         CreateInteractionResponse, CreateInteractionResponseMessage, EditInteractionResponse,
-        GuildId, UserId,
+        GuildId, Permissions, UserId,
     },
     builder::CreateCommand,
     client::Context,
@@ -41,6 +43,28 @@ pub struct SettingsPanel {
     pub category: SettingsPanelCategory,
     pub guild_available: bool,
     pub summaries: Vec<SettingSummary>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SettingsContext {
+    pub user_id: UserId,
+    pub guild_id: Option<GuildId>,
+    pub member_permissions: Option<Permissions>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsWriteTarget {
+    User(UserId),
+    Guild(GuildId),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SettingsWritePlan {
+    pub target: SettingsWriteTarget,
+    pub value: SettingValue,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,6 +136,38 @@ pub fn render_settings_panel(panel: &SettingsPanel) -> String {
         SettingsPanelCategory::Overview => render_overview_panel(panel),
         SettingsPanelCategory::Setting(key) => render_category_panel(panel, key),
     }
+}
+
+#[allow(dead_code)]
+#[instrument(name = "command.settings.plan_write", skip(context, value))]
+pub fn plan_settings_write(
+    scope: SettingScope,
+    value: SettingValue,
+    context: SettingsContext,
+) -> Result<SettingsWritePlan, String> {
+    validate_value_for_scope(scope, value)?;
+
+    let target = match scope {
+        SettingScope::Effective => {
+            return Err("`effective` is read-only because it is resolved from user, guild, and default settings. Choose `user` or `guild` when setting a value.".to_string());
+        }
+        SettingScope::User => SettingsWriteTarget::User(context.user_id),
+        SettingScope::Guild => {
+            let Some(guild_id) = context.guild_id else {
+                return Err("Guild settings can only be changed from inside a server.".to_string());
+            };
+
+            if !can_manage_guild_settings(context.member_permissions) {
+                return Err(
+                    "You need the Manage Server permission to change guild settings.".to_string(),
+                );
+            }
+
+            SettingsWriteTarget::Guild(guild_id)
+        }
+    };
+
+    Ok(SettingsWritePlan { target, value })
 }
 
 #[instrument(name = "command.settings.run", skip(ctx, interaction))]
@@ -340,6 +396,40 @@ fn format_guild_layer(
     }
 
     format_optional_layer(value)
+}
+
+#[allow(dead_code)]
+#[instrument(name = "command.settings.validate_value_for_scope", skip(value))]
+fn validate_value_for_scope(scope: SettingScope, value: SettingValue) -> Result<(), String> {
+    match (scope, value) {
+        (SettingScope::User, SettingValue::GuildScores(GuildScoresPreference::Disabled)) => Err(
+            "Use `opted_out` to exclude yourself from guild scores, or `enabled` to participate. `disabled` is only for guild settings."
+                .to_string(),
+        ),
+        (SettingScope::Guild, SettingValue::AnalyticsPrivacy(_)) => {
+            Err(analytics_privacy_user_scope_message().to_string())
+        }
+        (SettingScope::Guild, SettingValue::GuildScores(GuildScoresPreference::OptedOut)) => Err(
+            "Use `disabled` to turn guild scores off for the server, or `enabled` to allow participating users. `opted_out` is only for user settings."
+                .to_string(),
+        ),
+        _ => Ok(()),
+    }
+}
+
+#[allow(dead_code)]
+#[instrument(name = "command.settings.analytics_privacy_user_scope_message")]
+fn analytics_privacy_user_scope_message() -> &'static str {
+    "Analytics privacy is a user-level setting. Choose the `user` scope to view or update your own analytics preference."
+}
+
+#[allow(dead_code)]
+#[instrument(name = "command.settings.can_manage_guild_settings")]
+fn can_manage_guild_settings(permissions: Option<Permissions>) -> bool {
+    permissions.is_some_and(|permissions| {
+        permissions.contains(Permissions::MANAGE_GUILD)
+            || permissions.contains(Permissions::ADMINISTRATOR)
+    })
 }
 
 #[instrument(name = "command.settings.format_value", skip(value))]
@@ -592,5 +682,67 @@ mod tests {
         assert!(content.contains("**Guild scores**"));
         assert!(content.contains("Allowed values: `enabled`, `disabled`, `opted_out`"));
         assert!(!content.contains("**Title display**"));
+    }
+
+    #[test]
+    fn write_planning_preserves_user_target_for_future_edit_flow() {
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: None,
+        };
+        let value = SettingValue::AnalyticsPrivacy(AnalyticsPrivacyPreference::OptedOut);
+
+        let plan = plan_settings_write(SettingScope::User, value, context)
+            .expect("user write should be planned");
+
+        assert_eq!(plan.target, SettingsWriteTarget::User(UserId::new(42)));
+        assert_eq!(plan.value, value);
+    }
+
+    #[test]
+    fn write_planning_preserves_guild_permission_check_for_future_edit_flow() {
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: Some(Permissions::VIEW_CHANNEL),
+        };
+        let value = SettingValue::TitleDisplay(TitleDisplayPreference::English);
+
+        let error = plan_settings_write(SettingScope::Guild, value, context)
+            .expect_err("guild writes require Manage Server");
+
+        assert!(error.contains("Manage Server"));
+    }
+
+    #[test]
+    fn write_planning_preserves_guild_target_for_future_edit_flow() {
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: Some(Permissions::MANAGE_GUILD),
+        };
+        let value = SettingValue::TitleDisplay(TitleDisplayPreference::English);
+
+        let plan = plan_settings_write(SettingScope::Guild, value, context)
+            .expect("guild write should be planned");
+
+        assert_eq!(plan.target, SettingsWriteTarget::Guild(GuildId::new(7)));
+        assert_eq!(plan.value, value);
+    }
+
+    #[test]
+    fn write_planning_preserves_scope_value_validation_for_future_edit_flow() {
+        let context = SettingsContext {
+            user_id: UserId::new(42),
+            guild_id: Some(GuildId::new(7)),
+            member_permissions: Some(Permissions::MANAGE_GUILD),
+        };
+        let value = SettingValue::GuildScores(GuildScoresPreference::OptedOut);
+
+        let error = plan_settings_write(SettingScope::Guild, value, context)
+            .expect_err("guild scope cannot use user opt-out value");
+
+        assert!(error.contains("only for user settings"));
     }
 }

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -374,9 +374,7 @@ fn format_summary(
 
 #[instrument(name = "command.settings.format_optional_layer", skip(value))]
 fn format_optional_layer(value: Option<SettingValue>) -> String {
-    value
-        .map(format_setting_value)
-        .unwrap_or_else(|| "not set".to_string())
+    value.map_or_else(|| "not set".to_string(), format_setting_value)
 }
 
 #[instrument(name = "command.settings.format_guild_layer", skip(value))]

--- a/src/commands/settings/mod.rs
+++ b/src/commands/settings/mod.rs
@@ -1,3 +1,3 @@
 pub mod command;
 
-pub use command::{register, run};
+pub use command::{handle_component, is_settings_component, register, run};

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,9 @@ use tracing::{Instrument, info, info_span, instrument, warn};
 use tracing_subscriber::{EnvFilter, prelude::*, util::SubscriberInitExt};
 
 use serenity::{
-    all::{CreateEmbed, CreateMessage},
+    all::{
+        CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage,
+    },
     async_trait,
     builder::CreateCommand,
     client::{Client, Context, EventHandler},
@@ -59,49 +61,82 @@ struct Handler {
 impl EventHandler for Handler {
     #[instrument(name = "discord.interaction_create", skip_all)]
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
-        if let Interaction::Command(mut command) = interaction {
-            let guild_id = command
-                .guild_id
-                .map(|guild_id| hash_discord_id(guild_id.get()).to_string());
-            let command_span = info_span!(
-                "discord.command",
-                command_name = %command.data.name,
-                user_id = %hash_user_id(command.user.id.get()),
-                guild_id = guild_id.as_deref()
-            );
+        match interaction {
+            Interaction::Command(mut command) => {
+                let guild_id = command
+                    .guild_id
+                    .map(|guild_id| hash_discord_id(guild_id.get()).to_string());
+                let command_span = info_span!(
+                    "discord.command",
+                    command_name = %command.data.name,
+                    user_id = %hash_user_id(command.user.id.get()),
+                    guild_id = guild_id.as_deref()
+                );
 
-            async {
-                info!("Received command interaction");
-                self.capture_command_hit(&ctx, &command);
+                async {
+                    info!("Received command interaction");
+                    self.capture_command_hit(&ctx, &command);
 
-                match command.data.name.as_str() {
-                    "ping" => commands::ping::run(&ctx, &command).await,
-                    "help" => commands::help::run(&ctx, &command).await,
-                    "songs" => commands::songs::command::run(&ctx, &mut command).await,
-                    "manga" => commands::manga::command::run(&ctx, &mut command).await,
-                    "anime" => commands::anime::command::run(&ctx, &mut command).await,
-                    "search" => commands::search::command::run(&ctx, &mut command).await,
-                    "recommend" => commands::recommend::command::run(&ctx, &mut command).await,
-                    "character" => commands::character::command::run(&ctx, &mut command).await,
-                    "register" => commands::register::command::run(&ctx, &mut command).await,
-                    "unregister" => commands::unregister::run(&ctx, &mut command).await,
-                    "whoami" => commands::whoami::run(&ctx, &mut command).await,
-                    "settings" => commands::settings::run(&ctx, &mut command).await,
-                    _ => {
-                        let embed = CreateEmbed::new()
-                            .title("Error")
-                            .description("Not implemented");
-                        let builder = CreateMessage::new().embed(embed);
-                        let msg = command.channel_id.send_message(&ctx.http, builder).await;
-                        if let Err(why) = msg {
-                            println!("Error sending message: {why:?}");
-                            info!("Cannot respond to slash command: {why}");
+                    match command.data.name.as_str() {
+                        "ping" => commands::ping::run(&ctx, &command).await,
+                        "help" => commands::help::run(&ctx, &command).await,
+                        "songs" => commands::songs::command::run(&ctx, &mut command).await,
+                        "manga" => commands::manga::command::run(&ctx, &mut command).await,
+                        "anime" => commands::anime::command::run(&ctx, &mut command).await,
+                        "search" => commands::search::command::run(&ctx, &mut command).await,
+                        "recommend" => commands::recommend::command::run(&ctx, &mut command).await,
+                        "character" => commands::character::command::run(&ctx, &mut command).await,
+                        "register" => commands::register::command::run(&ctx, &mut command).await,
+                        "unregister" => commands::unregister::run(&ctx, &mut command).await,
+                        "whoami" => commands::whoami::run(&ctx, &mut command).await,
+                        "settings" => commands::settings::run(&ctx, &mut command).await,
+                        _ => {
+                            let embed = CreateEmbed::new()
+                                .title("Error")
+                                .description("Not implemented");
+                            let builder = CreateMessage::new().embed(embed);
+                            let msg = command.channel_id.send_message(&ctx.http, builder).await;
+                            if let Err(why) = msg {
+                                println!("Error sending message: {why:?}");
+                                info!("Cannot respond to slash command: {why}");
+                            }
                         }
-                    }
-                };
+                    };
+                }
+                .instrument(command_span)
+                .await;
             }
-            .instrument(command_span)
-            .await;
+            Interaction::Component(mut component) => {
+                let guild_id = component
+                    .guild_id
+                    .map(|guild_id| hash_discord_id(guild_id.get()).to_string());
+                let component_span = info_span!(
+                    "discord.component",
+                    custom_id = %component.data.custom_id,
+                    user_id = %hash_user_id(component.user.id.get()),
+                    guild_id = guild_id.as_deref()
+                );
+
+                async {
+                    info!("Received component interaction");
+
+                    if commands::settings::is_settings_component(&component.data.custom_id) {
+                        commands::settings::handle_component(&ctx, &mut component).await;
+                    } else {
+                        let builder = CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new()
+                                .content(
+                                    "I don't recognize that control. Please run the command again.",
+                                )
+                                .ephemeral(true),
+                        );
+                        let _ = component.create_response(&ctx.http, builder).await;
+                    }
+                }
+                .instrument(component_span)
+                .await;
+            }
+            _ => {}
         }
     }
 

--- a/src/models/db/settings.rs
+++ b/src/models/db/settings.rs
@@ -223,6 +223,79 @@ pub async fn get_user_settings_for_discord_ids(
 }
 
 #[instrument(
+    name = "db.settings.resolve_all_setting_layers",
+    skip(pool, user_discord_id, guild_id, setting_keys),
+    fields(
+        discord_user_id = %hash_user_id(user_discord_id.get()),
+        guild_id = guild_id.map(|id| hash_discord_id(id.get()).to_string()),
+        setting_count = setting_keys.len()
+    )
+)]
+pub async fn resolve_all_setting_layers(
+    pool: &DbPool,
+    user_discord_id: UserId,
+    guild_id: Option<GuildId>,
+    setting_keys: &[SettingKey],
+) -> Result<Vec<ResolvedSettingLayers>, SettingsStorageError> {
+    if setting_keys.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let setting_key_names = setting_keys
+        .iter()
+        .map(|key| key.as_str().to_string())
+        .collect::<Vec<_>>();
+
+    let mut transaction = pool.begin().await?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        .execute(&mut *transaction)
+        .await?;
+
+    let user_rows = sqlx::query_as::<_, StoredSettingRow>(
+        "SELECT setting_key, setting_value FROM annie_mei.user_settings \
+         WHERE discord_user_id = $1 AND setting_key = ANY($2)",
+    )
+    .bind(user_discord_id.get().to_string())
+    .bind(&setting_key_names)
+    .fetch_all(&mut *transaction)
+    .await?;
+    let user_values = parse_stored_settings(user_rows)?;
+
+    let guild_values = match guild_id {
+        Some(guild_id) => {
+            let guild_rows = sqlx::query_as::<_, StoredSettingRow>(
+                "SELECT setting_key, setting_value FROM annie_mei.guild_settings \
+                 WHERE guild_id = $1 AND setting_key = ANY($2)",
+            )
+            .bind(guild_id.get().to_string())
+            .bind(&setting_key_names)
+            .fetch_all(&mut *transaction)
+            .await?;
+
+            parse_stored_settings(guild_rows)?
+        }
+        None => Vec::new(),
+    };
+
+    transaction.commit().await?;
+
+    Ok(setting_keys
+        .iter()
+        .map(|key| {
+            let user = setting_value_for_key(&user_values, *key);
+            let guild = setting_value_for_key(&guild_values, *key);
+            let effective = resolve_scoped_setting(*key, ScopedSettingValues { user, guild });
+
+            ResolvedSettingLayers {
+                user,
+                guild,
+                effective,
+            }
+        })
+        .collect())
+}
+
+#[instrument(
     name = "db.settings.resolve_setting_layers",
     skip(pool, user_discord_id, guild_id),
     fields(
@@ -237,46 +310,38 @@ pub async fn resolve_setting_layers(
     guild_id: Option<GuildId>,
     setting_key: SettingKey,
 ) -> Result<ResolvedSettingLayers, SettingsStorageError> {
-    let mut transaction = pool.begin().await?;
-    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
-        .execute(&mut *transaction)
-        .await?;
+    let layers =
+        resolve_all_setting_layers(pool, user_discord_id, guild_id, &[setting_key]).await?;
 
-    let user_row = sqlx::query_as::<_, StoredSettingRow>(
-        "SELECT setting_key, setting_value FROM annie_mei.user_settings \
-         WHERE discord_user_id = $1 AND setting_key = $2",
-    )
-    .bind(user_discord_id.get().to_string())
-    .bind(setting_key.as_str())
-    .fetch_optional(&mut *transaction)
-    .await?;
-    let user = parse_optional_setting(user_row, setting_key)?;
+    Ok(layers
+        .into_iter()
+        .next()
+        .expect("single-key resolve should return one layer"))
+}
 
-    let guild = match guild_id {
-        Some(guild_id) => {
-            let row = sqlx::query_as::<_, StoredSettingRow>(
-                "SELECT setting_key, setting_value FROM annie_mei.guild_settings \
-                 WHERE guild_id = $1 AND setting_key = $2",
-            )
-            .bind(guild_id.get().to_string())
-            .bind(setting_key.as_str())
-            .fetch_optional(&mut *transaction)
-            .await?;
+#[instrument(name = "db.settings.parse_stored_settings", skip(rows))]
+fn parse_stored_settings(
+    rows: Vec<StoredSettingRow>,
+) -> Result<Vec<(SettingKey, SettingValue)>, SettingsStorageError> {
+    rows.into_iter()
+        .filter_map(|row| {
+            SettingKey::parse(&row.setting_key).map(|key| {
+                key.parse_value(&row.setting_value)
+                    .map(|value| (key, value))
+                    .map_err(Into::into)
+            })
+        })
+        .collect()
+}
 
-            parse_optional_setting(row, setting_key)?
-        }
-        None => None,
-    };
-
-    transaction.commit().await?;
-
-    let effective = resolve_scoped_setting(setting_key, ScopedSettingValues { user, guild });
-
-    Ok(ResolvedSettingLayers {
-        user,
-        guild,
-        effective,
-    })
+#[instrument(name = "db.settings.setting_value_for_key", skip(values))]
+fn setting_value_for_key(
+    values: &[(SettingKey, SettingValue)],
+    setting_key: SettingKey,
+) -> Option<SettingValue> {
+    values
+        .iter()
+        .find_map(|(key, value)| (*key == setting_key).then_some(*value))
 }
 
 #[instrument(name = "db.settings.parse_optional_setting", skip(row), fields(setting_key = %setting_key.as_str()))]

--- a/src/models/db/settings.rs
+++ b/src/models/db/settings.rs
@@ -97,6 +97,7 @@ pub struct ResolvedSettingLayers {
         setting_key = %value.key().as_str()
     )
 )]
+#[allow(dead_code)]
 pub async fn set_user_setting(
     pool: &DbPool,
     user_discord_id: UserId,
@@ -122,6 +123,7 @@ pub async fn set_user_setting(
     skip(pool, guild_id, value),
     fields(guild_id = %hash_discord_id(guild_id.get()), setting_key = %value.key().as_str())
 )]
+#[allow(dead_code)]
 pub async fn set_guild_setting(
     pool: &DbPool,
     guild_id: GuildId,

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -4,6 +4,7 @@ use std::fmt;
 
 use tracing::instrument;
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingScope {
     Effective,
@@ -11,12 +12,14 @@ pub enum SettingScope {
     Guild,
 }
 
+#[allow(dead_code)]
 pub const ALL_SETTING_SCOPES: [SettingScope; 3] = [
     SettingScope::Effective,
     SettingScope::User,
     SettingScope::Guild,
 ];
 
+#[allow(dead_code)]
 impl SettingScope {
     pub fn parse(raw: &str) -> Option<Self> {
         match normalize_token(raw).as_str() {
@@ -208,6 +211,7 @@ pub enum SettingValue {
 }
 
 impl SettingValue {
+    #[allow(dead_code)]
     pub fn key(self) -> SettingKey {
         match self {
             Self::TitleDisplay(_) => SettingKey::TitleDisplay,


### PR DESCRIPTION
## Summary

Adds a no-argument ephemeral settings panel that summarizes current/effective settings and routes settings component interactions to settings-specific handlers.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- d1864daea5914dd100bc63b9541163d395632c18: add the read-only settings panel, stable settings custom IDs, category controls, and targeted panel/custom ID tests
- 363a7deda4f20ffd700512ee6acf5b9a0ae50214: route message component interactions through settings-specific code without affecting slash command dispatch
- f89163d1ced350dfaa737c4870c2c5c3a0c903a6: keep deferred settings edit storage/model helpers available for the upcoming editable panel work while avoiding dead-code warnings
- a8e978ffd6fbe77105153882d038d849d01ee72f: preserve reusable write planning, validation, and permission helpers for the upcoming editable panel work

### Notes

The panel is intentionally read-only; editable settings flows are left for follow-up work.

## Validation
- [x] cargo test
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] reviewer subagent pass with no actionable findings after fixes

---

This PR description was written by GPT-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->