### PR TITLE
[ANNIE-194]/make settings panel editable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -171,7 +171,15 @@ pub fn plan_settings_write(
         .parse_value(raw_value)
         .map_err(|error| SettingsWriteError::InvalidValue(error.to_string()))?;
 
-    if !allowed_values_for_scope(scope, key).contains(&value.as_storage_value()) {
+    let Some(allowed_values) = allowed_values_for_scope(scope, key) else {
+        return Err(SettingsWriteError::InvalidValue(format!(
+            "{} does not support a {}.",
+            key.label(),
+            scope.label()
+        )));
+    };
+
+    if !allowed_values.contains(&value.as_storage_value()) {
         return Err(SettingsWriteError::InvalidValue(format!(
             "{} cannot be saved as a {}.",
             format_setting_value(value),
@@ -625,6 +633,7 @@ fn setting_select_row(
     selected: Option<SettingValue>,
 ) -> CreateActionRow {
     let options = allowed_values_for_scope(scope, key)
+        .unwrap_or(&[])
         .iter()
         .filter_map(|raw_value| setting_select_option(key, raw_value, selected))
         .collect::<Vec<_>>();
@@ -659,12 +668,15 @@ fn guild_select_available(key: SettingKey, guild_available: bool, can_manage_gui
 }
 
 #[instrument(name = "command.settings.allowed_values_for_scope")]
-fn allowed_values_for_scope(scope: SettingScope, key: SettingKey) -> &'static [&'static str] {
+fn allowed_values_for_scope(
+    scope: SettingScope,
+    key: SettingKey,
+) -> Option<&'static [&'static str]> {
     match (scope, key) {
-        (SettingScope::User, SettingKey::GuildScores) => &["enabled", "opted_out"],
-        (SettingScope::Guild, SettingKey::GuildScores) => &["enabled", "disabled"],
-        (SettingScope::Guild, SettingKey::AnalyticsPrivacy) => &[],
-        _ => key.allowed_values(),
+        (SettingScope::User, SettingKey::GuildScores) => Some(&["enabled", "opted_out"]),
+        (SettingScope::Guild, SettingKey::GuildScores) => Some(&["enabled", "disabled"]),
+        (SettingScope::Guild, SettingKey::AnalyticsPrivacy) => None,
+        _ => Some(key.allowed_values()),
     }
 }
 
@@ -1007,11 +1019,15 @@ mod tests {
     fn guild_scores_scope_values_prevent_invalid_combinations() {
         assert_eq!(
             allowed_values_for_scope(SettingScope::User, SettingKey::GuildScores),
-            &["enabled", "opted_out"]
+            Some(&["enabled", "opted_out"][..])
         );
         assert_eq!(
             allowed_values_for_scope(SettingScope::Guild, SettingKey::GuildScores),
-            &["enabled", "disabled"]
+            Some(&["enabled", "disabled"][..])
+        );
+        assert_eq!(
+            allowed_values_for_scope(SettingScope::Guild, SettingKey::AnalyticsPrivacy),
+            None
         );
     }
 

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -583,25 +583,24 @@ fn settings_panel_components(panel: &SettingsPanel) -> Vec<CreateActionRow> {
         ),
     ])];
 
-    if let SettingsPanelCategory::Setting(key) = active {
-        if let Some(summary) = panel
+    if let SettingsPanelCategory::Setting(key) = active
+        && let Some(summary) = panel
             .summaries
             .iter()
             .find(|summary| summary.layers.effective.key == key)
-        {
-            rows.push(setting_select_row(
-                SettingScope::User,
-                key,
-                summary.layers.user,
-            ));
+    {
+        rows.push(setting_select_row(
+            SettingScope::User,
+            key,
+            summary.layers.user,
+        ));
 
-            if guild_select_available(key, panel.guild_available) {
-                rows.push(setting_select_row(
-                    SettingScope::Guild,
-                    key,
-                    summary.layers.guild,
-                ));
-            }
+        if guild_select_available(key, panel.guild_available) {
+            rows.push(setting_select_row(
+                SettingScope::Guild,
+                key,
+                summary.layers.guild,
+            ));
         }
     }
 

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -1,6 +1,9 @@
 use crate::{
     models::{
-        db::settings::{ResolvedSettingLayers, SettingsStorageError, resolve_all_setting_layers},
+        db::settings::{
+            ResolvedSettingLayers, SettingsStorageError, resolve_all_setting_layers,
+            set_guild_setting, set_user_setting,
+        },
         settings::{ALL_SETTING_KEYS, SettingKey, SettingValue},
     },
     utils::{
@@ -12,9 +15,10 @@ use crate::{
 
 use serenity::{
     all::{
-        ButtonStyle, CommandInteraction, ComponentInteraction, CreateActionRow, CreateButton,
-        CreateInteractionResponse, CreateInteractionResponseMessage, EditInteractionResponse,
-        GuildId, UserId,
+        ButtonStyle, CommandInteraction, ComponentInteraction, ComponentInteractionDataKind,
+        CreateActionRow, CreateButton, CreateInteractionResponse, CreateInteractionResponseMessage,
+        CreateSelectMenu, CreateSelectMenuKind, CreateSelectMenuOption, EditInteractionResponse,
+        GuildId, Permissions, UserId,
     },
     builder::CreateCommand,
     client::Context,
@@ -25,6 +29,7 @@ const SETTINGS_COMPONENT_PREFIX: &str = "settings";
 const SETTINGS_COMPONENT_ID_PREFIX: &str = "settings:";
 const OVERVIEW_COMPONENT: &str = "overview";
 const CATEGORY_COMPONENT: &str = "category";
+const SET_COMPONENT: &str = "set";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettingsPanelCategory {
@@ -48,6 +53,7 @@ pub struct SettingsPanel {
 pub enum SettingsComponentId {
     Overview,
     Category(SettingKey),
+    Set(SettingScope, SettingKey),
 }
 
 impl SettingsComponentId {
@@ -55,8 +61,52 @@ impl SettingsComponentId {
         match self {
             Self::Overview => SettingsPanelCategory::Overview,
             Self::Category(key) => SettingsPanelCategory::Setting(*key),
+            Self::Set(_, key) => SettingsPanelCategory::Setting(*key),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingScope {
+    User,
+    Guild,
+}
+
+impl SettingScope {
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "user" => Some(Self::User),
+            "guild" => Some(Self::Guild),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Guild => "guild",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::User => "user setting",
+            Self::Guild => "server setting",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsWritePlan {
+    User(SettingValue),
+    Guild(SettingValue),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsWriteError {
+    MissingGuild,
+    MissingManageGuild,
+    InvalidValue(String),
 }
 
 pub fn register() -> CreateCommand {
@@ -81,6 +131,15 @@ pub fn settings_category_custom_id(key: SettingKey) -> String {
     )
 }
 
+#[instrument(name = "command.settings.set_custom_id", fields(scope = %scope.as_str(), setting_key = %key.as_str()))]
+pub fn settings_set_custom_id(scope: SettingScope, key: SettingKey) -> String {
+    format!(
+        "{SETTINGS_COMPONENT_PREFIX}:{SET_COMPONENT}:{}:{}",
+        scope.as_str(),
+        key.as_str()
+    )
+}
+
 #[instrument(name = "command.settings.parse_component_id")]
 pub fn parse_settings_component_id(custom_id: &str) -> Option<SettingsComponentId> {
     let parts = custom_id.split(':').collect::<Vec<_>>();
@@ -90,7 +149,40 @@ pub fn parse_settings_component_id(custom_id: &str) -> Option<SettingsComponentI
         [SETTINGS_COMPONENT_PREFIX, CATEGORY_COMPONENT, raw_key] => {
             SettingKey::parse(raw_key).map(SettingsComponentId::Category)
         }
+        [SETTINGS_COMPONENT_PREFIX, SET_COMPONENT, raw_scope, raw_key] => {
+            let scope = SettingScope::parse(raw_scope)?;
+            let key = SettingKey::parse(raw_key)?;
+            Some(SettingsComponentId::Set(scope, key))
+        }
         _ => None,
+    }
+}
+
+#[instrument(name = "command.settings.plan_write")]
+pub fn plan_settings_write(
+    scope: SettingScope,
+    key: SettingKey,
+    raw_value: &str,
+    guild_available: bool,
+    can_manage_guild: bool,
+) -> Result<SettingsWritePlan, SettingsWriteError> {
+    let value = key
+        .parse_value(raw_value)
+        .map_err(|error| SettingsWriteError::InvalidValue(error.to_string()))?;
+
+    if !allowed_values_for_scope(scope, key).contains(&value.as_storage_value()) {
+        return Err(SettingsWriteError::InvalidValue(format!(
+            "{} cannot be saved as a {}.",
+            format_setting_value(value),
+            scope.label()
+        )));
+    }
+
+    match scope {
+        SettingScope::User => Ok(SettingsWritePlan::User(value)),
+        SettingScope::Guild if !guild_available => Err(SettingsWriteError::MissingGuild),
+        SettingScope::Guild if !can_manage_guild => Err(SettingsWriteError::MissingManageGuild),
+        SettingScope::Guild => Ok(SettingsWritePlan::Guild(value)),
     }
 }
 
@@ -112,6 +204,17 @@ pub fn render_settings_panel(panel: &SettingsPanel) -> String {
     match panel.category {
         SettingsPanelCategory::Overview => render_overview_panel(panel),
         SettingsPanelCategory::Setting(key) => render_category_panel(panel, key),
+    }
+}
+
+#[instrument(
+    name = "command.settings.render_panel_with_notice",
+    skip(panel, notice)
+)]
+fn render_settings_panel_with_notice(panel: &SettingsPanel, notice: Option<&str>) -> String {
+    match notice {
+        Some(notice) => format!("{}\n\n{}", bold(notice), render_settings_panel(panel)),
+        None => render_settings_panel(panel),
     }
 }
 
@@ -160,7 +263,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         interaction,
         ctx,
         render_settings_panel(&response),
-        settings_panel_components(response.category),
+        settings_panel_components(&response),
     )
     .await;
 }
@@ -203,6 +306,95 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
     };
 
     let category = component_id.panel_category();
+    let notice = match component_id {
+        SettingsComponentId::Overview | SettingsComponentId::Category(_) => None,
+        SettingsComponentId::Set(scope, key) => {
+            let Some(raw_value) = selected_string_value(interaction) else {
+                respond_to_component(
+                    interaction,
+                    ctx,
+                    "I couldn't read that settings value. Please try again.".to_string(),
+                    Vec::new(),
+                )
+                .await;
+                return;
+            };
+
+            match plan_settings_write(
+                scope,
+                key,
+                raw_value,
+                interaction.guild_id.is_some(),
+                can_manage_guild_settings(interaction),
+            ) {
+                Ok(SettingsWritePlan::User(value)) => {
+                    if let Err(error) =
+                        set_user_setting(&database_pool, interaction.user.id, value).await
+                    {
+                        log_settings_storage_error(
+                            "set_user",
+                            interaction.user.id,
+                            interaction.guild_id,
+                            &error,
+                        );
+                        respond_to_component(
+                            interaction,
+                            ctx,
+                            "I hit an internal error while saving your setting. Please try again later."
+                                .to_string(),
+                            Vec::new(),
+                        )
+                        .await;
+                        return;
+                    }
+
+                    Some(format!(
+                        "Saved {} as your {}.",
+                        format_setting_value(value),
+                        key.label()
+                    ))
+                }
+                Ok(SettingsWritePlan::Guild(value)) => {
+                    let Some(guild_id) = interaction.guild_id else {
+                        respond_to_component(
+                            interaction,
+                            ctx,
+                            settings_write_error_message(SettingsWriteError::MissingGuild),
+                            Vec::new(),
+                        )
+                        .await;
+                        return;
+                    };
+
+                    if let Err(error) = set_guild_setting(&database_pool, guild_id, value).await {
+                        log_settings_storage_error(
+                            "set_guild",
+                            interaction.user.id,
+                            interaction.guild_id,
+                            &error,
+                        );
+                        respond_to_component(
+                            interaction,
+                            ctx,
+                            "I hit an internal error while saving the server setting. Please try again later."
+                                .to_string(),
+                            Vec::new(),
+                        )
+                        .await;
+                        return;
+                    }
+
+                    Some(format!(
+                        "Saved {} as this server's {}.",
+                        format_setting_value(value),
+                        key.label()
+                    ))
+                }
+                Err(error) => Some(settings_write_error_message(error)),
+            }
+        }
+    };
+
     let response = match load_settings_panel(
         &database_pool,
         interaction.user.id,
@@ -234,8 +426,8 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
     respond_to_component(
         interaction,
         ctx,
-        render_settings_panel(&response),
-        settings_panel_components(response.category),
+        render_settings_panel_with_notice(&response, notice.as_deref()),
+        settings_panel_components(&response),
     )
     .await;
 }
@@ -260,7 +452,7 @@ async fn load_settings_panel(
 fn render_overview_panel(panel: &SettingsPanel) -> String {
     let mut sections = vec![
         format!("{}", bold("Settings")),
-        "Read-only summary of your current Annie Mei preferences. Use the buttons below to inspect each category; changing values will be added in a later update.".to_string(),
+        "Summary of your current Annie Mei preferences. Use the buttons below to inspect and edit each category.".to_string(),
     ];
 
     sections.extend(
@@ -286,7 +478,7 @@ fn render_category_panel(panel: &SettingsPanel, key: SettingKey) -> String {
     format!(
         "{}\n{}\n\n{}",
         bold("Settings"),
-        "Read-only category details. Use Overview to return to the full settings summary.",
+        "Use the menus below to update this category. Use Overview to return to the full settings summary.",
         format_summary(summary, panel.guild_available, true),
     )
 }
@@ -361,9 +553,10 @@ fn format_allowed_values(key: SettingKey) -> String {
         .join(", ")
 }
 
-#[instrument(name = "command.settings.components")]
-fn settings_panel_components(active: SettingsPanelCategory) -> Vec<CreateActionRow> {
-    vec![CreateActionRow::Buttons(vec![
+#[instrument(name = "command.settings.components", skip(panel))]
+fn settings_panel_components(panel: &SettingsPanel) -> Vec<CreateActionRow> {
+    let active = panel.category;
+    let mut rows = vec![CreateActionRow::Buttons(vec![
         panel_button(
             SettingsPanelCategory::Overview,
             "Overview",
@@ -388,7 +581,112 @@ fn settings_panel_components(active: SettingsPanelCategory) -> Vec<CreateActionR
             settings_category_custom_id(SettingKey::GuildScores),
             active,
         ),
-    ])]
+    ])];
+
+    if let SettingsPanelCategory::Setting(key) = active {
+        if let Some(summary) = panel
+            .summaries
+            .iter()
+            .find(|summary| summary.layers.effective.key == key)
+        {
+            rows.push(setting_select_row(
+                SettingScope::User,
+                key,
+                summary.layers.user,
+            ));
+
+            if guild_select_available(key, panel.guild_available) {
+                rows.push(setting_select_row(
+                    SettingScope::Guild,
+                    key,
+                    summary.layers.guild,
+                ));
+            }
+        }
+    }
+
+    rows
+}
+
+#[instrument(name = "command.settings.setting_select_row", skip(selected))]
+fn setting_select_row(
+    scope: SettingScope,
+    key: SettingKey,
+    selected: Option<SettingValue>,
+) -> CreateActionRow {
+    let options = allowed_values_for_scope(scope, key)
+        .iter()
+        .filter_map(|raw_value| setting_select_option(key, raw_value, selected))
+        .collect::<Vec<_>>();
+
+    CreateActionRow::SelectMenu(
+        CreateSelectMenu::new(
+            settings_set_custom_id(scope, key),
+            CreateSelectMenuKind::String { options },
+        )
+        .placeholder(format!("Set {} {}", scope.as_str(), key.label()))
+        .min_values(1)
+        .max_values(1),
+    )
+}
+
+#[instrument(name = "command.settings.setting_select_option", skip(selected))]
+fn setting_select_option(
+    key: SettingKey,
+    raw_value: &str,
+    selected: Option<SettingValue>,
+) -> Option<CreateSelectMenuOption> {
+    let value = key.parse_value(raw_value).ok()?;
+    Some(
+        CreateSelectMenuOption::new(value.display_label(), value.as_storage_value())
+            .description(raw_value)
+            .default_selection(selected == Some(value)),
+    )
+}
+
+#[instrument(name = "command.settings.guild_select_available")]
+fn guild_select_available(key: SettingKey, guild_available: bool) -> bool {
+    guild_available && key != SettingKey::AnalyticsPrivacy
+}
+
+#[instrument(name = "command.settings.allowed_values_for_scope")]
+fn allowed_values_for_scope(scope: SettingScope, key: SettingKey) -> &'static [&'static str] {
+    match (scope, key) {
+        (SettingScope::User, SettingKey::GuildScores) => &["enabled", "opted_out"],
+        (SettingScope::Guild, SettingKey::GuildScores) => &["enabled", "disabled"],
+        (SettingScope::Guild, SettingKey::AnalyticsPrivacy) => &[],
+        _ => key.allowed_values(),
+    }
+}
+
+#[instrument(name = "command.settings.selected_string_value", skip(interaction))]
+fn selected_string_value(interaction: &ComponentInteraction) -> Option<&str> {
+    match &interaction.data.kind {
+        ComponentInteractionDataKind::StringSelect { values } => values.first().map(String::as_str),
+        _ => None,
+    }
+}
+
+#[instrument(name = "command.settings.can_manage_guild", skip(interaction))]
+fn can_manage_guild_settings(interaction: &ComponentInteraction) -> bool {
+    interaction
+        .member
+        .as_ref()
+        .and_then(|member| member.permissions)
+        .is_some_and(|permissions| permissions.contains(Permissions::MANAGE_GUILD))
+}
+
+#[instrument(name = "command.settings.write_error_message")]
+fn settings_write_error_message(error: SettingsWriteError) -> String {
+    match error {
+        SettingsWriteError::MissingGuild => {
+            "Server settings can only be changed from inside a server.".to_string()
+        }
+        SettingsWriteError::MissingManageGuild => {
+            "You need the Manage Server permission to change server settings.".to_string()
+        }
+        SettingsWriteError::InvalidValue(message) => message,
+    }
 }
 
 #[instrument(name = "command.settings.panel_button")]
@@ -545,6 +843,16 @@ mod tests {
             None
         );
         assert_eq!(
+            parse_settings_component_id(&settings_set_custom_id(
+                SettingScope::Guild,
+                SettingKey::TitleDisplay
+            )),
+            Some(SettingsComponentId::Set(
+                SettingScope::Guild,
+                SettingKey::TitleDisplay
+            ))
+        );
+        assert_eq!(
             parse_settings_component_id("search:category:guild_scores"),
             None
         );
@@ -589,9 +897,165 @@ mod tests {
         );
         let content = render_settings_panel(&panel);
 
-        assert!(content.contains("Read-only category details"));
+        assert!(content.contains("Use the menus below to update this category"));
         assert!(content.contains("**Guild scores**"));
         assert!(content.contains("Allowed values: `enabled`, `disabled`, `opted_out`"));
         assert!(!content.contains("**Title display**"));
+    }
+
+    #[test]
+    fn category_components_include_edit_selects_for_title_user_and_guild_scopes() {
+        let panel = plan_settings_panel(
+            SettingsPanelCategory::Setting(SettingKey::TitleDisplay),
+            true,
+            test_summaries(),
+        );
+
+        let value = serde_json::to_value(settings_panel_components(&panel))
+            .expect("components should serialize");
+
+        assert_eq!(value.as_array().expect("rows").len(), 3);
+        assert!(value.to_string().contains(&settings_set_custom_id(
+            SettingScope::User,
+            SettingKey::TitleDisplay
+        )));
+        assert!(value.to_string().contains(&settings_set_custom_id(
+            SettingScope::Guild,
+            SettingKey::TitleDisplay
+        )));
+    }
+
+    #[test]
+    fn analytics_privacy_components_only_include_user_scope() {
+        let panel = plan_settings_panel(
+            SettingsPanelCategory::Setting(SettingKey::AnalyticsPrivacy),
+            true,
+            test_summaries(),
+        );
+
+        let value = serde_json::to_value(settings_panel_components(&panel))
+            .expect("components should serialize");
+
+        assert_eq!(value.as_array().expect("rows").len(), 2);
+        assert!(value.to_string().contains(&settings_set_custom_id(
+            SettingScope::User,
+            SettingKey::AnalyticsPrivacy
+        )));
+        assert!(
+            !value
+                .to_string()
+                .contains("settings:set:guild:analytics_privacy")
+        );
+    }
+
+    #[test]
+    fn guild_scores_scope_values_prevent_invalid_combinations() {
+        assert_eq!(
+            allowed_values_for_scope(SettingScope::User, SettingKey::GuildScores),
+            &["enabled", "opted_out"]
+        );
+        assert_eq!(
+            allowed_values_for_scope(SettingScope::Guild, SettingKey::GuildScores),
+            &["enabled", "disabled"]
+        );
+    }
+
+    #[test]
+    fn plans_user_setting_writes_for_title_privacy_and_guild_score_participation() {
+        assert_eq!(
+            plan_settings_write(
+                SettingScope::User,
+                SettingKey::TitleDisplay,
+                "native",
+                false,
+                false,
+            ),
+            Ok(SettingsWritePlan::User(SettingValue::TitleDisplay(
+                TitleDisplayPreference::Native
+            )))
+        );
+        assert_eq!(
+            plan_settings_write(
+                SettingScope::User,
+                SettingKey::AnalyticsPrivacy,
+                "opted_out",
+                false,
+                false,
+            ),
+            Ok(SettingsWritePlan::User(SettingValue::AnalyticsPrivacy(
+                AnalyticsPrivacyPreference::OptedOut
+            )))
+        );
+        assert_eq!(
+            plan_settings_write(
+                SettingScope::User,
+                SettingKey::GuildScores,
+                "enabled",
+                true,
+                false,
+            ),
+            Ok(SettingsWritePlan::User(SettingValue::GuildScores(
+                GuildScoresPreference::Enabled
+            )))
+        );
+    }
+
+    #[test]
+    fn guild_setting_writes_require_server_and_manage_server_permission() {
+        assert_eq!(
+            plan_settings_write(
+                SettingScope::Guild,
+                SettingKey::TitleDisplay,
+                "english",
+                false,
+                true,
+            ),
+            Err(SettingsWriteError::MissingGuild)
+        );
+        assert_eq!(
+            plan_settings_write(
+                SettingScope::Guild,
+                SettingKey::TitleDisplay,
+                "english",
+                true,
+                false,
+            ),
+            Err(SettingsWriteError::MissingManageGuild)
+        );
+        assert_eq!(
+            plan_settings_write(
+                SettingScope::Guild,
+                SettingKey::GuildScores,
+                "disabled",
+                true,
+                true,
+            ),
+            Ok(SettingsWritePlan::Guild(SettingValue::GuildScores(
+                GuildScoresPreference::Disabled
+            )))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_scope_value_combinations_with_clear_messages() {
+        let user_disabled = plan_settings_write(
+            SettingScope::User,
+            SettingKey::GuildScores,
+            "disabled",
+            true,
+            false,
+        )
+        .expect_err("users should not set guild-score disabled");
+        let guild_opted_out = plan_settings_write(
+            SettingScope::Guild,
+            SettingKey::GuildScores,
+            "opted_out",
+            true,
+            true,
+        )
+        .expect_err("guilds should not set opted_out");
+
+        assert!(settings_write_error_message(user_disabled).contains("user setting"));
+        assert!(settings_write_error_message(guild_opted_out).contains("server setting"));
     }
 }

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -46,6 +46,7 @@ pub struct SettingSummary {
 pub struct SettingsPanel {
     pub category: SettingsPanelCategory,
     pub guild_available: bool,
+    pub can_manage_guild: bool,
     pub summaries: Vec<SettingSummary>,
 }
 
@@ -190,11 +191,13 @@ pub fn plan_settings_write(
 pub fn plan_settings_panel(
     category: SettingsPanelCategory,
     guild_available: bool,
+    can_manage_guild: bool,
     summaries: Vec<SettingSummary>,
 ) -> SettingsPanel {
     SettingsPanel {
         category,
         guild_available,
+        can_manage_guild,
         summaries,
     }
 }
@@ -240,6 +243,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         &database_pool,
         user.id,
         interaction.guild_id,
+        can_manage_guild_settings_for_command(interaction),
         SettingsPanelCategory::Overview,
     )
     .await
@@ -399,6 +403,7 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
         &database_pool,
         interaction.user.id,
         interaction.guild_id,
+        can_manage_guild_settings(interaction),
         category,
     )
     .await
@@ -437,6 +442,7 @@ async fn load_settings_panel(
     pool: &DbPool,
     user_id: UserId,
     guild_id: Option<GuildId>,
+    can_manage_guild: bool,
     category: SettingsPanelCategory,
 ) -> Result<SettingsPanel, SettingsStorageError> {
     let summaries = resolve_all_setting_layers(pool, user_id, guild_id, &ALL_SETTING_KEYS)
@@ -445,7 +451,12 @@ async fn load_settings_panel(
         .map(|layers| SettingSummary { layers })
         .collect();
 
-    Ok(plan_settings_panel(category, guild_id.is_some(), summaries))
+    Ok(plan_settings_panel(
+        category,
+        guild_id.is_some(),
+        can_manage_guild,
+        summaries,
+    ))
 }
 
 #[instrument(name = "command.settings.render_overview", skip(panel))]
@@ -595,7 +606,7 @@ fn settings_panel_components(panel: &SettingsPanel) -> Vec<CreateActionRow> {
             summary.layers.user,
         ));
 
-        if guild_select_available(key, panel.guild_available) {
+        if guild_select_available(key, panel.guild_available, panel.can_manage_guild) {
             rows.push(setting_select_row(
                 SettingScope::Guild,
                 key,
@@ -638,14 +649,13 @@ fn setting_select_option(
     let value = key.parse_value(raw_value).ok()?;
     Some(
         CreateSelectMenuOption::new(value.display_label(), value.as_storage_value())
-            .description(raw_value)
             .default_selection(selected == Some(value)),
     )
 }
 
 #[instrument(name = "command.settings.guild_select_available")]
-fn guild_select_available(key: SettingKey, guild_available: bool) -> bool {
-    guild_available && key != SettingKey::AnalyticsPrivacy
+fn guild_select_available(key: SettingKey, guild_available: bool, can_manage_guild: bool) -> bool {
+    guild_available && can_manage_guild && key != SettingKey::AnalyticsPrivacy
 }
 
 #[instrument(name = "command.settings.allowed_values_for_scope")]
@@ -668,6 +678,15 @@ fn selected_string_value(interaction: &ComponentInteraction) -> Option<&str> {
 
 #[instrument(name = "command.settings.can_manage_guild", skip(interaction))]
 fn can_manage_guild_settings(interaction: &ComponentInteraction) -> bool {
+    interaction
+        .member
+        .as_ref()
+        .and_then(|member| member.permissions)
+        .is_some_and(|permissions| permissions.contains(Permissions::MANAGE_GUILD))
+}
+
+#[instrument(name = "command.settings.can_manage_guild_command", skip(interaction))]
+fn can_manage_guild_settings_for_command(interaction: &CommandInteraction) -> bool {
     interaction
         .member
         .as_ref()
@@ -866,7 +885,12 @@ mod tests {
 
     #[test]
     fn overview_renders_current_effective_settings() {
-        let panel = plan_settings_panel(SettingsPanelCategory::Overview, true, test_summaries());
+        let panel = plan_settings_panel(
+            SettingsPanelCategory::Overview,
+            true,
+            true,
+            test_summaries(),
+        );
         let content = render_settings_panel(&panel);
 
         assert!(content.contains("**Settings**"));
@@ -881,7 +905,12 @@ mod tests {
 
     #[test]
     fn overview_marks_guild_settings_unavailable_in_dms() {
-        let panel = plan_settings_panel(SettingsPanelCategory::Overview, false, test_summaries());
+        let panel = plan_settings_panel(
+            SettingsPanelCategory::Overview,
+            false,
+            false,
+            test_summaries(),
+        );
         let content = render_settings_panel(&panel);
 
         assert!(content.contains("Guild: not available in DMs"));
@@ -891,6 +920,7 @@ mod tests {
     fn category_panel_renders_selected_details() {
         let panel = plan_settings_panel(
             SettingsPanelCategory::Setting(SettingKey::GuildScores),
+            true,
             true,
             test_summaries(),
         );
@@ -907,6 +937,7 @@ mod tests {
         let panel = plan_settings_panel(
             SettingsPanelCategory::Setting(SettingKey::TitleDisplay),
             true,
+            true,
             test_summaries(),
         );
 
@@ -922,12 +953,37 @@ mod tests {
             SettingScope::Guild,
             SettingKey::TitleDisplay
         )));
+        assert!(!value.to_string().contains("\"description\""));
+    }
+
+    #[test]
+    fn category_components_hide_guild_scope_without_manage_server() {
+        let panel = plan_settings_panel(
+            SettingsPanelCategory::Setting(SettingKey::TitleDisplay),
+            true,
+            false,
+            test_summaries(),
+        );
+
+        let value = serde_json::to_value(settings_panel_components(&panel))
+            .expect("components should serialize");
+
+        assert_eq!(value.as_array().expect("rows").len(), 2);
+        assert!(value.to_string().contains(&settings_set_custom_id(
+            SettingScope::User,
+            SettingKey::TitleDisplay
+        )));
+        assert!(!value.to_string().contains(&settings_set_custom_id(
+            SettingScope::Guild,
+            SettingKey::TitleDisplay
+        )));
     }
 
     #[test]
     fn analytics_privacy_components_only_include_user_scope() {
         let panel = plan_settings_panel(
             SettingsPanelCategory::Setting(SettingKey::AnalyticsPrivacy),
+            true,
             true,
             test_summaries(),
         );

--- a/src/models/db/settings.rs
+++ b/src/models/db/settings.rs
@@ -97,7 +97,6 @@ pub struct ResolvedSettingLayers {
         setting_key = %value.key().as_str()
     )
 )]
-#[allow(dead_code)]
 pub async fn set_user_setting(
     pool: &DbPool,
     user_discord_id: UserId,
@@ -123,7 +122,6 @@ pub async fn set_user_setting(
     skip(pool, guild_id, value),
     fields(guild_id = %hash_discord_id(guild_id.get()), setting_key = %value.key().as_str())
 )]
-#[allow(dead_code)]
 pub async fn set_guild_setting(
     pool: &DbPool,
     guild_id: GuildId,

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -168,7 +168,6 @@ pub enum SettingValue {
 }
 
 impl SettingValue {
-    #[allow(dead_code)]
     pub fn key(self) -> SettingKey {
         match self {
             Self::TitleDisplay(_) => SettingKey::TitleDisplay,


### PR DESCRIPTION
## Summary

Make the interactive `/settings` panel editable for current user- and guild-scoped settings.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- e8839aafe94d134a6be5ca3cb2b6e481cc43fec4: Add select-menu edit flows for title display, analytics privacy, and guild score settings with scoped validation, Manage Server checks, save feedback, and panel refreshes
- c99a02cf4f70b1edde2ee46938e5658bc5597f1a: Bump package version to 3.7.0
- b40f66121d3391dc14ef496a02337c4dba1d0676: Collapse the settings panel component branch to satisfy clippy

### Notes

Guild-scoped edits are available only in servers and still require Manage Server. Analytics privacy remains user-only. Guild scores expose user participation as enabled/opted_out and server availability as enabled/disabled to avoid invalid scope/value combinations in normal UI use.

## Validation
- [x] cargo test
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo check

---

This PR description was written by Amp.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->