### PR TITLE
[ANNIE-111]/improve UX text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.7.0"
+version = "3.8.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -31,12 +31,12 @@ use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("anime")
-        .description("Fetches the details for an anime")
+        .description("Look up anime details from AniList")
         .add_option(
             CreateCommandOption::new(
                 CommandOptionType::String,
                 "search",
-                "Anilist ID or Search term",
+                "AniList ID or anime search term",
             )
             .required(true),
         )
@@ -84,7 +84,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         interaction.data.options.first().map(|opt| &opt.value)
     else {
         let builder = EditInteractionResponse::new()
-            .content("Missing or invalid `search` option — please provide an anime name or ID.");
+            .content("Tell me which anime to look up with `search:<name or AniList ID>`.");
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
@@ -92,7 +92,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     if let Err(err) = validate_search_term(&search_term) {
         let builder = EditInteractionResponse::new().content(format!(
-            "Invalid search input: {err}. Please check your input and try again."
+            "I couldn't use that search: {err}. Try an anime title or AniList ID."
         ));
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;

--- a/src/commands/character/command.rs
+++ b/src/commands/character/command.rs
@@ -31,7 +31,7 @@ const DISALLOW_SPOILERS: &str = "disallow";
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("character")
-        .description("Fetches the details for an AniList character")
+        .description("Look up AniList character details")
         .add_option(
             CreateCommandOption::new(
                 CommandOptionType::String,
@@ -97,14 +97,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     let Some((search_term, allow_spoilers)) = parse_character_options(&interaction.data.options)
     else {
         let builder = EditInteractionResponse::new()
-            .content("Missing or invalid `search` option — please provide a character name or ID.");
+            .content("Tell me which character to look up with `search:<name or AniList ID>`.");
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
 
     if let Err(err) = validate_search_term(&search_term) {
         let builder = EditInteractionResponse::new().content(format!(
-            "Invalid search input: {err}. Please check your input and try again."
+            "I couldn't use that search: {err}. Try a character name or AniList ID."
         ));
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -11,7 +11,7 @@ use serenity::{
 use tracing::{error, instrument, warn};
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("help").description("Shows how to use the bot")
+    CreateCommand::new("help").description("Show Annie Mei commands and tips")
 }
 
 #[instrument(name = "command.help.run", skip(ctx, interaction))]
@@ -24,21 +24,21 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
         .colour(0x00ff00)
         .title(format!("{} • Annie Mei Help", user.name))
         .description(
-            "I can help you look up anime, manga, and character details, theme songs, and show what guild members are watching or reading.",
+            "I can look up anime, manga, characters, recommendations, theme songs, and what people in this server are watching or reading.",
         )
         .field(
             "Get started",
-            "1. Run `/register` and click the secure AniList link button\n2. Finish the AniList authorization in your browser, then return to Discord\n3. Use `/anime`, `/manga`, `/recommend`, or `/character` with an AniList ID or search term\n4. Use `/songs` to fetch openings/endings and links\n5. If your AniList connection ever expires later, run `/register` again to relink it, or `/unregister confirmation:Confirm unlink` to unlink it",
+            "1. Run `/register` and click the secure AniList link button\n2. Finish authorization in your browser, then return to Discord\n3. Use `/anime`, `/manga`, `/recommend`, or `/character` with an AniList ID or search term\n4. Use `/search` when you only remember a vibe, plot, or partial title\n5. Use `/songs` for opening and ending theme songs",
             false,
         )
         .field(
             "Commands",
-            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/recommend type:<anime|manga> search:<term or id>` - AniList recommendations\n`/character search:<term or id> spoilers:<allow|disallow>` - character details\n`/songs search:<term or id>` - OP/ED songs + links\n`/settings` - open your interactive settings panel\n`/register` - open the AniList OAuth link or relink flow\n`/unregister confirmation:<confirm|cancel>` - unlink your AniList account after confirmation\n`/whoami` - show your linked AniList username and profile link\n`/ping` - bot health check\n`/help` - show this guide",
+            "`/anime search:<term or id>` - anime details\n`/manga search:<term or id>` - manga details\n`/search query:<description>` - natural-language anime/manga search\n`/recommend type:<anime|manga> search:<term or id>` - community recommendations\n`/character search:<term or id> spoilers:<allow|disallow>` - character details\n`/songs search:<term or id>` - opening and ending themes\n`/settings` - preferences for titles, analytics, and guild scores\n`/register` - link or relink AniList\n`/unregister confirmation:<confirm|cancel>` - unlink AniList\n`/whoami` - show your linked AniList account\n`/ping` - bot health check\n`/help` - show this guide",
             false,
         )
         .field(
             "Tips",
-            "You can search with full names, short names, or AniList IDs. If the AniList link page expires or fails, or if you need to reconnect your AniList account later, run `/register` again to get a fresh secure link. Use `/unregister confirmation:Confirm unlink` when you want Annie Mei to forget your linked AniList account.",
+            "Full titles, short titles, and AniList IDs all work. If you only remember a scene or premise, try `/search`. Run `/settings` to pick title language and privacy preferences. If your AniList link expires or you want to reconnect, run `/register` again.",
             false,
         )
         .footer(CreateEmbedFooter::new("Annie Mei"))

--- a/src/commands/manga/command.rs
+++ b/src/commands/manga/command.rs
@@ -31,12 +31,12 @@ use tracing::{info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("manga")
-        .description("Fetches the details for a manga")
+        .description("Look up manga details from AniList")
         .add_option(
             CreateCommandOption::new(
                 CommandOptionType::String,
                 "search",
-                "Anilist ID or Search term",
+                "AniList ID or manga search term",
             )
             .required(true),
         )
@@ -84,7 +84,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         interaction.data.options.first().map(|opt| &opt.value)
     else {
         let builder = EditInteractionResponse::new()
-            .content("Missing or invalid `search` option — please provide a manga name or ID.");
+            .content("Tell me which manga to look up with `search:<name or AniList ID>`.");
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
@@ -92,7 +92,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     if let Err(err) = validate_search_term(&search_term) {
         let builder = EditInteractionResponse::new().content(format!(
-            "Invalid search input: {err}. Please check your input and try again."
+            "I couldn't use that search: {err}. Try a manga title or AniList ID."
         ));
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -9,7 +9,7 @@ use serenity::{
 };
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("ping").description("A ping command")
+    CreateCommand::new("ping").description("Check whether Annie Mei is awake")
 }
 
 // ── Core logic (transport-agnostic) ─────────────────────────────────────
@@ -20,7 +20,7 @@ pub fn register() -> CreateCommand {
 /// `CommandInteraction`.
 pub fn handle_ping(user_mention: &str) -> CommandResponse {
     CommandResponse::Message(format!(
-        "Hello {user_mention}! I'm Annie Mei, a bot that helps you find anime and manga!",
+        "Hi {user_mention}! I'm Annie Mei, awake and ready to help with anime, manga, recommendations, and theme songs.",
     ))
 }
 
@@ -71,7 +71,7 @@ mod tests {
     fn ping_response_includes_bot_description() {
         let text = handle_ping("<@999>").unwrap_message();
         assert!(
-            text.contains("anime and manga"),
+            text.contains("anime, manga"),
             "response should describe what the bot does"
         );
     }

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -367,10 +367,6 @@ fn format_recommendation(
     recommendation: &Recommendation,
     recommended_media: &RecommendedMedia,
 ) -> String {
-    let score = recommended_media
-        .average_score()
-        .map(|score| format!("{score}/100"))
-        .unwrap_or_else(|| EMPTY_STR.to_string());
     let genres = recommended_media
         .genres()
         .iter()
@@ -378,21 +374,35 @@ fn format_recommendation(
         .map(|genre| code(&titlecase(genre)))
         .collect::<Vec<_>>()
         .join(" - ");
-    let genres = if genres.is_empty() {
-        EMPTY_STR.to_string()
-    } else {
-        genres
-    };
 
-    format!(
-        "{} • {} • {} • Score: {} • AniList rating: {}\nGenres: {}",
+    let mut summary_parts = vec![
         linker("AniList", recommended_media.site_url()),
         titlecase(recommended_media.media_type()),
-        format_media_descriptor(recommended_media),
-        score,
-        recommendation.rating_text(),
-        genres,
-    )
+    ];
+
+    let descriptor = format_media_descriptor(recommended_media);
+    if !descriptor.is_empty() {
+        summary_parts.push(descriptor);
+    }
+
+    if let Some(score) = recommended_media.average_score() {
+        summary_parts.push(format!("Audience score: {score}/100"));
+    }
+
+    let mut lines = vec![summary_parts.join(" • ")];
+
+    if let Some(rating) = recommendation.rating() {
+        let noun = if rating == 1 { "user" } else { "users" };
+        lines.push(format!(
+            "Community pick: {rating} AniList {noun} recommended this"
+        ));
+    }
+
+    if !genres.is_empty() {
+        lines.push(format!("Genres: {genres}"));
+    }
+
+    lines.join("\n")
 }
 
 #[instrument(skip(recommended_media))]
@@ -593,8 +603,53 @@ mod tests {
             value["fields"][0]["value"]
                 .as_str()
                 .unwrap()
-                .contains("AniList rating: 42")
+                .contains("Community pick: 42 AniList users recommended this")
         );
+    }
+
+    #[test]
+    fn recommendations_omit_missing_optional_details() {
+        let media = sample_media(false, false);
+        let recommendation: Recommendation = serde_json::from_value(serde_json::json!({
+            "rating": null,
+            "mediaRecommendation": {
+                "type": "ANIME",
+                "isAdult": false,
+                "title": {
+                    "romaji": "Mystery Show",
+                    "english": null,
+                    "native": null
+                },
+                "format": null,
+                "status": null,
+                "genres": [],
+                "coverImage": {
+                    "extraLarge": null,
+                    "large": null,
+                    "medium": null,
+                    "color": null
+                },
+                "averageScore": null,
+                "siteUrl": "https://anilist.co/anime/999"
+            }
+        }))
+        .expect("recommendation should deserialize");
+        let recommended_media = recommendation
+            .recommended_media()
+            .expect("recommended media should exist");
+
+        let embed = recommendations_embed(
+            &media,
+            &[(&recommendation, recommended_media)],
+            None,
+            TitleDisplayPreference::Matched,
+        );
+
+        let value = serde_json::to_value(&embed).expect("embed serializes");
+        let field = value["fields"][0]["value"].as_str().unwrap();
+        assert!(!field.contains("Audience score"));
+        assert!(!field.contains("Community pick"));
+        assert!(!field.contains("Genres:"));
     }
 
     #[test]

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -392,10 +392,7 @@ fn format_recommendation(
     let mut lines = vec![summary_parts.join(" • ")];
 
     if let Some(rating) = recommendation.rating() {
-        let noun = if rating == 1 { "user" } else { "users" };
-        lines.push(format!(
-            "Community pick: {rating} AniList {noun} recommended this"
-        ));
+        lines.push(format_recommendation_rating(rating));
     }
 
     if !genres.is_empty() {
@@ -403,6 +400,21 @@ fn format_recommendation(
     }
 
     lines.join("\n")
+}
+
+#[instrument]
+fn format_recommendation_rating(rating: i32) -> String {
+    match rating {
+        rating if rating > 0 => {
+            let noun = if rating == 1 { "user" } else { "users" };
+            format!("Community pick: {rating} AniList {noun} recommended this")
+        }
+        0 => "Community pick: AniList users are split on this recommendation".to_string(),
+        rating => format!(
+            "Community note: AniList users downvoted this recommendation by {}",
+            rating.abs()
+        ),
+    }
 }
 
 #[instrument(skip(recommended_media))]
@@ -650,6 +662,18 @@ mod tests {
         assert!(!field.contains("Audience score"));
         assert!(!field.contains("Community pick"));
         assert!(!field.contains("Genres:"));
+    }
+
+    #[test]
+    fn recommendation_rating_copy_handles_non_positive_scores() {
+        assert_eq!(
+            format_recommendation_rating(0),
+            "Community pick: AniList users are split on this recommendation"
+        );
+        assert_eq!(
+            format_recommendation_rating(-3),
+            "Community note: AniList users downvoted this recommendation by 3"
+        );
     }
 
     #[test]

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -405,15 +405,9 @@ fn format_recommendation(
 #[instrument]
 fn format_recommendation_rating(rating: i32) -> String {
     match rating {
-        rating if rating > 0 => {
-            let noun = if rating == 1 { "user" } else { "users" };
-            format!("Community pick: {rating} AniList {noun} recommended this")
-        }
+        rating if rating > 0 => format!("Community score: +{rating}"),
         0 => "Community pick: AniList users are split on this recommendation".to_string(),
-        rating => format!(
-            "Community note: AniList users downvoted this recommendation by {}",
-            rating.abs()
-        ),
+        rating => format!("Community score: {rating}"),
     }
 }
 
@@ -615,7 +609,7 @@ mod tests {
             value["fields"][0]["value"]
                 .as_str()
                 .unwrap()
-                .contains("Community pick: 42 AniList users recommended this")
+                .contains("Community score: +42")
         );
     }
 
@@ -670,10 +664,7 @@ mod tests {
             format_recommendation_rating(0),
             "Community pick: AniList users are split on this recommendation"
         );
-        assert_eq!(
-            format_recommendation_rating(-3),
-            "Community note: AniList users downvoted this recommendation by 3"
-        );
+        assert_eq!(format_recommendation_rating(-3), "Community score: -3");
     }
 
     #[test]

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -381,7 +381,7 @@ fn format_recommendation(
     ];
 
     let descriptor = format_media_descriptor(recommended_media);
-    if !descriptor.is_empty() {
+    if !descriptor.is_empty() && descriptor != EMPTY_STR {
         summary_parts.push(descriptor);
     }
 

--- a/src/commands/recommend/command.rs
+++ b/src/commands/recommend/command.rs
@@ -47,12 +47,12 @@ const RECOMMENDATION_LIMIT: usize = 5;
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("recommend")
-        .description("Fetch AniList recommendations for an anime or manga")
+        .description("Find community recommendations for an anime or manga")
         .add_option(
             CreateCommandOption::new(
                 CommandOptionType::String,
                 TYPE_OPTION,
-                "Whether to find anime or manga recommendations",
+                "Choose whether the source title is anime or manga",
             )
             .add_string_choice("Anime", ANIME_TYPE)
             .add_string_choice("Manga", MANGA_TYPE)
@@ -122,7 +122,7 @@ pub fn handle_recommend(
 
     if recommendations.is_empty() {
         return CommandResponse::Content(format!(
-            "No recommendations found for {}.",
+            "I couldn't find community recommendations for {} yet.",
             media.transform_preferred_title(title_variant, title_preference)
         ));
     }
@@ -141,7 +141,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let Some((media_type, search_term)) = parse_recommend_options(&interaction.data.options) else {
         let builder = EditInteractionResponse::new().content(
-            "Missing or invalid options — choose a type and provide an anime or manga name or ID.",
+            "Choose anime or manga, then tell me what to recommend from with `search:<name or AniList ID>`.",
         );
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
@@ -149,7 +149,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     if let Err(err) = validate_search_term(&search_term) {
         let builder = EditInteractionResponse::new().content(format!(
-            "Invalid search input: {err}. Please check your input and try again."
+            "I couldn't use that search: {err}. Try a title or AniList ID."
         ));
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
@@ -563,7 +563,7 @@ mod tests {
         assert!(
             response
                 .unwrap_content()
-                .contains("No recommendations found")
+                .contains("I couldn't find community recommendations")
         );
     }
 
@@ -580,7 +580,7 @@ mod tests {
         assert!(response.is_content());
         assert_eq!(
             response.unwrap_content(),
-            "No recommendations found for Yotsuba&!."
+            "I couldn't find community recommendations for Yotsuba&! yet."
         );
     }
 

--- a/src/commands/register/command.rs
+++ b/src/commands/register/command.rs
@@ -15,8 +15,7 @@ use serenity::{
 use tracing::{error, info, instrument};
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("register")
-        .description("Link or relink your AniList account with a secure OAuth flow")
+    CreateCommand::new("register").description("Link or refresh your AniList account")
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -40,7 +39,7 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
 
     RegisterResponse {
         content: format!(
-            "Click the button below to link your AniList account. This secure link is only for you and {expires_in}. If the page says the link expired or failed, or if you ever need to reconnect AniList later, run `/register` again in Discord.",
+            "Click the button below to link AniList. This secure link is only for you and {expires_in}. If it expires or you need to reconnect later, run `/register` again.",
         ),
         oauth_url: Some(oauth_url.to_string()),
     }
@@ -50,7 +49,7 @@ fn handle_register(oauth_url: &str, ttl_seconds: i64) -> RegisterResponse {
 fn handle_already_linked(credential: &OAuthCredential) -> RegisterResponse {
     RegisterResponse {
         content: format!(
-            "You're already linked to AniList account **{}**.\nProfile: <{}>\nIf you want to link a different AniList account, run `/unregister confirmation:Confirm unlink` first, then run `/register` again.",
+            "You're linked to AniList as **{}**.\nProfile: <{}>\nTo switch accounts, run `/unregister confirmation:Confirm unlink`, then `/register` again.",
             credential.anilist_display_name(),
             credential.anilist_profile_url(),
         ),
@@ -61,7 +60,8 @@ fn handle_already_linked(credential: &OAuthCredential) -> RegisterResponse {
 #[instrument(name = "command.register.handle_lookup_error")]
 fn handle_lookup_error() -> RegisterResponse {
     RegisterResponse {
-        content: "I couldn't check your existing AniList link right now. Please try `/register` again in a moment.".to_string(),
+        content: "I couldn't check your AniList link right now. Try `/register` again in a moment."
+            .to_string(),
         oauth_url: None,
     }
 }
@@ -70,11 +70,11 @@ fn handle_lookup_error() -> RegisterResponse {
 fn handle_register_error(err: &OAuthContextError) -> RegisterResponse {
     let content = match err {
         OAuthContextError::MissingEnv(_) => {
-            "AniList account linking is not configured right now. Please try again later."
-                .to_string()
+            "AniList linking is not configured right now. Please try again later.".to_string()
         }
-        _ => "I couldn't start the AniList linking flow right now. Please try again in a moment."
-            .to_string(),
+        _ => {
+            "I couldn't start AniList linking right now. Please try again in a moment.".to_string()
+        }
     };
 
     RegisterResponse {
@@ -192,7 +192,7 @@ mod tests {
         assert!(response.content.contains("only for you"));
         assert!(response.content.contains("about 5 minutes"));
         assert!(response.content.contains("run `/register` again"));
-        assert!(response.content.contains("reconnect AniList later"));
+        assert!(response.content.contains("reconnect later"));
     }
 
     #[test]
@@ -209,7 +209,7 @@ mod tests {
         let response = handle_already_linked(&credential);
 
         assert_eq!(response.oauth_url, None);
-        assert!(response.content.contains("already linked"));
+        assert!(response.content.contains("You're linked"));
         assert!(response.content.contains("**AniUser**"));
         assert!(
             response
@@ -238,7 +238,7 @@ mod tests {
             response.oauth_url,
             Some("https://auth.example.com/oauth/anilist/start?ctx=abc".to_string())
         );
-        assert!(response.content.contains("link your AniList account"));
+        assert!(response.content.contains("link AniList"));
     }
 
     #[test]
@@ -247,7 +247,7 @@ mod tests {
 
         assert_eq!(response.oauth_url, None);
         assert!(response.content.contains("couldn't check"));
-        assert!(response.content.contains("try `/register` again"));
+        assert!(response.content.contains("Try `/register` again"));
     }
 
     #[test]

--- a/src/commands/response.rs
+++ b/src/commands/response.rs
@@ -29,7 +29,7 @@ pub enum CommandResponse {
     /// A plain-text deferred reply (adapter should defer first, then edit).
     ///
     /// Used when the command did async work but the result is just text
-    /// (e.g. "No such anime").
+    /// (e.g. a not-found message).
     Content(String),
 
     /// An embed deferred reply (adapter should defer first, then edit).

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -34,7 +34,7 @@ use serenity::{
 };
 use tracing::{info, instrument, warn};
 
-const NOT_FOUND_SEARCH: &str = "I couldn't find an anime or manga for that search.";
+const NOT_FOUND_SEARCH: &str = "I couldn't find an anime or manga that matches that search.";
 const MAX_LLM_SEARCH_TERM_LENGTH: usize = 120;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -132,7 +132,7 @@ impl SearchIntent {
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("search")
-        .description("Find anime or manga from a natural-language search")
+        .description("Describe an anime or manga and let Annie Mei search for it")
         .add_option(
             CreateCommandOption::new(
                 CommandOptionType::String,
@@ -295,7 +295,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         interaction.data.options.first().map(|opt| &opt.value)
     else {
         let builder = EditInteractionResponse::new()
-            .content("Missing or invalid `query` option — please describe what to find.");
+            .content("Describe what you're looking for with `query:<title, vibe, or plot>`.");
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
@@ -303,7 +303,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     if let Err(err) = validate_search_term(&query) {
         let builder = EditInteractionResponse::new().content(format!(
-            "Invalid search input: {err}. Please check your input and try again."
+            "I couldn't use that search: {err}. Try a title, vibe, or short plot description."
         ));
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
@@ -415,12 +415,12 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 fn format_interpretation(intent: &SearchIntent) -> String {
     match intent.media_type {
         SearchMediaType::Anime => {
-            format!("I think you're thinking of the anime `{}`.", intent.search)
+            format!("I searched AniList for the anime `{}`.", intent.search)
         }
         SearchMediaType::Manga => {
-            format!("I think you're thinking of the manga `{}`.", intent.search)
+            format!("I searched AniList for the manga `{}`.", intent.search)
         }
-        SearchMediaType::Unknown => format!("I think you're thinking of `{}`.", intent.search),
+        SearchMediaType::Unknown => format!("I searched AniList for `{}`.", intent.search),
     }
 }
 

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -429,7 +429,7 @@ fn format_interpretation(intent: &SearchIntent) -> String {
 
 #[instrument(name = "command.search.interpretation_variant", skip(intent))]
 fn interpretation_variant(intent: &SearchIntent) -> usize {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = DefaultHasher::default();
     intent.search.hash(&mut hasher);
     match intent.media_type {
         SearchMediaType::Anime => 0_u8,

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -1,4 +1,8 @@
-use std::fmt;
+use std::{
+    collections::hash_map::DefaultHasher,
+    fmt,
+    hash::{Hash, Hasher},
+};
 
 use crate::{
     commands::{
@@ -36,6 +40,7 @@ use tracing::{info, instrument, warn};
 
 const NOT_FOUND_SEARCH: &str = "I couldn't find an anime or manga that matches that search.";
 const MAX_LLM_SEARCH_TERM_LENGTH: usize = 120;
+const INTERPRETATION_VARIANT_COUNT: u64 = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchMediaType {
@@ -413,14 +418,68 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
 #[instrument(name = "command.search.format_interpretation", skip(intent))]
 fn format_interpretation(intent: &SearchIntent) -> String {
+    let variant = interpretation_variant(intent);
+
     match intent.media_type {
-        SearchMediaType::Anime => {
-            format!("I searched AniList for the anime `{}`.", intent.search)
-        }
-        SearchMediaType::Manga => {
-            format!("I searched AniList for the manga `{}`.", intent.search)
-        }
-        SearchMediaType::Unknown => format!("I searched AniList for `{}`.", intent.search),
+        SearchMediaType::Anime => format_anime_interpretation(variant, &intent.search),
+        SearchMediaType::Manga => format_manga_interpretation(variant, &intent.search),
+        SearchMediaType::Unknown => format_unknown_interpretation(variant, &intent.search),
+    }
+}
+
+#[instrument(name = "command.search.interpretation_variant", skip(intent))]
+fn interpretation_variant(intent: &SearchIntent) -> usize {
+    let mut hasher = DefaultHasher::new();
+    intent.search.hash(&mut hasher);
+    match intent.media_type {
+        SearchMediaType::Anime => 0_u8,
+        SearchMediaType::Manga => 1,
+        SearchMediaType::Unknown => 2,
+    }
+    .hash(&mut hasher);
+
+    (hasher.finish() % INTERPRETATION_VARIANT_COUNT) as usize
+}
+
+#[instrument(name = "command.search.format_anime_interpretation", skip(search))]
+fn format_anime_interpretation(variant: usize, search: &str) -> String {
+    match variant {
+        0 => format!("I'm checking AniList for the anime `{search}`."),
+        1 => format!("I found this likely anime candidate: `{search}`."),
+        2 => format!("Best guess: anime `{search}`."),
+        3 => format!("My best anime guess: `{search}`."),
+        4 => format!("Anime radar says: `{search}`."),
+        5 => format!("I went hunting on AniList for `{search}`."),
+        6 => format!("I chased that clue to the anime `{search}`."),
+        _ => format!("That sounds like the anime `{search}` to me."),
+    }
+}
+
+#[instrument(name = "command.search.format_manga_interpretation", skip(search))]
+fn format_manga_interpretation(variant: usize, search: &str) -> String {
+    match variant {
+        0 => format!("I'm checking AniList for the manga `{search}`."),
+        1 => format!("I found this likely manga candidate: `{search}`."),
+        2 => format!("Best guess: manga `{search}`."),
+        3 => format!("My best manga guess: `{search}`."),
+        4 => format!("Manga radar says: `{search}`."),
+        5 => format!("I went hunting on AniList for `{search}`."),
+        6 => format!("I chased that clue to the manga `{search}`."),
+        _ => format!("That sounds like the manga `{search}` to me."),
+    }
+}
+
+#[instrument(name = "command.search.format_unknown_interpretation", skip(search))]
+fn format_unknown_interpretation(variant: usize, search: &str) -> String {
+    match variant {
+        0 => format!("I'm checking AniList for `{search}`."),
+        1 => format!("I found this likely candidate: `{search}`."),
+        2 => format!("Best guess: `{search}`."),
+        3 => format!("My best guess: `{search}`."),
+        4 => format!("AniList radar says: `{search}`."),
+        5 => format!("I went hunting on AniList for `{search}`."),
+        6 => format!("I chased that clue to `{search}`."),
+        _ => format!("That sounds like `{search}` to me."),
     }
 }
 

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::hash_map::DefaultHasher,
-    fmt,
-    hash::{Hash, Hasher},
-};
+use std::fmt;
 
 use crate::{
     commands::{
@@ -429,16 +425,20 @@ fn format_interpretation(intent: &SearchIntent) -> String {
 
 #[instrument(name = "command.search.interpretation_variant", skip(intent))]
 fn interpretation_variant(intent: &SearchIntent) -> usize {
-    let mut hasher = DefaultHasher::default();
-    intent.search.hash(&mut hasher);
-    match intent.media_type {
+    let media_type = match intent.media_type {
         SearchMediaType::Anime => 0_u8,
         SearchMediaType::Manga => 1,
         SearchMediaType::Unknown => 2,
-    }
-    .hash(&mut hasher);
+    };
 
-    (hasher.finish() % INTERPRETATION_VARIANT_COUNT) as usize
+    let hash = intent
+        .search
+        .bytes()
+        .fold(u64::from(media_type), |hash, byte| {
+            hash.wrapping_mul(31).wrapping_add(u64::from(byte))
+        });
+
+    (hash % INTERPRETATION_VARIANT_COUNT) as usize
 }
 
 #[instrument(name = "command.search.format_anime_interpretation", skip(search))]

--- a/src/commands/search/tests.rs
+++ b/src/commands/search/tests.rs
@@ -181,7 +181,7 @@ fn format_interpretation_is_conversational() {
 
     assert_eq!(
         format_interpretation(&intent),
-        "I searched AniList for the manga `Berserk`."
+        format_manga_interpretation(interpretation_variant(&intent), "Berserk")
     );
 }
 
@@ -195,8 +195,43 @@ fn format_interpretation_handles_unknown_media_type() {
 
     assert_eq!(
         format_interpretation(&intent),
-        "I searched AniList for `Monster`."
+        format_unknown_interpretation(interpretation_variant(&intent), "Monster")
     );
+}
+
+#[test]
+fn interpretation_variant_is_stable_for_same_search() {
+    let intent = SearchIntent {
+        media_type: SearchMediaType::Anime,
+        search: "Trigun".to_string(),
+        candidates: Vec::new(),
+    };
+
+    assert_eq!(
+        interpretation_variant(&intent),
+        interpretation_variant(&intent)
+    );
+}
+
+#[test]
+fn interpretation_templates_cover_all_variants() {
+    let anime_expected = [
+        "I'm checking AniList for the anime `Cowboy Bebop`.",
+        "I found this likely anime candidate: `Cowboy Bebop`.",
+        "Best guess: anime `Cowboy Bebop`.",
+        "My best anime guess: `Cowboy Bebop`.",
+        "Anime radar says: `Cowboy Bebop`.",
+        "I went hunting on AniList for `Cowboy Bebop`.",
+        "I chased that clue to the anime `Cowboy Bebop`.",
+        "That sounds like the anime `Cowboy Bebop` to me.",
+    ];
+
+    for (variant, expected) in anime_expected.into_iter().enumerate() {
+        assert_eq!(
+            format_anime_interpretation(variant, "Cowboy Bebop"),
+            expected
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/commands/search/tests.rs
+++ b/src/commands/search/tests.rs
@@ -181,7 +181,7 @@ fn format_interpretation_is_conversational() {
 
     assert_eq!(
         format_interpretation(&intent),
-        "I think you're thinking of the manga `Berserk`."
+        "I searched AniList for the manga `Berserk`."
     );
 }
 
@@ -195,7 +195,7 @@ fn format_interpretation_handles_unknown_media_type() {
 
     assert_eq!(
         format_interpretation(&intent),
-        "I think you're thinking of `Monster`."
+        "I searched AniList for `Monster`."
     );
 }
 

--- a/src/commands/search/tests.rs
+++ b/src/commands/search/tests.rs
@@ -214,6 +214,17 @@ fn interpretation_variant_is_stable_for_same_search() {
 }
 
 #[test]
+fn interpretation_variant_has_stable_cross_toolchain_mapping() {
+    let intent = SearchIntent {
+        media_type: SearchMediaType::Anime,
+        search: "Trigun".to_string(),
+        candidates: Vec::new(),
+    };
+
+    assert_eq!(interpretation_variant(&intent), 5);
+}
+
+#[test]
 fn interpretation_templates_cover_all_variants() {
     let anime_expected = [
         "I'm checking AniList for the anime `Cowboy Bebop`.",

--- a/src/commands/settings/command.rs
+++ b/src/commands/settings/command.rs
@@ -240,7 +240,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         respond_to_command(
             interaction,
             ctx,
-            "Database is not initialized. Please try again later.".to_string(),
+            "I can't reach my database right now. Please try again later.".to_string(),
             Vec::new(),
         )
         .await;
@@ -262,8 +262,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
             respond_to_command(
                 interaction,
                 ctx,
-                "I hit an internal error while reading your settings. Please try again later."
-                    .to_string(),
+                "I couldn't read your settings right now. Please try again later.".to_string(),
                 Vec::new(),
             )
             .await;
@@ -310,7 +309,7 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
         respond_to_component(
             interaction,
             ctx,
-            "Database is not initialized. Please try again later.".to_string(),
+            "I can't reach my database right now. Please try again later.".to_string(),
             Vec::new(),
         )
         .await;
@@ -352,7 +351,7 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
                         respond_to_component(
                             interaction,
                             ctx,
-                            "I hit an internal error while saving your setting. Please try again later."
+                            "I couldn't save your setting right now. Please try again later."
                                 .to_string(),
                             Vec::new(),
                         )
@@ -388,7 +387,7 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
                         respond_to_component(
                             interaction,
                             ctx,
-                            "I hit an internal error while saving the server setting. Please try again later."
+                            "I couldn't save the server setting right now. Please try again later."
                                 .to_string(),
                             Vec::new(),
                         )
@@ -427,8 +426,7 @@ pub async fn handle_component(ctx: &Context, interaction: &mut ComponentInteract
             respond_to_component(
                 interaction,
                 ctx,
-                "I hit an internal error while reading your settings. Please try again later."
-                    .to_string(),
+                "I couldn't read your settings right now. Please try again later.".to_string(),
                 Vec::new(),
             )
             .await;

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -23,12 +23,12 @@ use tracing::{error, info, instrument};
 
 pub fn register() -> CreateCommand {
     CreateCommand::new("songs")
-        .description("Fetches the songs of an anime")
+        .description("Find anime opening and ending theme songs")
         .add_option(
             CreateCommandOption::new(
                 CommandOptionType::String,
                 "search",
-                "Anilist ID or Search term",
+                "AniList ID or anime search term",
             )
             .required(true),
         )
@@ -83,13 +83,17 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 CreateEmbed::new()
                     .title(mal_response.transform_title())
                     .field(
-                        "Openings",
+                        "Opening themes",
                         MalResponse::format_parsed_songs(&openings),
                         false,
                     )
-                    .field("Endings", MalResponse::format_parsed_songs(&endings), false)
+                    .field(
+                        "Ending themes",
+                        MalResponse::format_parsed_songs(&endings),
+                        false,
+                    )
                     .thumbnail(mal_response.transform_thumbnail())
-                    .field("\u{200b}", mal_response.transform_mal_link(), false),
+                    .field("Source", mal_response.transform_mal_link(), false),
             );
             interaction.edit_response(&ctx.http, builder).await
         }
@@ -98,8 +102,9 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
             interaction.edit_response(&ctx.http, builder).await
         }
         SongFetchResult::AnimeNotFoundOnMal => {
-            let builder = EditInteractionResponse::new()
-                .content("Anime not found on MAL. Song data is only available for anime listed on MyAnimeList.");
+            let builder = EditInteractionResponse::new().content(
+                "I found that anime on AniList, but couldn't find a MyAnimeList page for its theme songs.",
+            );
             interaction.edit_response(&ctx.http, builder).await
         }
         SongFetchResult::FetchError => {

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -50,7 +50,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         && let Err(err) = validate_search_term(search_term)
     {
         let builder = EditInteractionResponse::new().content(format!(
-            "Invalid search input: {err}. Please check your input and try again."
+            "I couldn't use that search: {err}. Try an anime title or AniList ID."
         ));
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
@@ -65,18 +65,21 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
             let endings = mal_response.parse_endings();
 
             // Narrow spawn_blocking: only the sync Spotify + Redis I/O
-            let (openings, endings) =
-                match task::spawn_blocking(move || enrich_song_sections(openings, endings)).await {
-                    Ok(result) => result,
-                    Err(err) => {
-                        error!(error = %err, "spawn_blocking panicked during Spotify enrichment");
-                        let builder = EditInteractionResponse::new().content(
-                        "An internal error occurred while fetching songs. Please try again later.",
+            let (openings, endings) = match task::spawn_blocking(move || {
+                enrich_song_sections(openings, endings)
+            })
+            .await
+            {
+                Ok(result) => result,
+                Err(err) => {
+                    error!(error = %err, "spawn_blocking panicked during Spotify enrichment");
+                    let builder = EditInteractionResponse::new().content(
+                        "I found the anime, but something went wrong while checking theme song links. Please try again later.",
                     );
-                        let _ = interaction.edit_response(&ctx.http, builder).await;
-                        return;
-                    }
-                };
+                    let _ = interaction.edit_response(&ctx.http, builder).await;
+                    return;
+                }
+            };
 
             // Pure formatting — no I/O, no spawn_blocking needed
             let builder = EditInteractionResponse::new().embed(
@@ -109,7 +112,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
         }
         SongFetchResult::FetchError => {
             let builder = EditInteractionResponse::new()
-                .content("An error occurred while fetching song data. Please try again later.");
+                .content("I couldn't fetch theme song data right now. Please try again later.");
             interaction.edit_response(&ctx.http, builder).await
         }
     };

--- a/src/commands/unregister.rs
+++ b/src/commands/unregister.rs
@@ -76,19 +76,18 @@ fn parse_unregister_confirmation(options: &[CommandDataOption]) -> Option<bool> 
 pub fn handle_unregister(outcome: UnregisterOutcome) -> CommandResponse {
     match outcome {
         UnregisterOutcome::Unlinked => CommandResponse::Content(
-            "Your AniList account has been unlinked from Annie Mei and your stored OAuth credentials have been deleted."
+            "Your AniList account is unlinked, and Annie Mei deleted the stored OAuth credentials."
                 .to_string(),
         ),
         UnregisterOutcome::NotLinked => CommandResponse::Content(
-            "You do not have a linked AniList account. Run `/register` if you want to link one."
+            "No AniList account is linked right now. Run `/register` if you want to connect one."
                 .to_string(),
         ),
         UnregisterOutcome::Cancelled => CommandResponse::Content(
             "Cancelled. Your AniList account link was not changed.".to_string(),
         ),
         UnregisterOutcome::Failed => CommandResponse::Content(
-            "I hit an internal error while unlinking your AniList account. Please try again later."
-                .to_string(),
+            "I couldn't unlink your AniList account right now. Please try again later.".to_string(),
         ),
     }
 }
@@ -156,8 +155,9 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
     configure_sentry_scope("Unregister", user.id.get(), None);
 
     let Some(confirmed) = parse_unregister_confirmation(&interaction.data.options) else {
-        let builder = EditInteractionResponse::new()
-            .content("Missing or invalid `confirmation` option — choose `Confirm unlink` to unlink your AniList account.");
+        let builder = EditInteractionResponse::new().content(
+            "Choose `Confirm unlink` to unlink AniList, or `Cancel` to leave it connected.",
+        );
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
@@ -174,7 +174,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let Some(database_pool) = get_pool_from_context(ctx).await else {
         let builder = EditInteractionResponse::new()
-            .content("Database is not initialized. Please try again later.");
+            .content("I can't reach my database right now. Please try again later.");
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
@@ -248,8 +248,8 @@ mod tests {
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
-        assert!(content.contains("has been unlinked"));
-        assert!(content.contains("OAuth credentials have been deleted"));
+        assert!(content.contains("is unlinked"));
+        assert!(content.contains("deleted the stored OAuth credentials"));
     }
 
     #[test]
@@ -258,7 +258,7 @@ mod tests {
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
-        assert!(content.contains("do not have a linked AniList account"));
+        assert!(content.contains("No AniList account is linked"));
         assert!(content.contains("/register"));
     }
 
@@ -307,7 +307,7 @@ mod tests {
 
         assert!(response.is_content(), "expected Content variant");
         let content = response.unwrap_content();
-        assert!(content.contains("internal error"));
+        assert!(content.contains("couldn't unlink"));
         assert!(content.contains("try again later"));
     }
 

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -15,19 +15,19 @@ use serenity::{
 use tracing::{error, instrument};
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("whoami").description("Show your currently linked AniList account")
+    CreateCommand::new("whoami").description("Show the AniList account linked to you")
 }
 
 #[instrument(name = "command.whoami.handle", skip(profile))]
 pub fn handle_whoami(profile: Option<OAuthCredential>) -> CommandResponse {
     match profile {
         Some(profile) => CommandResponse::Content(format!(
-            "Your linked AniList account is **{}**.\nProfile: <{}>",
+            "You're linked to AniList as **{}**.\nProfile: <{}>",
             profile.anilist_display_name(),
             profile.anilist_profile_url()
         )),
         None => CommandResponse::Content(
-            "You have not linked an AniList account yet. Run `/register` first.".to_string(),
+            "No AniList account is linked yet. Run `/register` to connect one.".to_string(),
         ),
     }
 }
@@ -41,7 +41,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 
     let Some(database_pool) = get_pool_from_context(ctx).await else {
         let builder = EditInteractionResponse::new()
-            .content("Database is not initialized. Please try again later.");
+            .content("I can't reach my database right now. Please try again later.");
         let _ = interaction.edit_response(&ctx.http, builder).await;
         return;
     };
@@ -58,7 +58,7 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
                 "Failed to fetch whoami profile from database"
             );
             CommandResponse::Content(
-                "I hit an internal error while looking up your AniList account. Please try again later."
+                "I couldn't look up your AniList account right now. Please try again later."
                     .to_string(),
             )
         }

--- a/src/models/anilist_recommendation.rs
+++ b/src/models/anilist_recommendation.rs
@@ -80,9 +80,8 @@ impl Recommendation {
         self.media_recommendation.as_ref()
     }
 
-    pub fn rating_text(&self) -> String {
+    pub fn rating(&self) -> Option<i32> {
         self.rating
-            .map_or_else(|| EMPTY_STR.to_string(), |rating| rating.to_string())
     }
 }
 
@@ -392,7 +391,7 @@ mod tests {
 
         let recommendation = media.recommendations().next().unwrap();
         let recommended_media = recommendation.recommended_media().unwrap();
-        assert_eq!(recommendation.rating_text(), "42");
+        assert_eq!(recommendation.rating(), Some(42));
         assert_eq!(
             recommended_media.display_title(None, TitleDisplayPreference::Matched),
             "Samurai Champloo"

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -130,7 +130,7 @@ impl MalResponse {
             }
 
             if let Some(ref episodes) = song.episode_numbers {
-                write!(line, " · Episodes: {}", episodes).unwrap();
+                write!(line, " · {}", episodes).unwrap();
             }
 
             lines.push(line);
@@ -282,7 +282,7 @@ mod tests {
 
         assert_eq!(
             MalResponse::format_parsed_songs(&songs),
-            "1. Again by YUI · Episodes: eps 1-14"
+            "1. Again by YUI · eps 1-14"
         );
     }
 

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -108,7 +108,7 @@ impl MalResponse {
     #[instrument(name = "mal_response.format_parsed_songs", skip(songs))]
     pub fn format_parsed_songs(songs: &[ParsedSong]) -> String {
         if songs.is_empty() {
-            return "No information available".to_string();
+            return "No theme songs listed yet.".to_string();
         }
 
         let mut lines: Vec<String> = Vec::with_capacity(songs.len());
@@ -130,7 +130,7 @@ impl MalResponse {
             }
 
             if let Some(ref episodes) = song.episode_numbers {
-                write!(line, " | {}", episodes).unwrap();
+                write!(line, " · Episodes: {}", episodes).unwrap();
             }
 
             lines.push(line);
@@ -223,7 +223,7 @@ impl MalResponse {
 
     pub fn transform_mal_link(&self) -> String {
         let link = format!("https://www.myanimelist.net/anime/{}", self.id);
-        linker("MyAnimeList", &link)
+        format!("Theme song data from {}", linker("MyAnimeList", &link))
     }
 
     pub fn transform_thumbnail(&self) -> String {
@@ -244,7 +244,7 @@ impl MalResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::MalResponse;
+    use super::{MalResponse, ParsedSong};
 
     #[test]
     fn get_song_number_parses_numeric_prefixes() {
@@ -258,5 +258,51 @@ mod tests {
         let song = "#TV: \"Again\" by YUI";
 
         assert_eq!(MalResponse::get_song_number(song), None);
+    }
+
+    #[test]
+    fn format_parsed_songs_uses_friendly_empty_state() {
+        assert_eq!(
+            MalResponse::format_parsed_songs(&[]),
+            "No theme songs listed yet."
+        );
+    }
+
+    #[test]
+    fn format_parsed_songs_uses_episode_label() {
+        let songs = vec![ParsedSong {
+            display_number: 1,
+            song_name: "Again".to_string(),
+            romaji_name: "Again".to_string(),
+            kana_name: None,
+            artist_names: Some("YUI".to_string()),
+            episode_numbers: Some("eps 1-14".to_string()),
+            spotify_url: None,
+        }];
+
+        assert_eq!(
+            MalResponse::format_parsed_songs(&songs),
+            "1. Again by YUI · Episodes: eps 1-14"
+        );
+    }
+
+    #[test]
+    fn transform_mal_link_describes_source() {
+        let response: MalResponse = serde_json::from_value(serde_json::json!({
+            "id": 5114,
+            "title": "Fullmetal Alchemist: Brotherhood",
+            "main_picture": {
+                "medium": "https://example.com/medium.jpg",
+                "large": "https://example.com/large.jpg"
+            },
+            "opening_themes": [],
+            "ending_themes": []
+        }))
+        .expect("MAL response should deserialize");
+
+        assert_eq!(
+            response.transform_mal_link(),
+            "Theme song data from [MyAnimeList](https://www.myanimelist.net/anime/5114)"
+        );
     }
 }

--- a/src/models/mal_response.rs
+++ b/src/models/mal_response.rs
@@ -223,7 +223,7 @@ impl MalResponse {
 
     pub fn transform_mal_link(&self) -> String {
         let link = format!("https://www.myanimelist.net/anime/{}", self.id);
-        format!("Theme song data from {}", linker("MyAnimeList", &link))
+        linker("MyAnimeList", &link)
     }
 
     pub fn transform_thumbnail(&self) -> String {
@@ -287,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    fn transform_mal_link_describes_source() {
+    fn transform_mal_link_returns_source_link() {
         let response: MalResponse = serde_json::from_value(serde_json::json!({
             "id": 5114,
             "title": "Fullmetal Alchemist: Brotherhood",
@@ -302,7 +302,7 @@ mod tests {
 
         assert_eq!(
             response.transform_mal_link(),
-            "Theme song data from [MyAnimeList](https://www.myanimelist.net/anime/5114)"
+            "[MyAnimeList](https://www.myanimelist.net/anime/5114)"
         );
     }
 }

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -62,12 +62,12 @@ impl SettingKey {
 
     pub fn description(self) -> &'static str {
         match self {
-            Self::TitleDisplay => "Which AniList title variant Annie Mei should prefer.",
+            Self::TitleDisplay => "Pick which title language Annie Mei should show first.",
             Self::AnalyticsPrivacy => {
-                "Whether user-level analytics may include raw user-provided content. The default is `standard`; `opted_out` disables raw query, prompt, and output capture in supported analytics/observability while keeping pseudonymous operational telemetry."
+                "Choose whether analytics may include your raw searches and AI search prompts. `opted_out` keeps operational telemetry pseudonymous and skips raw content capture."
             }
             Self::GuildScores => {
-                "Whether guild score displays are enabled for a server and whether a user participates. Guild disabled wins over user participation; users who opt out are excluded."
+                "Control whether Annie Mei shows server members' AniList status and scores. Server disable wins; users who opt out are always excluded."
             }
         }
     }
@@ -232,7 +232,7 @@ impl fmt::Display for SettingValidationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "`{}` is not valid for {}. Allowed values: {}.",
+            "`{}` is not valid for {}. Choose one of: {}.",
             self.raw_value,
             self.setting_key.label(),
             self.setting_key.allowed_values_sentence()

--- a/src/models/user_media_list.rs
+++ b/src/models/user_media_list.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::fmt;
+use tracing::instrument;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -40,36 +41,138 @@ impl fmt::Display for MediaListStatus {
 }
 
 impl MediaListData {
+    #[instrument(skip(self))]
     pub fn format_for_embed(&self, is_anime: bool) -> String {
-        let mut embed = String::default();
+        let mut parts = Vec::new();
+
         if let Some(status) = &self.status {
-            let status = {
-                if !is_anime && matches!(status, MediaListStatus::Current) {
-                    "Reading".to_string()
-                } else {
-                    status.to_string()
-                }
-            };
-            embed.push_str(&format!("**Status:** {}  ", status));
+            parts.push(status_phrase(status, is_anime).to_string());
         }
+
+        if !matches!(self.status, Some(MediaListStatus::Completed))
+            && !matches!(self.status, Some(MediaListStatus::Planning))
+            && let Some(progress) = self.progress
+        {
+            parts.push(progress_phrase(
+                progress,
+                self.progress_volumes,
+                self.status.as_ref(),
+                is_anime,
+            ));
+        }
+
         if let Some(score) = &self.score {
-            embed.push_str(&format!("**Score:** {}  ", score));
+            parts.push(format!("rated {score}/100"));
         }
 
-        // Skip other fields if status is completed
-        if matches!(self.status, Some(MediaListStatus::Completed)) {
-            return embed;
-        } else {
-            if let Some(progress) = &self.progress {
-                embed.push_str(&format!("**Progress:** {progress}"));
-            }
-            if let Some(progress_volumes) = &self.progress_volumes
-                && progress_volumes != &0
-            {
-                embed.push_str(&format!("[{progress_volumes}]"));
-            }
-        }
+        parts.join(", ")
+    }
+}
 
-        embed
+#[instrument]
+fn status_phrase(status: &MediaListStatus, is_anime: bool) -> &'static str {
+    match status {
+        MediaListStatus::Current if is_anime => "is watching",
+        MediaListStatus::Current => "is reading",
+        MediaListStatus::Planning if is_anime => "plans to watch it",
+        MediaListStatus::Planning => "plans to read it",
+        MediaListStatus::Completed => "finished it",
+        MediaListStatus::Dropped => "dropped it",
+        MediaListStatus::Paused => "paused it",
+        MediaListStatus::Repeating if is_anime => "is rewatching",
+        MediaListStatus::Repeating => "is rereading",
+    }
+}
+
+#[instrument]
+fn progress_phrase(
+    progress: u32,
+    progress_volumes: Option<u32>,
+    status: Option<&MediaListStatus>,
+    is_anime: bool,
+) -> String {
+    let progress_text = if is_anime {
+        format!("{progress} {}", pluralize(progress, "ep", "eps"))
+    } else {
+        let mut text = format!("{progress} {}", pluralize(progress, "chapter", "chapters"));
+        if let Some(volumes) = progress_volumes
+            && volumes > 0
+        {
+            text.push_str(&format!(
+                " / {volumes} {}",
+                pluralize(volumes, "vol", "vols")
+            ));
+        }
+        text
+    };
+
+    match status {
+        Some(MediaListStatus::Dropped) => format!("after {progress_text}"),
+        Some(MediaListStatus::Paused) => format!("at {progress_text}"),
+        _ => format!("{progress_text} in"),
+    }
+}
+
+#[instrument]
+fn pluralize(count: u32, singular: &'static str, plural: &'static str) -> &'static str {
+    if count == 1 { singular } else { plural }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_anime_formats_as_sentence() {
+        let data = MediaListData {
+            status: Some(MediaListStatus::Current),
+            score: Some(91),
+            progress: Some(5),
+            progress_volumes: None,
+        };
+
+        assert_eq!(
+            data.format_for_embed(true),
+            "is watching, 5 eps in, rated 91/100"
+        );
+    }
+
+    #[test]
+    fn current_manga_formats_chapters_and_volumes() {
+        let data = MediaListData {
+            status: Some(MediaListStatus::Current),
+            score: Some(88),
+            progress: Some(12),
+            progress_volumes: Some(2),
+        };
+
+        assert_eq!(
+            data.format_for_embed(false),
+            "is reading, 12 chapters / 2 vols in, rated 88/100"
+        );
+    }
+
+    #[test]
+    fn completed_media_skips_progress() {
+        let data = MediaListData {
+            status: Some(MediaListStatus::Completed),
+            score: Some(100),
+            progress: Some(24),
+            progress_volumes: None,
+        };
+
+        assert_eq!(data.format_for_embed(true), "finished it, rated 100/100");
+    }
+
+    #[test]
+    fn missing_optional_values_are_omitted() {
+        let data = MediaListData {
+            status: Some(MediaListStatus::Planning),
+            score: None,
+            progress: Some(0),
+            progress_volumes: Some(0),
+        };
+
+        assert_eq!(data.format_for_embed(false), "plans to read it");
     }
 }

--- a/src/models/user_media_list.rs
+++ b/src/models/user_media_list.rs
@@ -61,7 +61,9 @@ impl MediaListData {
             ));
         }
 
-        if let Some(score) = &self.score {
+        if let Some(score) = self.score
+            && score > 0
+        {
             parts.push(format!("rated {score}/100"));
         }
 
@@ -174,5 +176,17 @@ mod tests {
         };
 
         assert_eq!(data.format_for_embed(false), "plans to read it");
+    }
+
+    #[test]
+    fn zero_score_is_omitted_as_unscored() {
+        let data = MediaListData {
+            status: Some(MediaListStatus::Current),
+            score: Some(0),
+            progress: Some(3),
+            progress_volumes: None,
+        };
+
+        assert_eq!(data.format_for_embed(true), "is watching, 3 eps in");
     }
 }

--- a/src/models/user_media_list.rs
+++ b/src/models/user_media_list.rs
@@ -44,8 +44,10 @@ impl MediaListData {
     #[instrument(skip(self))]
     pub fn format_for_embed(&self, is_anime: bool) -> String {
         let mut parts = Vec::new();
+        let mut status_index = None;
 
         if let Some(status) = &self.status {
+            status_index = Some(parts.len());
             parts.push(status_phrase(status, is_anime).to_string());
         }
 
@@ -53,12 +55,22 @@ impl MediaListData {
             && !matches!(self.status, Some(MediaListStatus::Planning))
             && let Some(progress) = self.progress
         {
-            parts.push(progress_phrase(
+            let progress = progress_phrase(
                 progress,
                 self.progress_volumes,
                 self.status.as_ref(),
                 is_anime,
-            ));
+            );
+
+            if matches!(
+                self.status,
+                Some(MediaListStatus::Dropped | MediaListStatus::Paused)
+            ) && let Some(index) = status_index
+            {
+                parts[index].push_str(&format!(" {progress}"));
+            } else {
+                parts.push(progress);
+            }
         }
 
         if let Some(score) = self.score
@@ -188,5 +200,32 @@ mod tests {
         };
 
         assert_eq!(data.format_for_embed(true), "is watching, 3 eps in");
+    }
+
+    #[test]
+    fn dropped_progress_reads_as_single_phrase() {
+        let data = MediaListData {
+            status: Some(MediaListStatus::Dropped),
+            score: Some(80),
+            progress: Some(5),
+            progress_volumes: None,
+        };
+
+        assert_eq!(
+            data.format_for_embed(true),
+            "dropped it after 5 eps, rated 80/100"
+        );
+    }
+
+    #[test]
+    fn paused_progress_reads_as_single_phrase() {
+        let data = MediaListData {
+            status: Some(MediaListStatus::Paused),
+            score: None,
+            progress: Some(7),
+            progress_volumes: None,
+        };
+
+        assert_eq!(data.format_for_embed(true), "paused it at 7 eps");
     }
 }

--- a/src/utils/statics.rs
+++ b/src/utils/statics.rs
@@ -1,8 +1,8 @@
-pub const NOT_FOUND_ANIME: &str = "No such anime";
-pub const NOT_FOUND_MANGA: &str = "No such manga";
-pub const NOT_FOUND_CHARACTER: &str = "No such character";
+pub const NOT_FOUND_ANIME: &str = "I couldn't find that anime on AniList.";
+pub const NOT_FOUND_MANGA: &str = "I couldn't find that manga on AniList.";
+pub const NOT_FOUND_CHARACTER: &str = "I couldn't find that character on AniList.";
 pub const NSFW_NOT_ALLOWED: &str =
-    "This content is age-restricted and can only be viewed in NSFW channels";
+    "That result is age-restricted, so I can only show it in an NSFW channel.";
 pub const EMPTY_STR: &str = "-";
 pub const ANILIST_STATUS_RELEASING: &str = "RELEASING";
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Polishes user-facing copy across Annie Mei commands, embeds, and account/settings flows so responses read more conversationally and less like raw API labels.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- ac8b239c4148273346a77f76c733d538ac7479e7: Reworked guild member media status lines and recommendation entries into friendlier, sentence-style copy while omitting empty optional details.
- 89034383ff9287b61b10391d0d0d0f58c0f79d02: Bumped the package version to 3.8.0 and updated Cargo.lock.
- 115e3bde2b48f2528ab6bfaeca1c9521500ea6ff: Polished theme song copy for /songs, including section labels, MyAnimeList source text, empty states, and error messages.
- 4f5c24295f33fd0aaf156bb911904d1d05567844: Polished command descriptions, not-found/NSFW messages, validation guidance, help text, account-linking copy, and settings descriptions.

### Notes

The UX text is deterministic rather than LLM-generated so command output stays fast, predictable, and easy to test.

## Validation
- [x] cargo test
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [ ] Manual Discord QA for representative command responses

---

This PR description was written by GPT-5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->