### PR TITLE
[ANNIE-196]/fix release build recursion limit overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.8.5"
+version = "3.8.6"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.8.5"
+version = "3.8.6"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 mod commands;
 mod models;
 mod utils;


### PR DESCRIPTION
## Summary

Raises the binary crate recursion limit so the release build can complete after dependency updates increased compiler query depth in the main async command-dispatch future. Bumps the patch version for the build fix release.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 3046e15e0ec22f5b56c9b9408c36f88e704b621b: Added a crate-level recursion limit for the main binary to satisfy rustc's release-build query depth requirement.
- 393e430279944f93767d77080bd88bd02b8734cf: Bumped the crate patch version to 3.8.6 and refreshed Cargo.lock for the release build fix.

## Validation
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo build --release

## References
- Failed release build: https://github.com/annie-mei/annie-mei/actions/runs/27313163871/job/80687768231
- Failed release build: https://github.com/annie-mei/annie-mei/actions/runs/27313451894/job/80688692047

---

This PR description was written by Amp.