### PR TITLE
[ANNIE-201]/set up orbs on Amp

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This repository has no local services required for builds or tests. Runtime
+# PostgreSQL, Redis, and third-party APIs are configured externally.
+echo "No local services need to be resumed."

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+
+echo "Installing system dependencies..."
+packages=(build-essential ca-certificates curl libpq-dev pkg-config)
+missing_packages=()
+for package in "${packages[@]}"; do
+  if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q '^install ok installed$'; then
+    missing_packages+=("$package")
+  fi
+done
+
+if ((${#missing_packages[@]})); then
+  if ((EUID == 0)); then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing_packages[@]}"
+  else
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing_packages[@]}"
+  fi
+fi
+
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "Installing rustup..."
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    sh -s -- -y --profile minimal --default-toolchain none --no-modify-path
+fi
+
+toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2; exit }' rust-toolchain.toml)"
+echo "Installing Rust ${toolchain} and development components..."
+rustup toolchain install "$toolchain" \
+  --profile minimal \
+  --component clippy \
+  --component rust-analyzer \
+  --component rustfmt
+
+# Setup runs before Amp starts, so its PATH export does not reach later shells.
+# Expose rustup's command proxies through a directory already on the orb PATH.
+cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin"
+rust_commands=(cargo cargo-clippy cargo-fmt clippy-driver rust-analyzer rustc rustdoc rustfmt rustup)
+for command in "${rust_commands[@]}"; do
+  [[ -e "$cargo_bin/$command" ]] || continue
+  if ((EUID == 0)); then
+    ln -sfn "$cargo_bin/$command" "/usr/local/bin/$command"
+  else
+    sudo ln -sfn "$cargo_bin/$command" "/usr/local/bin/$command"
+  fi
+done
+
+echo "Fetching locked Cargo dependencies..."
+cargo fetch --locked
+
+echo "Orb setup complete."


### PR DESCRIPTION
## Summary

Prepare Annie Mei for reliable development in fresh and resumed Amp orbs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- bf7b9edb3e3752cbf61bb0ba193fcbb4db2efa14: add executable Amp setup and resume lifecycle scripts

### Notes

The setup script installs the pinned Rust 1.95 toolchain, development components, native PostgreSQL build dependencies, and locked Cargo dependencies. It exposes rustup command proxies on the orb PATH for later Amp shells. The resume script intentionally starts no services because builds and tests do not require local PostgreSQL or Redis instances.

## Validation
- [x] Ran `.agents/setup` successfully and confirmed an idempotent rerun
- [x] Ran `.agents/resume` successfully in approximately 0.003 seconds
- [x] Ran `cargo build --all-features`
- [x] Ran `cargo test --all-features` (207 passed)

## References

- ANNIE-201

---

This PR description was written by Amp.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->