### PR TITLE
[ANNIE-195]/add playful randomized response variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.9.0"
+version = "3.10.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/search/command.rs
+++ b/src/commands/search/command.rs
@@ -416,6 +416,14 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
 fn format_interpretation(intent: &SearchIntent) -> String {
     let variant = interpretation_variant(intent);
 
+    format_interpretation_with_variant(intent, variant)
+}
+
+#[instrument(
+    name = "command.search.format_interpretation_with_variant",
+    skip(intent)
+)]
+fn format_interpretation_with_variant(intent: &SearchIntent, variant: usize) -> String {
     match intent.media_type {
         SearchMediaType::Anime => format_anime_interpretation(variant, &intent.search),
         SearchMediaType::Manga => format_manga_interpretation(variant, &intent.search),
@@ -425,20 +433,41 @@ fn format_interpretation(intent: &SearchIntent) -> String {
 
 #[instrument(name = "command.search.interpretation_variant", skip(intent))]
 fn interpretation_variant(intent: &SearchIntent) -> usize {
+    let mut random_bytes = [0_u8; 8];
+    let random_value = getrandom::fill(&mut random_bytes)
+        .ok()
+        .map(|()| u64::from_ne_bytes(random_bytes));
+
+    interpretation_variant_with_random_value(intent, random_value)
+}
+
+#[instrument(
+    name = "command.search.interpretation_variant_with_random_value",
+    skip(intent)
+)]
+fn interpretation_variant_with_random_value(
+    intent: &SearchIntent,
+    random_value: Option<u64>,
+) -> usize {
+    let value = random_value.unwrap_or_else(|| stable_interpretation_value(intent));
+
+    (value % INTERPRETATION_VARIANT_COUNT) as usize
+}
+
+#[instrument(name = "command.search.stable_interpretation_value", skip(intent))]
+fn stable_interpretation_value(intent: &SearchIntent) -> u64 {
     let media_type = match intent.media_type {
         SearchMediaType::Anime => 0_u8,
         SearchMediaType::Manga => 1,
         SearchMediaType::Unknown => 2,
     };
 
-    let hash = intent
+    intent
         .search
         .bytes()
         .fold(u64::from(media_type), |hash, byte| {
             hash.wrapping_mul(31).wrapping_add(u64::from(byte))
-        });
-
-    (hash % INTERPRETATION_VARIANT_COUNT) as usize
+        })
 }
 
 #[instrument(name = "command.search.format_anime_interpretation", skip(search))]

--- a/src/commands/search/tests.rs
+++ b/src/commands/search/tests.rs
@@ -180,8 +180,8 @@ fn format_interpretation_is_conversational() {
     };
 
     assert_eq!(
-        format_interpretation(&intent),
-        format_manga_interpretation(interpretation_variant(&intent), "Berserk")
+        format_interpretation_with_variant(&intent, 4),
+        "Manga radar says: `Berserk`."
     );
 }
 
@@ -194,34 +194,36 @@ fn format_interpretation_handles_unknown_media_type() {
     };
 
     assert_eq!(
-        format_interpretation(&intent),
-        format_unknown_interpretation(interpretation_variant(&intent), "Monster")
+        format_interpretation_with_variant(&intent, 6),
+        "I chased that clue to `Monster`."
     );
 }
 
 #[test]
-fn interpretation_variant_is_stable_for_same_search() {
+fn interpretation_variant_uses_supplied_random_value() {
     let intent = SearchIntent {
         media_type: SearchMediaType::Anime,
         search: "Trigun".to_string(),
         candidates: Vec::new(),
     };
 
-    assert_eq!(
-        interpretation_variant(&intent),
-        interpretation_variant(&intent)
-    );
+    for expected in 0..INTERPRETATION_VARIANT_COUNT {
+        assert_eq!(
+            interpretation_variant_with_random_value(&intent, Some(expected)),
+            expected as usize
+        );
+    }
 }
 
 #[test]
-fn interpretation_variant_has_stable_cross_toolchain_mapping() {
+fn interpretation_variant_falls_back_to_stable_cross_toolchain_mapping() {
     let intent = SearchIntent {
         media_type: SearchMediaType::Anime,
         search: "Trigun".to_string(),
         candidates: Vec::new(),
     };
 
-    assert_eq!(interpretation_variant(&intent), 5);
+    assert_eq!(interpretation_variant_with_random_value(&intent, None), 5);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Randomize `/search` interpretation prefaces per interaction while preserving the existing clear, media-aware phrase bank and deterministic fallback behavior.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- 8a467ca8b3bb4788748faa02ea2645f34c5bcf4a: select `/search` interpretation variants with OS randomness, retain stable-hash fallback behavior, add deterministic coverage, and bump the release version to 3.10.0

### Notes

Tests inject variant values instead of asserting random production output, keeping the suite deterministic and non-flaky.

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo test` (218 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

## References

- [ANNIE-195](https://linear.app/annie-mei/issue/ANNIE-195/add-playful-randomized-response-variants)

---

This PR description was written by GPT-5.4.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->