### PR TITLE
[ANNIE-205]/reuse Spotify authentication across song enrichment batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.10.0"
+version = "3.10.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/commands/songs/command.rs
+++ b/src/commands/songs/command.rs
@@ -123,8 +123,10 @@ fn enrich_song_sections(
     mut openings: Vec<ParsedSong>,
     mut endings: Vec<ParsedSong>,
 ) -> (Vec<ParsedSong>, Vec<ParsedSong>) {
+    let opening_count = openings.len();
+    openings.append(&mut endings);
     enrich_songs_with_spotify(&mut openings);
-    enrich_songs_with_spotify(&mut endings);
+    let endings = openings.split_off(opening_count);
     (openings, endings)
 }
 

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -7,13 +7,86 @@ use crate::{
 };
 
 use rspotify::{
-    ClientCredsSpotify, ClientError, Credentials,
+    ClientCredsSpotify, Credentials,
     model::{Country, Market, SearchResult, SearchType},
     prelude::*,
 };
 
 use std::env;
 use tracing::{error, info, instrument};
+
+enum CacheLookup {
+    Hit(Option<String>),
+    Miss,
+}
+
+enum SearchOutcome {
+    Found(String),
+    NotFound,
+    Failed,
+}
+
+trait SpotifyBackend {
+    fn read_cache(&mut self, key: &str) -> CacheLookup;
+    fn authenticate(&mut self) -> bool;
+    fn search(&mut self, song_name: &str, artist_name: &str) -> SearchOutcome;
+    fn write_cache(&mut self, key: &str, value: &str);
+}
+
+#[derive(Default)]
+struct DefaultSpotifyBackend {
+    client: Option<ClientCredsSpotify>,
+}
+
+impl SpotifyBackend for DefaultSpotifyBackend {
+    fn read_cache(&mut self, key: &str) -> CacheLookup {
+        match check_cache(key) {
+            Ok(value) => {
+                info!("Cache hit for {key:#?}");
+                match value.as_str() {
+                    "None" => CacheLookup::Hit(None),
+                    _ => CacheLookup::Hit(Some(value)),
+                }
+            }
+            Err(err) => {
+                info!("Cache miss for {key:#?} with error {err:#?}");
+                CacheLookup::Miss
+            }
+        }
+    }
+
+    fn authenticate(&mut self) -> bool {
+        let spotify = get_spotify_client();
+        if let Err(err) = spotify.request_token() {
+            error!(error = %err, "Failed to request Spotify token");
+            return false;
+        }
+
+        self.client = Some(spotify);
+        true
+    }
+
+    fn search(&mut self, song_name: &str, artist_name: &str) -> SearchOutcome {
+        let Some(spotify) = self.client.as_ref() else {
+            return SearchOutcome::Failed;
+        };
+
+        match send_search_request(spotify, song_name, artist_name) {
+            Ok(search_result) => match get_url_from_search_result(search_result) {
+                Some(url) => SearchOutcome::Found(url),
+                None => SearchOutcome::NotFound,
+            },
+            Err(err) => {
+                info!(error = %err, "Could not find Spotify track");
+                SearchOutcome::Failed
+            }
+        }
+    }
+
+    fn write_cache(&mut self, key: &str, value: &str) {
+        try_to_cache_response(key, value);
+    }
+}
 
 #[instrument(name = "spotify.get_client", skip_all)]
 fn get_spotify_client() -> ClientCredsSpotify {
@@ -30,75 +103,14 @@ fn get_spotify_client() -> ClientCredsSpotify {
     spotify
 }
 
-#[instrument(name = "spotify.get_song_url", skip(kana_name, romaji_name, artist_name), fields(song = %romaji_name, artist = %artist_name))]
-pub fn get_song_url(
-    romaji_name: String,
-    kana_name: Option<String>,
-    artist_name: String,
-) -> Option<String> {
-    // If cached response if found, return it
-    let cache_key = format!("{romaji_name}:{kana_name:#?}:{artist_name}");
-    match check_cache(&cache_key) {
-        Ok(value) => {
-            info!("Cache hit for {:#?}", cache_key);
-            return match value.as_str() {
-                "None" => None,
-                _ => Some(value),
-            };
-        }
-        Err(e) => {
-            info!("Cache miss for {:#?} with error {:#?}", cache_key, e);
-        }
-    };
-
-    let romaji_search = send_search_request(&romaji_name, &artist_name);
-    match romaji_search {
-        Ok(search_result) => {
-            info!("Searched track: {search_result:#?}");
-            if let Some(url) = get_url_from_search_result(search_result) {
-                try_to_cache_response(&cache_key, &url);
-                return Some(url);
-            } else if let Some(kana_name) = kana_name {
-                let kana_search = send_search_request(&kana_name, &artist_name);
-                match kana_search {
-                    Ok(search_result) => {
-                        info!(
-                            "Searched track using Track: {kana_name:#?} Artist: {artist_name:#?}: {search_result:#?}"
-                        );
-                        match get_url_from_search_result(search_result) {
-                            Some(url) => {
-                                try_to_cache_response(&cache_key, &url);
-                                return Some(url);
-                            }
-                            None => {
-                                try_to_cache_response(&cache_key, "None");
-                                return None;
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        info!("Error searching track: {e:#?}");
-                    }
-                }
-            } else {
-                try_to_cache_response(&cache_key, "None");
-                return None;
-            }
-        }
-        Err(err) => info!("Could not find track: {err:#?}"),
-    }
-    try_to_cache_response(&cache_key, "None");
-    None
-}
-
-#[instrument(name = "spotify.send_search_request", skip(song_name, artist_name), fields(song = %song_name, artist = %artist_name))]
-fn send_search_request(song_name: &str, artist_name: &str) -> Result<SearchResult, ClientError> {
-    let spotify = get_spotify_client();
-    if let Err(err) = spotify.request_token() {
-        error!(error = %err, "Failed to request Spotify token");
-        return Err(err);
-    }
-
+#[instrument(name = "spotify.send_search_request", skip(spotify, song_name, artist_name), fields(song = %song_name, artist = %artist_name))]
+fn send_search_request(
+    spotify: &ClientCredsSpotify,
+    song_name: &str,
+    artist_name: &str,
+) -> Result<SearchResult, rspotify::ClientError> {
+    // rspotify's blocking ureq client applies a 10-second deadline to each
+    // token and API request.
     spotify.search(
         format!("track:{song_name} artist:{artist_name}").as_str(),
         SearchType::Track,
@@ -125,18 +137,228 @@ fn get_url_from_search_result(search_result: SearchResult) -> Option<String> {
     }
 }
 
+#[instrument(name = "spotify.search_song", skip(backend, kana_name, romaji_name, artist_name), fields(song = %romaji_name, artist = %artist_name))]
+fn search_song<B: SpotifyBackend>(
+    backend: &mut B,
+    romaji_name: &str,
+    kana_name: Option<&str>,
+    artist_name: &str,
+) -> Option<String> {
+    match backend.search(romaji_name, artist_name) {
+        SearchOutcome::Found(url) => Some(url),
+        SearchOutcome::NotFound => match kana_name {
+            Some(kana_name) => match backend.search(kana_name, artist_name) {
+                SearchOutcome::Found(url) => Some(url),
+                SearchOutcome::NotFound | SearchOutcome::Failed => None,
+            },
+            None => None,
+        },
+        SearchOutcome::Failed => None,
+    }
+}
+
+#[instrument(name = "spotify.enrich_songs_backend", skip(songs, backend), fields(count = songs.len()))]
+fn enrich_songs_with_backend<B: SpotifyBackend>(songs: &mut [ParsedSong], backend: &mut B) {
+    let mut authentication = None;
+
+    for song in songs.iter_mut() {
+        let Some(artist) = song.artist_names.as_deref() else {
+            continue;
+        };
+
+        // Keep the historical cache key format for compatibility.
+        let cache_key = format!("{}:{:#?}:{}", song.romaji_name, song.kana_name, artist);
+        if let CacheLookup::Hit(url) = backend.read_cache(&cache_key) {
+            song.spotify_url = url;
+            continue;
+        }
+
+        let authenticated = *authentication.get_or_insert_with(|| backend.authenticate());
+        let url = if authenticated {
+            search_song(
+                backend,
+                &song.romaji_name,
+                song.kana_name.as_deref(),
+                artist,
+            )
+        } else {
+            None
+        };
+
+        backend.write_cache(&cache_key, url.as_deref().unwrap_or("None"));
+        song.spotify_url = url;
+    }
+}
+
 /// Fill in `spotify_url` for each [`ParsedSong`] that has an artist.
-/// This performs synchronous Spotify + Redis I/O and is intended to run
-/// inside `spawn_blocking`.
+///
+/// One client and access token are reused for all uncached songs and kana
+/// fallbacks in this batch. This performs synchronous Spotify + Redis I/O and
+/// is intended to run inside `spawn_blocking`.
 #[instrument(name = "spotify.enrich_songs", skip(songs), fields(count = songs.len()))]
 pub fn enrich_songs_with_spotify(songs: &mut [ParsedSong]) {
-    for song in songs.iter_mut() {
-        if let Some(ref artist) = song.artist_names {
-            song.spotify_url = get_song_url(
-                song.romaji_name.clone(),
-                song.kana_name.clone(),
-                artist.clone(),
-            );
+    enrich_songs_with_backend(songs, &mut DefaultSpotifyBackend::default());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, VecDeque};
+
+    #[derive(Default)]
+    struct FakeBackend {
+        cache: HashMap<String, Option<String>>,
+        cached_writes: Vec<(String, String)>,
+        authentication_count: usize,
+        searches: Vec<(String, String)>,
+        search_results: VecDeque<SearchOutcome>,
+    }
+
+    impl SpotifyBackend for FakeBackend {
+        fn read_cache(&mut self, key: &str) -> CacheLookup {
+            match self.cache.get(key) {
+                Some(value) => CacheLookup::Hit(value.clone()),
+                None => CacheLookup::Miss,
+            }
         }
+
+        fn authenticate(&mut self) -> bool {
+            self.authentication_count += 1;
+            true
+        }
+
+        fn search(&mut self, song_name: &str, artist_name: &str) -> SearchOutcome {
+            self.searches
+                .push((song_name.to_string(), artist_name.to_string()));
+            self.search_results
+                .pop_front()
+                .unwrap_or(SearchOutcome::NotFound)
+        }
+
+        fn write_cache(&mut self, key: &str, value: &str) {
+            self.cached_writes
+                .push((key.to_string(), value.to_string()));
+        }
+    }
+
+    fn song(romaji_name: &str, kana_name: Option<&str>, artist: &str) -> ParsedSong {
+        ParsedSong {
+            display_number: 1,
+            song_name: romaji_name.to_string(),
+            romaji_name: romaji_name.to_string(),
+            kana_name: kana_name.map(str::to_string),
+            artist_names: Some(artist.to_string()),
+            episode_numbers: None,
+            spotify_url: None,
+        }
+    }
+
+    #[test]
+    fn enrichment_authenticates_once_for_multiple_songs() {
+        let mut songs = vec![
+            song("First", None, "Artist A"),
+            song("Second", None, "Artist B"),
+        ];
+        let mut backend = FakeBackend {
+            search_results: VecDeque::from([
+                SearchOutcome::Found("https://spotify/first".to_string()),
+                SearchOutcome::Found("https://spotify/second".to_string()),
+            ]),
+            ..Default::default()
+        };
+
+        enrich_songs_with_backend(&mut songs, &mut backend);
+
+        assert_eq!(backend.authentication_count, 1);
+        assert_eq!(backend.searches.len(), 2);
+        assert_eq!(
+            songs[0].spotify_url.as_deref(),
+            Some("https://spotify/first")
+        );
+        assert_eq!(
+            songs[1].spotify_url.as_deref(),
+            Some("https://spotify/second")
+        );
+    }
+
+    #[test]
+    fn kana_fallback_reuses_authenticated_client() {
+        let mut songs = vec![song("Romaji", Some("かな"), "Artist")];
+        let mut backend = FakeBackend {
+            search_results: VecDeque::from([
+                SearchOutcome::NotFound,
+                SearchOutcome::Found("https://spotify/kana".to_string()),
+            ]),
+            ..Default::default()
+        };
+
+        enrich_songs_with_backend(&mut songs, &mut backend);
+
+        assert_eq!(backend.authentication_count, 1);
+        assert_eq!(
+            backend.searches,
+            [
+                ("Romaji".to_string(), "Artist".to_string()),
+                ("かな".to_string(), "Artist".to_string())
+            ]
+        );
+        assert_eq!(
+            songs[0].spotify_url.as_deref(),
+            Some("https://spotify/kana")
+        );
+    }
+
+    #[test]
+    fn cache_hits_skip_authentication_and_preserve_negative_entries() {
+        let mut songs = vec![
+            song("Found", None, "Artist"),
+            song("Missing", None, "Artist"),
+        ];
+        let mut backend = FakeBackend::default();
+        backend.cache.insert(
+            "Found:None:Artist".to_string(),
+            Some("https://spotify/cached".to_string()),
+        );
+        backend
+            .cache
+            .insert("Missing:None:Artist".to_string(), None);
+
+        enrich_songs_with_backend(&mut songs, &mut backend);
+
+        assert_eq!(backend.authentication_count, 0);
+        assert!(backend.searches.is_empty());
+        assert_eq!(
+            songs[0].spotify_url.as_deref(),
+            Some("https://spotify/cached")
+        );
+        assert!(songs[1].spotify_url.is_none());
+    }
+
+    #[test]
+    fn failed_lookup_does_not_prevent_later_songs_from_succeeding() {
+        let mut songs = vec![
+            song("First", None, "Artist"),
+            song("Second", None, "Artist"),
+        ];
+        let mut backend = FakeBackend {
+            search_results: VecDeque::from([
+                SearchOutcome::Failed,
+                SearchOutcome::Found("https://spotify/second".to_string()),
+            ]),
+            ..Default::default()
+        };
+
+        enrich_songs_with_backend(&mut songs, &mut backend);
+
+        assert_eq!(backend.authentication_count, 1);
+        assert!(songs[0].spotify_url.is_none());
+        assert_eq!(
+            songs[1].spotify_url.as_deref(),
+            Some("https://spotify/second")
+        );
+        assert_eq!(
+            backend.cached_writes[0],
+            ("First:None:Artist".to_string(), "None".to_string())
+        );
     }
 }

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -15,6 +15,8 @@ use rspotify::{
 use std::env;
 use tracing::{error, info, instrument};
 
+const MAX_AUTHENTICATION_ATTEMPTS: usize = 2;
+
 enum CacheLookup {
     Hit(Option<String>),
     Miss,
@@ -164,6 +166,7 @@ fn search_song<B: SpotifyBackend>(
 #[instrument(name = "spotify.enrich_songs_backend", skip(songs, backend), fields(count = songs.len()))]
 fn enrich_songs_with_backend<B: SpotifyBackend>(songs: &mut [ParsedSong], backend: &mut B) {
     let mut authentication = None;
+    let mut authentication_attempts = 0;
 
     for song in songs.iter_mut() {
         let Some(artist) = song.artist_names.as_deref() else {
@@ -177,7 +180,16 @@ fn enrich_songs_with_backend<B: SpotifyBackend>(songs: &mut [ParsedSong], backen
             continue;
         }
 
-        let authenticated = *authentication.get_or_insert_with(|| backend.authenticate());
+        let authenticated = match authentication {
+            Some(true) => true,
+            _ if authentication_attempts < MAX_AUTHENTICATION_ATTEMPTS => {
+                authentication_attempts += 1;
+                let authenticated = backend.authenticate();
+                authentication = Some(authenticated);
+                authenticated
+            }
+            _ => false,
+        };
         if !authenticated {
             // No Spotify lookup occurred, so do not turn a transient token
             // failure into a five-hour negative cache entry.
@@ -217,7 +229,7 @@ mod tests {
         cache: HashMap<String, Option<String>>,
         cached_writes: Vec<(String, String)>,
         authentication_count: usize,
-        authentication_result: Option<bool>,
+        authentication_results: VecDeque<bool>,
         searches: Vec<(String, String)>,
         search_results: VecDeque<SearchOutcome>,
     }
@@ -232,7 +244,7 @@ mod tests {
 
         fn authenticate(&mut self) -> bool {
             self.authentication_count += 1;
-            self.authentication_result.unwrap_or(true)
+            self.authentication_results.pop_front().unwrap_or(true)
         }
 
         fn search(&mut self, song_name: &str, artist_name: &str) -> SearchOutcome {
@@ -377,15 +389,46 @@ mod tests {
             song("Second", None, "Artist"),
         ];
         let mut backend = FakeBackend {
-            authentication_result: Some(false),
+            authentication_results: VecDeque::from([false, false]),
             ..Default::default()
         };
 
         enrich_songs_with_backend(&mut songs, &mut backend);
 
-        assert_eq!(backend.authentication_count, 1);
+        assert_eq!(backend.authentication_count, MAX_AUTHENTICATION_ATTEMPTS);
         assert!(backend.searches.is_empty());
         assert!(backend.cached_writes.is_empty());
         assert!(songs.iter().all(|song| song.spotify_url.is_none()));
+    }
+
+    #[test]
+    fn transient_authentication_failure_retries_once_and_reuses_recovered_client() {
+        let mut songs = vec![
+            song("First", None, "Artist"),
+            song("Second", None, "Artist"),
+            song("Third", None, "Artist"),
+        ];
+        let mut backend = FakeBackend {
+            authentication_results: VecDeque::from([false, true]),
+            search_results: VecDeque::from([
+                SearchOutcome::Found("https://spotify/second".to_string()),
+                SearchOutcome::Found("https://spotify/third".to_string()),
+            ]),
+            ..Default::default()
+        };
+
+        enrich_songs_with_backend(&mut songs, &mut backend);
+
+        assert_eq!(backend.authentication_count, 2);
+        assert!(songs[0].spotify_url.is_none());
+        assert_eq!(
+            songs[1].spotify_url.as_deref(),
+            Some("https://spotify/second")
+        );
+        assert_eq!(
+            songs[2].spotify_url.as_deref(),
+            Some("https://spotify/third")
+        );
+        assert_eq!(backend.cached_writes.len(), 2);
     }
 }

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -174,16 +174,19 @@ fn enrich_songs_with_backend<B: SpotifyBackend>(songs: &mut [ParsedSong], backen
         }
 
         let authenticated = *authentication.get_or_insert_with(|| backend.authenticate());
-        let url = if authenticated {
-            search_song(
-                backend,
-                &song.romaji_name,
-                song.kana_name.as_deref(),
-                artist,
-            )
-        } else {
-            None
-        };
+        if !authenticated {
+            // No Spotify lookup occurred, so do not turn a transient token
+            // failure into a five-hour negative cache entry.
+            song.spotify_url = None;
+            continue;
+        }
+
+        let url = search_song(
+            backend,
+            &song.romaji_name,
+            song.kana_name.as_deref(),
+            artist,
+        );
 
         backend.write_cache(&cache_key, url.as_deref().unwrap_or("None"));
         song.spotify_url = url;
@@ -210,6 +213,7 @@ mod tests {
         cache: HashMap<String, Option<String>>,
         cached_writes: Vec<(String, String)>,
         authentication_count: usize,
+        authentication_result: Option<bool>,
         searches: Vec<(String, String)>,
         search_results: VecDeque<SearchOutcome>,
     }
@@ -224,7 +228,7 @@ mod tests {
 
         fn authenticate(&mut self) -> bool {
             self.authentication_count += 1;
-            true
+            self.authentication_result.unwrap_or(true)
         }
 
         fn search(&mut self, song_name: &str, artist_name: &str) -> SearchOutcome {
@@ -360,5 +364,24 @@ mod tests {
             backend.cached_writes[0],
             ("First:None:Artist".to_string(), "None".to_string())
         );
+    }
+
+    #[test]
+    fn failed_authentication_does_not_write_negative_cache_entries() {
+        let mut songs = vec![
+            song("First", None, "Artist"),
+            song("Second", None, "Artist"),
+        ];
+        let mut backend = FakeBackend {
+            authentication_result: Some(false),
+            ..Default::default()
+        };
+
+        enrich_songs_with_backend(&mut songs, &mut backend);
+
+        assert_eq!(backend.authentication_count, 1);
+        assert!(backend.searches.is_empty());
+        assert!(backend.cached_writes.is_empty());
+        assert!(songs.iter().all(|song| song.spotify_url.is_none()));
     }
 }

--- a/src/utils/spotify.rs
+++ b/src/utils/spotify.rs
@@ -39,6 +39,7 @@ struct DefaultSpotifyBackend {
 }
 
 impl SpotifyBackend for DefaultSpotifyBackend {
+    #[instrument(name = "spotify.backend.read_cache", skip(self, key), fields(key_len = key.len()))]
     fn read_cache(&mut self, key: &str) -> CacheLookup {
         match check_cache(key) {
             Ok(value) => {
@@ -55,6 +56,7 @@ impl SpotifyBackend for DefaultSpotifyBackend {
         }
     }
 
+    #[instrument(name = "spotify.backend.authenticate", skip(self))]
     fn authenticate(&mut self) -> bool {
         let spotify = get_spotify_client();
         if let Err(err) = spotify.request_token() {
@@ -66,6 +68,7 @@ impl SpotifyBackend for DefaultSpotifyBackend {
         true
     }
 
+    #[instrument(name = "spotify.backend.search", skip(self, song_name, artist_name), fields(song = %song_name, artist = %artist_name))]
     fn search(&mut self, song_name: &str, artist_name: &str) -> SearchOutcome {
         let Some(spotify) = self.client.as_ref() else {
             return SearchOutcome::Failed;
@@ -83,6 +86,7 @@ impl SpotifyBackend for DefaultSpotifyBackend {
         }
     }
 
+    #[instrument(name = "spotify.backend.write_cache", skip(self, key, value), fields(key_len = key.len(), value_len = value.len()))]
     fn write_cache(&mut self, key: &str, value: &str) {
         try_to_cache_response(key, value);
     }


### PR DESCRIPTION
## Summary

Reuse one authenticated Spotify client and access token across each `/songs` enrichment batch, including romaji and kana fallback searches, while preserving Redis cache compatibility and serial matching behavior.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore

## Changes
- c8d9b8f99c89d446ba8627619aef72762f6be6bd: reuse lazy Spotify authentication across uncached song lookups and fallback searches, with focused reuse, cache, fallback, and partial-failure tests
- 663d134f0028f280eeb8c8e9b2ae5bfc4006bf2c: combine opening and ending themes into one enrichment batch before restoring their sections
- d60333a6194c0facebe3fc9a67772d1b0aaf47c0: advance the application version from trunk's 3.10.0 to 3.10.1
- cbb91b87623be9c79d700961f175c88371724053: avoid writing negative cache entries when Spotify authentication fails before a search occurs
- 6c2e7ed11865b8214ad8a7b5f2f65e8bd65b7444: add tracing spans to the Spotify backend cache and authentication operations
- c5e764904a4ce14074dc2eb8b8f2cc480cd906bb: retry one transient authentication failure and reuse the recovered client for the rest of the batch

### Notes

- Bottom PR in native GitHub stack #368, rebased onto `main` at `8b286b77f142f7dc28a4d454d5d5df71848f927f`.
- Fully cached batches do not request a Spotify token.
- Normal successful batches authenticate once; failed authentication is retried once without creating negative cache entries.
- Spotify and Redis work remains inside the existing `spawn_blocking` boundary.
- The rspotify blocking ureq backend applies a 10-second deadline to each token and API request.
- Bounded concurrency was not added because token reuse addresses the demonstrated duplicate round trips without adding synchronization complexity.

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo test utils::spotify::tests` — 6 passed
- [x] `cargo test commands::songs::command::tests` — 1 passed
- [x] `cargo test --all-targets` — 232 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `git diff --check main...annie-205-reuse-spotify-authentication-across-song-enrichment-batches`
- [ ] Manual Discord `/songs` QA with live Spotify credentials

## References

- Native GitHub stack: #368
- Upstack PR: #364

---

This PR description was written by GPT-5.