### PR TITLE
[ANNIE-208]/reuse pooled Redis connections for cache operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "html2md",
  "linkify",
  "ngrammatic",
+ "r2d2",
  "redis",
  "reqwest 0.13.4",
  "rspotify",
@@ -2336,6 +2337,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2798,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.10.1"
+version = "3.10.2"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ linkify = "0.11"
 ngrammatic = "0.7.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls-no-provider"] }
 redis = { version = "1.2.2", features = ["tls-rustls"] }
+r2d2 = "0.8.10"
 rspotify = { version = "0.16.1", default-features = false, features = [
   "client-ureq",
   "ureq-rustls-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.10.1"
+version = "3.10.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.95"

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -1,40 +1,113 @@
-use redis::{Commands, Connection, ErrorKind, RedisResult};
-use std::env;
+use r2d2::{ManageConnection, NopErrorHandler, Pool};
+use redis::{Commands, Connection, ConnectionLike, ErrorKind, RedisError, RedisResult};
+use std::{env, sync::LazyLock, time::Duration};
 use tracing::{info, instrument};
 
 use crate::utils::{statics::REDIS_URL, tls::install_rustls_crypto_provider};
 
-#[instrument(name = "redis.get_connection", skip_all)]
-fn get_redis_client() -> RedisResult<Connection> {
-    let redis_url = env::var(REDIS_URL).map_err(|e| {
-        (
+const CACHE_TTL_SECONDS: u64 = 18_000;
+const REDIS_TIMEOUT: Duration = Duration::from_secs(2);
+const REDIS_POOL_SIZE: u32 = 8;
+
+#[derive(Clone)]
+struct RedisConnectionManager {
+    client: redis::Client,
+}
+
+impl ManageConnection for RedisConnectionManager {
+    type Connection = Connection;
+    type Error = RedisError;
+
+    #[instrument(name = "redis.connect", skip_all)]
+    fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let connection = self.client.get_connection_with_timeout(REDIS_TIMEOUT)?;
+        connection.set_read_timeout(Some(REDIS_TIMEOUT))?;
+        connection.set_write_timeout(Some(REDIS_TIMEOUT))?;
+        Ok(connection)
+    }
+
+    #[instrument(name = "redis.validate_connection", skip_all)]
+    fn is_valid(&self, connection: &mut Self::Connection) -> Result<(), Self::Error> {
+        redis::cmd("PING").query(connection)
+    }
+
+    #[instrument(name = "redis.connection_broken", skip_all)]
+    fn has_broken(&self, connection: &mut Self::Connection) -> bool {
+        !connection.is_open()
+    }
+}
+
+struct RedisCache {
+    pool: Pool<RedisConnectionManager>,
+}
+
+impl RedisCache {
+    #[instrument(name = "redis.create_pool", skip(redis_url))]
+    fn new(redis_url: &str) -> RedisResult<Self> {
+        install_rustls_crypto_provider();
+
+        let manager = RedisConnectionManager {
+            client: redis::Client::open(redis_url)?,
+        };
+        let pool = Pool::builder()
+            .max_size(REDIS_POOL_SIZE)
+            .min_idle(Some(0))
+            .connection_timeout(REDIS_TIMEOUT)
+            .error_handler(Box::new(NopErrorHandler))
+            .build_unchecked(manager);
+
+        Ok(Self { pool })
+    }
+
+    #[instrument(name = "redis.check_cache", skip(self), fields(key = %key, key_len = key.len()))]
+    fn get(&self, key: &str) -> RedisResult<String> {
+        let mut connection = self.connection()?;
+        connection.get(key)
+    }
+
+    #[instrument(name = "redis.cache_response", skip(self, response), fields(key = %key, key_len = key.len(), response_len = response.len()))]
+    fn set(&self, key: &str, response: &str) -> RedisResult<()> {
+        let mut connection = self.connection()?;
+        connection.set_ex(key, response, CACHE_TTL_SECONDS)
+    }
+
+    #[instrument(name = "redis.get_pooled_connection", skip(self))]
+    fn connection(&self) -> RedisResult<r2d2::PooledConnection<RedisConnectionManager>> {
+        self.pool.get_timeout(REDIS_TIMEOUT).map_err(|error| {
+            RedisError::from((
+                ErrorKind::Io,
+                "Timed out waiting for a Redis connection",
+                error.to_string(),
+            ))
+        })
+    }
+}
+
+static REDIS_CACHE: LazyLock<Result<RedisCache, String>> = LazyLock::new(|| {
+    let redis_url = env::var(REDIS_URL)
+        .map_err(|error| format!("Missing REDIS_URL environment variable: {error}"))?;
+    RedisCache::new(&redis_url).map_err(|error| error.to_string())
+});
+
+#[instrument(name = "redis.get_cache", skip_all)]
+fn redis_cache() -> RedisResult<&'static RedisCache> {
+    REDIS_CACHE.as_ref().map_err(|error| {
+        RedisError::from((
             ErrorKind::InvalidClientConfig,
-            "Missing REDIS_URL environment variable",
-            e.to_string(),
-        )
-    })?;
-
-    install_rustls_crypto_provider();
-
-    let client = redis::Client::open(redis_url)?;
-    let connection = client.get_connection()?;
-    info!("Redis connection established");
-    Ok(connection)
+            "Failed to configure Redis cache",
+            error.clone(),
+        ))
+    })
 }
 
 #[instrument(name = "redis.check_cache", fields(key = %key, key_len = key.len()))]
 pub fn check_cache(key: &str) -> RedisResult<String> {
-    let mut redis_client_connection = get_redis_client()?;
-    let cached_value: String = redis_client_connection.get(key)?;
-    Ok(cached_value)
+    redis_cache()?.get(key)
 }
 
 #[instrument(name = "redis.cache_response", skip(response), fields(key = %key, key_len = key.len(), response_len = response.len()))]
 fn cache_response(key: &str, response: &str) -> RedisResult<()> {
-    let mut redis_client_connection = get_redis_client()?;
-    // Expires cached value in 5 hours
-    redis_client_connection.set_ex::<_, _, ()>(key, response, 18_000)?;
-    Ok(())
+    redis_cache()?.set(key, response)
 }
 
 #[instrument(name = "redis.try_cache_response", skip(response), fields(key = %key, key_len = key.len(), response_len = response.len()))]

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -1,5 +1,5 @@
 use r2d2::{ManageConnection, NopErrorHandler, Pool};
-use redis::{Commands, Connection, ConnectionLike, ErrorKind, RedisError, RedisResult};
+use redis::{Cmd, Connection, ConnectionLike, ErrorKind, FromRedisValue, RedisError, RedisResult};
 use std::{env, sync::LazyLock, time::Duration};
 use tracing::{info, instrument};
 
@@ -14,8 +14,24 @@ struct RedisConnectionManager {
     client: redis::Client,
 }
 
+struct PooledRedisConnection {
+    connection: Connection,
+    poisoned: bool,
+}
+
+impl PooledRedisConnection {
+    #[instrument(name = "redis.query", skip_all)]
+    fn query<T: FromRedisValue>(&mut self, command: &Cmd) -> RedisResult<T> {
+        let result = command.query(&mut self.connection);
+        if result.as_ref().is_err_and(|error| error.is_io_error()) {
+            self.poisoned = true;
+        }
+        result
+    }
+}
+
 impl ManageConnection for RedisConnectionManager {
-    type Connection = Connection;
+    type Connection = PooledRedisConnection;
     type Error = RedisError;
 
     #[instrument(name = "redis.connect", skip_all)]
@@ -23,17 +39,26 @@ impl ManageConnection for RedisConnectionManager {
         let connection = self.client.get_connection_with_timeout(REDIS_TIMEOUT)?;
         connection.set_read_timeout(Some(REDIS_TIMEOUT))?;
         connection.set_write_timeout(Some(REDIS_TIMEOUT))?;
-        Ok(connection)
+        Ok(PooledRedisConnection {
+            connection,
+            poisoned: false,
+        })
     }
 
     #[instrument(name = "redis.validate_connection", skip_all)]
     fn is_valid(&self, connection: &mut Self::Connection) -> Result<(), Self::Error> {
-        redis::cmd("PING").query(connection)
+        match connection.query::<String>(&redis::cmd("PING"))? {
+            response if response == "PONG" => Ok(()),
+            _ => Err(RedisError::from((
+                ErrorKind::Client,
+                "Redis connection validation returned an unexpected response",
+            ))),
+        }
     }
 
     #[instrument(name = "redis.connection_broken", skip_all)]
     fn has_broken(&self, connection: &mut Self::Connection) -> bool {
-        !connection.is_open()
+        connection.poisoned || !connection.connection.is_open()
     }
 }
 
@@ -62,13 +87,18 @@ impl RedisCache {
     #[instrument(name = "redis.check_cache", skip(self), fields(key = %key, key_len = key.len()))]
     fn get(&self, key: &str) -> RedisResult<String> {
         let mut connection = self.connection()?;
-        connection.get(key)
+        connection.query(redis::cmd("GET").arg(key))
     }
 
     #[instrument(name = "redis.cache_response", skip(self, response), fields(key = %key, key_len = key.len(), response_len = response.len()))]
     fn set(&self, key: &str, response: &str) -> RedisResult<()> {
         let mut connection = self.connection()?;
-        connection.set_ex(key, response, CACHE_TTL_SECONDS)
+        connection.query(
+            redis::cmd("SETEX")
+                .arg(key)
+                .arg(CACHE_TTL_SECONDS)
+                .arg(response),
+        )
     }
 
     #[instrument(name = "redis.get_pooled_connection", skip(self))]
@@ -140,7 +170,9 @@ mod tests {
     struct MockRedis {
         address: String,
         accepted_connections: Arc<AtomicUsize>,
+        values: Arc<Mutex<HashMap<String, String>>>,
         ttl: Arc<Mutex<Option<u64>>>,
+        delay_next_get: Arc<AtomicBool>,
         stopping: Arc<AtomicBool>,
         server: Option<thread::JoinHandle<()>>,
     }
@@ -157,20 +189,26 @@ mod tests {
                 .to_string();
             let accepted_connections = Arc::new(AtomicUsize::new(0));
             let ttl = Arc::new(Mutex::new(None));
+            let delay_next_get = Arc::new(AtomicBool::new(false));
             let stopping = Arc::new(AtomicBool::new(false));
             let values = Arc::new(Mutex::new(HashMap::new()));
 
             let server_connections = Arc::clone(&accepted_connections);
             let server_ttl = Arc::clone(&ttl);
+            let server_delay_next_get = Arc::clone(&delay_next_get);
             let server_stopping = Arc::clone(&stopping);
+            let server_values = Arc::clone(&values);
             let server = thread::spawn(move || {
                 while !server_stopping.load(Ordering::Relaxed) {
                     match listener.accept() {
                         Ok((stream, _)) => {
                             server_connections.fetch_add(1, Ordering::Relaxed);
-                            let values = Arc::clone(&values);
+                            let values = Arc::clone(&server_values);
                             let ttl = Arc::clone(&server_ttl);
-                            thread::spawn(move || serve_connection(stream, &values, &ttl));
+                            let delay_next_get = Arc::clone(&server_delay_next_get);
+                            thread::spawn(move || {
+                                serve_connection(stream, &values, &ttl, &delay_next_get);
+                            });
                         }
                         Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                             thread::sleep(Duration::from_millis(5));
@@ -183,7 +221,9 @@ mod tests {
             Self {
                 address,
                 accepted_connections,
+                values,
                 ttl,
+                delay_next_get,
                 stopping,
                 server: Some(server),
             }
@@ -191,6 +231,17 @@ mod tests {
 
         fn url(&self) -> String {
             format!("redis://{}/", self.address)
+        }
+
+        fn insert(&self, key: &str, value: &str) {
+            self.values
+                .lock()
+                .expect("lock mock values")
+                .insert(key.to_string(), value.to_string());
+        }
+
+        fn delay_next_get(&self) {
+            self.delay_next_get.store(true, Ordering::Relaxed);
         }
     }
 
@@ -208,6 +259,7 @@ mod tests {
         stream: TcpStream,
         values: &Mutex<HashMap<String, String>>,
         ttl: &Mutex<Option<u64>>,
+        delay_next_get: &AtomicBool,
     ) {
         let mut writer = stream.try_clone().expect("clone mock Redis stream");
         let mut reader = BufReader::new(stream);
@@ -216,12 +268,17 @@ mod tests {
             match command[0].to_ascii_uppercase().as_str() {
                 "PING" => writer.write_all(b"+PONG\r\n").expect("reply to PING"),
                 "CLIENT" => writer.write_all(b"+OK\r\n").expect("reply to CLIENT"),
-                "GET" => match values.lock().expect("lock mock values").get(&command[1]) {
-                    Some(value) => writer
-                        .write_all(format!("${}\r\n{value}\r\n", value.len()).as_bytes())
-                        .expect("reply to GET"),
-                    None => writer.write_all(b"$-1\r\n").expect("reply to GET miss"),
-                },
+                "GET" => {
+                    if delay_next_get.swap(false, Ordering::Relaxed) {
+                        thread::sleep(Duration::from_millis(2_100));
+                    }
+                    match values.lock().expect("lock mock values").get(&command[1]) {
+                        Some(value) => writer
+                            .write_all(format!("${}\r\n{value}\r\n", value.len()).as_bytes())
+                            .expect("reply to GET"),
+                        None => writer.write_all(b"$-1\r\n").expect("reply to GET miss"),
+                    }
+                }
                 "SETEX" => {
                     values
                         .lock()
@@ -296,5 +353,19 @@ mod tests {
         assert!(cache.get("key").is_err());
         assert!(started.elapsed() < Duration::from_secs(3));
         server.join().expect("stop stalled Redis");
+    }
+
+    #[test]
+    fn timed_out_connection_is_not_reused() {
+        let redis = MockRedis::start();
+        redis.insert("slow", "stale");
+        redis.insert("fresh", "fresh");
+        redis.delay_next_get();
+        let cache = RedisCache::new(&redis.url()).expect("create Redis cache");
+
+        assert!(cache.get("slow").is_err());
+        assert_eq!(cache.get("fresh").expect("read fresh value"), "fresh");
+        assert_eq!(redis.accepted_connections.load(Ordering::Relaxed), 2);
+        thread::sleep(Duration::from_millis(150));
     }
 }

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -121,3 +121,180 @@ pub fn try_to_cache_response(key: &str, response: &str) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        collections::HashMap,
+        io::{BufRead, BufReader, Read, Write},
+        net::{TcpListener, TcpStream},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        thread,
+        time::Instant,
+    };
+
+    struct MockRedis {
+        address: String,
+        accepted_connections: Arc<AtomicUsize>,
+        ttl: Arc<Mutex<Option<u64>>>,
+        stopping: Arc<AtomicBool>,
+        server: Option<thread::JoinHandle<()>>,
+    }
+
+    impl MockRedis {
+        fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock Redis");
+            listener
+                .set_nonblocking(true)
+                .expect("make mock Redis nonblocking");
+            let address = listener
+                .local_addr()
+                .expect("read mock Redis address")
+                .to_string();
+            let accepted_connections = Arc::new(AtomicUsize::new(0));
+            let ttl = Arc::new(Mutex::new(None));
+            let stopping = Arc::new(AtomicBool::new(false));
+            let values = Arc::new(Mutex::new(HashMap::new()));
+
+            let server_connections = Arc::clone(&accepted_connections);
+            let server_ttl = Arc::clone(&ttl);
+            let server_stopping = Arc::clone(&stopping);
+            let server = thread::spawn(move || {
+                while !server_stopping.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            server_connections.fetch_add(1, Ordering::Relaxed);
+                            let values = Arc::clone(&values);
+                            let ttl = Arc::clone(&server_ttl);
+                            thread::spawn(move || serve_connection(stream, &values, &ttl));
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(error) => panic!("mock Redis accept failed: {error}"),
+                    }
+                }
+            });
+
+            Self {
+                address,
+                accepted_connections,
+                ttl,
+                stopping,
+                server: Some(server),
+            }
+        }
+
+        fn url(&self) -> String {
+            format!("redis://{}/", self.address)
+        }
+    }
+
+    impl Drop for MockRedis {
+        fn drop(&mut self) {
+            self.stopping.store(true, Ordering::Relaxed);
+            let _ = TcpStream::connect(&self.address);
+            if let Some(server) = self.server.take() {
+                server.join().expect("stop mock Redis");
+            }
+        }
+    }
+
+    fn serve_connection(
+        stream: TcpStream,
+        values: &Mutex<HashMap<String, String>>,
+        ttl: &Mutex<Option<u64>>,
+    ) {
+        let mut writer = stream.try_clone().expect("clone mock Redis stream");
+        let mut reader = BufReader::new(stream);
+
+        while let Some(command) = read_command(&mut reader) {
+            match command[0].to_ascii_uppercase().as_str() {
+                "PING" => writer.write_all(b"+PONG\r\n").expect("reply to PING"),
+                "CLIENT" => writer.write_all(b"+OK\r\n").expect("reply to CLIENT"),
+                "GET" => match values.lock().expect("lock mock values").get(&command[1]) {
+                    Some(value) => writer
+                        .write_all(format!("${}\r\n{value}\r\n", value.len()).as_bytes())
+                        .expect("reply to GET"),
+                    None => writer.write_all(b"$-1\r\n").expect("reply to GET miss"),
+                },
+                "SETEX" => {
+                    values
+                        .lock()
+                        .expect("lock mock values")
+                        .insert(command[1].clone(), command[3].clone());
+                    *ttl.lock().expect("lock mock TTL") =
+                        Some(command[2].parse().expect("parse SETEX TTL"));
+                    writer.write_all(b"+OK\r\n").expect("reply to SETEX");
+                }
+                command => panic!("unexpected Redis command: {command}"),
+            }
+        }
+    }
+
+    fn read_command(reader: &mut BufReader<TcpStream>) -> Option<Vec<String>> {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None;
+        }
+        let argument_count: usize = line.strip_prefix('*')?.trim().parse().ok()?;
+        let mut command = Vec::with_capacity(argument_count);
+
+        for _ in 0..argument_count {
+            line.clear();
+            reader.read_line(&mut line).ok()?;
+            let length: usize = line.strip_prefix('$')?.trim().parse().ok()?;
+            let mut argument = vec![0; length];
+            reader.read_exact(&mut argument).ok()?;
+            let mut crlf = [0; 2];
+            reader.read_exact(&mut crlf).ok()?;
+            command.push(String::from_utf8(argument).ok()?);
+        }
+
+        Some(command)
+    }
+
+    #[test]
+    fn cache_hit_miss_write_ttl_and_connection_reuse() {
+        let redis = MockRedis::start();
+        let cache = RedisCache::new(&redis.url()).expect("create Redis cache");
+
+        assert!(cache.get("missing").is_err());
+        cache.set("key", "value").expect("write cached value");
+        assert_eq!(cache.get("key").expect("read cached value"), "value");
+        assert_eq!(*redis.ttl.lock().expect("lock mock TTL"), Some(18_000));
+        assert_eq!(redis.accepted_connections.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn unavailable_redis_is_bounded() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve unavailable port");
+        let url = format!("redis://{}/", listener.local_addr().expect("read address"));
+        drop(listener);
+        let cache = RedisCache::new(&url).expect("create Redis cache");
+
+        let started = Instant::now();
+        assert!(cache.get("key").is_err());
+        assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn command_wait_is_bounded() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stalled Redis");
+        let url = format!("redis://{}/", listener.local_addr().expect("read address"));
+        let server = thread::spawn(move || {
+            let (_stream, _) = listener.accept().expect("accept stalled connection");
+            thread::sleep(Duration::from_secs(3));
+        });
+        let cache = RedisCache::new(&url).expect("create Redis cache");
+
+        let started = Instant::now();
+        assert!(cache.get("key").is_err());
+        assert!(started.elapsed() < Duration::from_secs(3));
+        server.join().expect("stop stalled Redis");
+    }
+}

--- a/src/utils/redis.rs
+++ b/src/utils/redis.rs
@@ -294,7 +294,7 @@ mod tests {
     }
 
     fn read_command(reader: &mut BufReader<TcpStream>) -> Option<Vec<String>> {
-        let mut line = String::new();
+        let mut line = String::default();
         if reader.read_line(&mut line).ok()? == 0 {
             return None;
         }


### PR DESCRIPTION
## Summary

Reuse established Redis connections for cache GET/SET operations through a lazy synchronous connection pool, with bounded pool acquisition, connection, read, and write waits. Existing cache keys, five-hour TTLs, and graceful cache failure behavior remain unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- 79cb4e43e19899ad6fd97e8b3322265381683fd4: add the r2d2 connection pool dependency and lockfile entries
- 0d143f8b86f57784b56055ee09cc1fa3c2fb9daa: replace per-operation Redis connections with a shared lazy pool and two-second wait bounds
- 72e2868c27af9bd855859a55e5a51d75dc302f5f: cover cache hit, miss, write, TTL, connection reuse, unavailable Redis, and stalled commands
- aba171e2a16d1fa4e829d806808986d8593e77ef: advance the cumulative stack version from 3.10.1 to 3.10.2
- 1842071f182b71a1c28797eaf161ce741a94807a: discard pooled connections after I/O errors and verify delayed replies cannot desynchronize later requests
- ecb3f8f47eb5489c4c6dd59e88e9eae902d1ac9a: replace an empty `String::new()` call flagged by DeepSource

### Notes

- Middle PR in native GitHub stack #368, targeting [PR #363](https://github.com/annie-mei/annie-mei/pull/363); cumulative package version 3.10.2.
- Keeps the existing synchronous Redis API and current `spawn_blocking` call boundaries.
- Uses a demand-created pool of up to eight connections.
- Removes the per-operation `Redis connection established` success log.
- Applies a two-second bound to pool checkout, connection establishment, socket reads, and socket writes.

### High-risk resources

- Redis-backed AniList and Spotify caches. Redis failures remain non-fatal and continue to fall back to upstream fetches.

## Validation
- [x] `cargo fmt --all -- --check`
- [x] `cargo test utils::redis::tests` — 4 passed
- [x] `cargo test --all-targets` — 232 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `git diff --check annie-205-reuse-spotify-authentication-across-song-enrichment-batches...annie-208-reuse-pooled-redis-connections-for-cache-operations`

## References

- Native GitHub stack: #368
- Downstack PR: #363
- Upstack PR: #365

---

This PR description was written by GPT-5.