### PR TITLE
[ANNIE-210]/upgrade Rust toolchain to 1.97.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "annie-mei"
 version = "3.10.8"
 edition = "2024"
 license = "GPL-3.0-or-later"
-rust-version = "1.95"
+rust-version = "1.97.1"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95"
+channel = "1.97.1"
 components = ["rust-analyzer"]


### PR DESCRIPTION
## Summary

Upgrade Annie Mei from Rust 1.95 to the latest stable Rust 1.97.1.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes
- d22220d8f7ec08459273978916d384797c643212: pin Rust 1.97.1 and update the package MSRV

### Notes

The CI workflows and orb setup already read the toolchain version from `rust-toolchain.toml`, so no duplicated CI version pins required changes.

## Validation
- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-features` (232 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

## References

- [ANNIE-210](https://linear.app/annie-mei/issue/ANNIE-210/upgrade-rust-toolchain-to-1971)
- [Rust 1.97.1 release](https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/)

---

This PR description was written by GPT-5.4.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/annie-mei/pull/366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
