### PR TITLE
[ANNIE-198]/add Discord command plumbing integration tests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,12 +43,18 @@ reviews:
         For slash commands, verify the newer architecture is followed where practical:
         - Prefer a transport-agnostic core handler plus a thin Serenity adapter in `run()`.
         - For substantial commands, prefer `src/commands/<name>/command.rs`.
-        - Check that command behavior matches the registration and dispatch structure in `src/main.rs`.
+        - Check that command registration and dispatch are both represented in the `BotCommand`
+          catalog in `src/commands/mod.rs`.
         - Ensure user-facing failures return clear Discord responses.
+
+    - path: "src/commands/mod.rs"
+      instructions: |
+        Review the `BotCommand` catalog as the shared source of truth for slash-command
+        registration and dispatch. Ensure names, definitions, and runtime adapters stay aligned.
 
     - path: "src/main.rs"
       instructions: |
-        Review command registration and dispatch carefully.
+        Review Discord event forwarding into the command catalog carefully.
         Check startup and shutdown flow, Sentry/tracing setup, and any privacy-sensitive logging.
 
     - path: "src/server.rs"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,7 @@ This PR description was written by MODEL_NAME.
 3. Implement `register()` for slash command definition
 4. Implement `run()` for command execution
 5. Export in `src/commands/mod.rs`
-6. Register in `main.rs` `ready` event
-7. Add match arm in `main.rs` `interaction_create`
+6. Add a `BotCommand` variant and its name, definition, and `run()` mappings in `src/commands/mod.rs`; this catalog drives both registration and dispatch
 
 Notes:
 
@@ -152,13 +151,13 @@ Annie Mei-specific settings tables in the `annie_mei` schema, such as
 1. **Always defer long operations** - Discord has a 3-second response window
 2. **Keep blocking I/O on explicit boundaries** - use `spawn_blocking` for known sync subsystems (Redis, Spotify sync calls). Database operations are async via SQLx and don't need spawn_blocking
 3. **SQLx pool connects eagerly at startup** - The bot will fail fast if DB is unavailable on boot
-4. **Global command registration is slow to propagate** - `main.rs` re-registers global slash commands on startup
+4. **Global command registration is slow to propagate** - the `BotCommand` catalog is re-registered globally from `main.rs` on startup
 5. **Check environment variables** - Bot requires multiple env vars to run
 6. **Don't assume all commands follow the same file shape** - some are folder-based, others are single files
 
 ## Review Guidelines
 
-- Confirm command changes follow the existing registration and dispatch structure in `src/main.rs`
+- Confirm command registration and dispatch are both represented in the `BotCommand` catalog in `src/commands/mod.rs`
 - Prefer the core-handler plus thin-Serenity-adapter pattern for substantial command work
 - Verify blocking I/O work (Redis, Spotify) uses explicit `tokio::task::spawn_blocking` boundaries
 - Database operations use native SQLx async (no spawn_blocking needed)
@@ -170,7 +169,8 @@ Annie Mei-specific settings tables in the `annie_mei` schema, such as
 
 ## Key Paths
 
-- `src/main.rs` - bot startup, command registration/dispatch, shutdown, Sentry setup
+- `src/main.rs` - bot startup, Discord event handling, shutdown, Sentry setup
+- `src/commands/mod.rs` - shared slash-command registration and dispatch catalog
 - `src/commands/<name>/command.rs` or `src/commands/<name>.rs` - slash commands
 - `src/commands/response.rs` and `src/commands/traits.rs` - testable command patterns
 - `src/models/transformers.rs` - shared embed construction

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei"
-version = "3.10.12"
+version = "3.10.13"
 dependencies = [
  "base64 0.23.1",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "getrandom 0.4.3",
  "hmac",
  "html2md",
+ "httpmock",
  "linkify",
  "ngrammatic",
  "r2d2",
@@ -286,6 +287,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
+dependencies = [
+ "async-lock",
+ "event-listener",
 ]
 
 [[package]]
@@ -435,6 +467,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytestring"
@@ -920,6 +955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1262,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.4.0",
+ "httpdate",
+ "mime",
+ "sha1 0.10.6",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.4.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1406,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-timer",
+ "futures-util",
+ "headers",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "path-tree",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1462,7 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2113,6 +2223,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "path-tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -2993,6 +3112,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,6 +3260,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
@@ -3418,6 +3553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringmetrics"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,6 +3663,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3929,6 +4079,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei"
-version = "3.10.12"
+version = "3.10.13"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,6 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = "2.5"
 uuid = { version = "1", features = ["v4"] }
 wana_kana = "5.0.0"
+
+[dev-dependencies]
+httpmock = "0.8.3"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Current settings shown in the panel:
 
 ## Documentation
 
+- [Testing Discord command plumbing](docs/testing.md) — deterministic protocol tests and the opt-in live Discord smoke checklist
 - [OAuth data contract](docs/oauth-contract.md) — shared schema and payload contract with the [`auth`](https://github.com/annie-mei/auth) repo
 - [Database schema ownership](docs/database-schemas.md) — shared Postgres schemas, migration isolation, grants, and deployment order
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,72 @@
+# Testing Discord command plumbing
+
+Annie Mei uses two complementary test layers: deterministic protocol tests
+that run without Discord credentials, and an opt-in live smoke test in a
+dedicated Discord guild.
+
+## Automated protocol tests
+
+Run the Discord plumbing suite with:
+
+```sh
+cargo test --test discord_plumbing
+```
+
+The suite deserializes synthetic Discord interaction payloads into Serenity
+models, resolves each command through Annie Mei's command catalog, and points
+Serenity's real HTTP client at a local mock server. It currently verifies:
+
+- `/ping` sends the expected immediate interaction callback route and JSON;
+- invalid `/anime` input sends a deferred callback followed by an edit to the
+  original interaction response; and
+- command definitions have unique names that match the runtime router.
+
+Fixtures under `tests/fixtures/interactions/` contain only synthetic IDs and
+tokens. These tests must remain deterministic and must not require Discord,
+AniList, MAL, Spotify, LLM, database, or Redis credentials.
+
+The complete repository suite remains:
+
+```sh
+cargo test --all-features
+```
+
+## Live Discord smoke test
+
+Use this only when a change needs confirmation across Discord's real Gateway,
+command registration, permissions, and client rendering.
+
+### Prerequisites
+
+1. Create a Discord application used only for testing and add its bot to a
+   private test guild with the `bot` and `applications.commands` scopes.
+2. Use test-specific infrastructure and credentials. Never point the smoke
+   run at the production bot token, guild, database, or Redis instance.
+3. Configure the environment variables required by the bot, using the test
+   application's token as `DISCORD_TOKEN`.
+
+### Checklist
+
+1. Start Annie Mei with `cargo run` and wait for the ready log confirming that
+   commands were registered.
+2. In the Discord client, invoke `/ping`.
+   - Confirm Discord shows a single immediate response mentioning the caller.
+   - Confirm the bot logs receipt of the command without exposing a raw user ID
+     or interaction token.
+3. Invoke `/anime search:One Piece`.
+   - Confirm Discord shows the deferred/loading state before the final embed.
+   - Confirm the final response replaces the loading state rather than posting
+     an unrelated second message.
+4. Invoke `/anime` with a search term longer than 255 characters.
+   - Confirm the deferred response is replaced with the validation message and
+     no AniList result is shown.
+5. Invoke `/settings` and use one displayed control.
+   - Confirm the component interaction updates or acknowledges the original
+     response without Discord reporting that the interaction failed.
+6. Stop the bot and retain only redacted logs needed to diagnose failures.
+
+The command invocations are intentionally manual. Discord does not expose a
+supported API for invoking a slash command as a user, bot accounts cannot do
+so on a user's behalf, and automating a normal user account is prohibited
+self-botting. An agent can prepare the environment, start the bot, and inspect
+the results, but a human must perform the Discord-client actions.

--- a/src/commands/anime/command.rs
+++ b/src/commands/anime/command.rs
@@ -24,6 +24,7 @@ use serenity::{
     all::{CommandInteraction, CreateCommandOption, EditInteractionResponse},
     builder::CreateCommand,
     client::Context,
+    http::Http,
     model::application::CommandOptionType,
 };
 
@@ -75,28 +76,11 @@ pub fn handle_anime(
 
 #[instrument(name = "command.anime.run", skip(ctx, interaction))]
 pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
-    let _ = interaction.defer(&ctx.http).await;
-
     let user = &interaction.user;
 
-    // Validate the required "search" option up-front.
-    let Some(serenity::all::CommandDataOptionValue::String(search_term)) =
-        interaction.data.options.first().map(|opt| &opt.value)
-    else {
-        let builder = EditInteractionResponse::new()
-            .content("Tell me which anime to look up with `search:<name or AniList ID>`.");
-        let _ = interaction.edit_response(&ctx.http, builder).await;
+    let Some(search_term) = defer_and_validate_search(&ctx.http, interaction).await else {
         return;
     };
-    let search_term = search_term.clone();
-
-    if let Err(err) = validate_search_term(&search_term) {
-        let builder = EditInteractionResponse::new().content(format!(
-            "I couldn't use that search: {err}. Try an anime title or AniList ID."
-        ));
-        let _ = interaction.edit_response(&ctx.http, builder).await;
-        return;
-    }
 
     configure_sentry_scope("Anime", user.id.get(), Some(json!(search_term.clone())));
 
@@ -166,6 +150,40 @@ pub async fn run(ctx: &Context, interaction: &mut CommandInteraction) {
             interaction.edit_response(&ctx.http, builder).await
         }
     };
+}
+
+/// Defer the interaction and validate the required search option.
+///
+/// This is the protocol-testable prefix of `/anime`; upstream lookups and
+/// cache-dependent behavior remain in [`run`].
+#[instrument(
+    name = "command.anime.defer_and_validate_search",
+    skip(http, interaction)
+)]
+pub async fn defer_and_validate_search(
+    http: &Http,
+    interaction: &CommandInteraction,
+) -> Option<String> {
+    let _ = interaction.defer(http).await;
+
+    let Some(serenity::all::CommandDataOptionValue::String(search_term)) =
+        interaction.data.options.first().map(|opt| &opt.value)
+    else {
+        let builder = EditInteractionResponse::new()
+            .content("Tell me which anime to look up with `search:<name or AniList ID>`.");
+        let _ = interaction.edit_response(http, builder).await;
+        return None;
+    };
+
+    if let Err(err) = validate_search_term(search_term) {
+        let builder = EditInteractionResponse::new().content(format!(
+            "I couldn't use that search: {err}. Try an anime title or AniList ID."
+        ));
+        let _ = interaction.edit_response(http, builder).await;
+        return None;
+    }
+
+    Some(search_term.clone())
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,3 +14,132 @@ pub mod studio;
 pub mod traits;
 pub mod unregister;
 pub mod whoami;
+
+use serenity::{builder::CreateCommand, client::Context, model::application::CommandInteraction};
+
+/// A slash command known to both Discord registration and runtime dispatch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BotCommand {
+    Ping,
+    Help,
+    Songs,
+    Manga,
+    Anime,
+    Search,
+    Recommend,
+    Character,
+    Studio,
+    Register,
+    Unregister,
+    Whoami,
+    Settings,
+}
+
+impl BotCommand {
+    pub const ALL: [Self; 13] = [
+        Self::Ping,
+        Self::Help,
+        Self::Songs,
+        Self::Manga,
+        Self::Anime,
+        Self::Search,
+        Self::Recommend,
+        Self::Character,
+        Self::Studio,
+        Self::Register,
+        Self::Unregister,
+        Self::Whoami,
+        Self::Settings,
+    ];
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Ping => "ping",
+            Self::Help => "help",
+            Self::Songs => "songs",
+            Self::Manga => "manga",
+            Self::Anime => "anime",
+            Self::Search => "search",
+            Self::Recommend => "recommend",
+            Self::Character => "character",
+            Self::Studio => "studio",
+            Self::Register => "register",
+            Self::Unregister => "unregister",
+            Self::Whoami => "whoami",
+            Self::Settings => "settings",
+        }
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|command| command.name() == name)
+    }
+
+    pub fn definition(self) -> CreateCommand {
+        match self {
+            Self::Ping => ping::register(),
+            Self::Help => help::register(),
+            Self::Songs => songs::command::register(),
+            Self::Manga => manga::command::register(),
+            Self::Anime => anime::command::register(),
+            Self::Search => search::command::register(),
+            Self::Recommend => recommend::command::register(),
+            Self::Character => character::command::register(),
+            Self::Studio => studio::command::register(),
+            Self::Register => register::command::register(),
+            Self::Unregister => unregister::register(),
+            Self::Whoami => whoami::register(),
+            Self::Settings => settings::register(),
+        }
+    }
+
+    pub async fn run(self, ctx: &Context, interaction: &mut CommandInteraction) {
+        match self {
+            Self::Ping => ping::run(ctx, interaction).await,
+            Self::Help => help::run(ctx, interaction).await,
+            Self::Songs => songs::command::run(ctx, interaction).await,
+            Self::Manga => manga::command::run(ctx, interaction).await,
+            Self::Anime => anime::command::run(ctx, interaction).await,
+            Self::Search => search::command::run(ctx, interaction).await,
+            Self::Recommend => recommend::command::run(ctx, interaction).await,
+            Self::Character => character::command::run(ctx, interaction).await,
+            Self::Studio => studio::command::run(ctx, interaction).await,
+            Self::Register => register::command::run(ctx, interaction).await,
+            Self::Unregister => unregister::run(ctx, interaction).await,
+            Self::Whoami => whoami::run(ctx, interaction).await,
+            Self::Settings => settings::run(ctx, interaction).await,
+        }
+    }
+}
+
+pub fn command_definitions() -> Vec<CreateCommand> {
+    BotCommand::ALL
+        .into_iter()
+        .map(BotCommand::definition)
+        .collect()
+}
+
+#[cfg(test)]
+mod catalog_tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn command_names_are_unique_and_match_definitions() {
+        let mut names = HashSet::new();
+
+        for command in BotCommand::ALL {
+            assert!(names.insert(command.name()), "duplicate command name");
+
+            let definition = serde_json::to_value(command.definition())
+                .expect("command definition should serialize");
+            assert_eq!(definition["name"], command.name());
+            assert_eq!(BotCommand::from_name(command.name()), Some(command));
+        }
+    }
+
+    #[test]
+    fn unknown_command_is_not_routable() {
+        assert_eq!(BotCommand::from_name("does-not-exist"), None);
+    }
+}

--- a/src/commands/ping.rs
+++ b/src/commands/ping.rs
@@ -5,6 +5,7 @@ use super::response::CommandResponse;
 use serenity::{
     all::{CommandInteraction, CreateInteractionResponse, CreateInteractionResponseMessage},
     builder::CreateCommand,
+    http::Http,
     prelude::*,
 };
 
@@ -27,9 +28,16 @@ pub fn handle_ping(user_mention: &str) -> CommandResponse {
 // ── Serenity adapter (thin wrapper) ─────────────────────────────────────
 
 pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
-    let user = &interaction.user;
+    configure_sentry_scope("Ping", interaction.user.id.get(), None);
+    let _ = run_with_http(&ctx.http, interaction).await;
+}
 
-    configure_sentry_scope("Ping", user.id.get(), None);
+/// Execute the Discord transport adapter with an explicit HTTP client.
+///
+/// Keeping this boundary independent of [`Context`] allows protocol tests to
+/// exercise Serenity's real request serialization against a local server.
+pub async fn run_with_http(http: &Http, interaction: &CommandInteraction) -> serenity::Result<()> {
+    let user = &interaction.user;
 
     let reply = handle_ping(&user.mention().to_string());
 
@@ -42,7 +50,7 @@ pub async fn run(ctx: &Context, interaction: &CommandInteraction) {
     let response_message = CreateInteractionResponseMessage::new().content(text);
     let response = CreateInteractionResponse::Message(response_message);
 
-    let _ = interaction.create_response(&ctx.http, response).await;
+    interaction.create_response(http, response).await
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+#![recursion_limit = "256"]
+
+pub mod commands;
+pub mod models;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,5 @@
 #![recursion_limit = "256"]
 
-mod commands;
-mod models;
-mod utils;
-
 use std::env;
 use std::sync::Arc;
 
@@ -17,22 +13,24 @@ use serenity::{
         CreateEmbed, CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage,
     },
     async_trait,
-    builder::CreateCommand,
     client::{Client, Context, EventHandler},
     gateway::ActivityData,
     model::{application::Command, application::Interaction, gateway::Ready},
     prelude::*,
 };
 
-use utils::{
-    channel::is_nsfw_channel,
-    database::{DatabasePoolKey, create_pool, run_migrations},
-    llm::{GeminiClient, GeminiClientKey, configured_model_name},
-    oauth::{OAuthContextConfigKey, load_context_config},
-    posthog::{CommandTelemetryContext, PostHogClient},
-    privacy::{hash_discord_id, hash_user_id, redact_url_credentials},
-    statics::{DISCORD_TOKEN, ENV, SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE},
-    tls::install_rustls_crypto_provider,
+use annie_mei::{
+    commands::{self, BotCommand},
+    utils::{
+        channel::is_nsfw_channel,
+        database::{DatabasePoolKey, create_pool, run_migrations},
+        llm::{GeminiClient, GeminiClientKey, configured_model_name},
+        oauth::{OAuthContextConfigKey, load_context_config},
+        posthog::{CommandTelemetryContext, PostHogClient},
+        privacy::{hash_discord_id, hash_user_id, redact_url_credentials},
+        statics::{DISCORD_TOKEN, ENV, SENTRY_DSN, SENTRY_TRACES_SAMPLE_RATE},
+        tls::install_rustls_crypto_provider,
+    },
 };
 
 /// Annie Mei Discord Bot
@@ -79,32 +77,19 @@ impl EventHandler for Handler {
                     info!("Received command interaction");
                     self.capture_command_hit(&ctx, &command);
 
-                    match command.data.name.as_str() {
-                        "ping" => commands::ping::run(&ctx, &command).await,
-                        "help" => commands::help::run(&ctx, &command).await,
-                        "songs" => commands::songs::command::run(&ctx, &mut command).await,
-                        "manga" => commands::manga::command::run(&ctx, &mut command).await,
-                        "anime" => commands::anime::command::run(&ctx, &mut command).await,
-                        "search" => commands::search::command::run(&ctx, &mut command).await,
-                        "recommend" => commands::recommend::command::run(&ctx, &mut command).await,
-                        "character" => commands::character::command::run(&ctx, &mut command).await,
-                        "studio" => commands::studio::command::run(&ctx, &mut command).await,
-                        "register" => commands::register::command::run(&ctx, &mut command).await,
-                        "unregister" => commands::unregister::run(&ctx, &mut command).await,
-                        "whoami" => commands::whoami::run(&ctx, &mut command).await,
-                        "settings" => commands::settings::run(&ctx, &mut command).await,
-                        _ => {
-                            let embed = CreateEmbed::new()
-                                .title("Error")
-                                .description("Not implemented");
-                            let builder = CreateMessage::new().embed(embed);
-                            let msg = command.channel_id.send_message(&ctx.http, builder).await;
-                            if let Err(why) = msg {
-                                println!("Error sending message: {why:?}");
-                                info!("Cannot respond to slash command: {why}");
-                            }
+                    if let Some(bot_command) = BotCommand::from_name(&command.data.name) {
+                        bot_command.run(&ctx, &mut command).await;
+                    } else {
+                        let embed = CreateEmbed::new()
+                            .title("Error")
+                            .description("Not implemented");
+                        let builder = CreateMessage::new().embed(embed);
+                        let msg = command.channel_id.send_message(&ctx.http, builder).await;
+                        if let Err(why) = msg {
+                            println!("Error sending message: {why:?}");
+                            info!("Cannot respond to slash command: {why}");
                         }
-                    };
+                    }
                 }
                 .instrument(command_span)
                 .await;
@@ -145,21 +130,7 @@ impl EventHandler for Handler {
 
     #[instrument(name = "discord.ready", skip_all)]
     async fn ready(&self, ctx: Context, ready: Ready) {
-        let commands: Vec<CreateCommand> = vec![
-            commands::ping::register(),
-            commands::help::register(),
-            commands::songs::command::register(),
-            commands::manga::command::register(),
-            commands::anime::command::register(),
-            commands::search::command::register(),
-            commands::recommend::command::register(),
-            commands::character::command::register(),
-            commands::studio::command::register(),
-            commands::register::command::register(),
-            commands::unregister::register(),
-            commands::whoami::register(),
-            commands::settings::register(),
-        ];
+        let commands = commands::command_definitions();
 
         let guild_commands = Command::set_global_commands(&ctx.http, commands).await;
 

--- a/tests/discord_plumbing.rs
+++ b/tests/discord_plumbing.rs
@@ -1,0 +1,46 @@
+use annie_mei::commands::{BotCommand, ping};
+use httpmock::{Method::POST, MockServer};
+use serde_json::json;
+use serenity::{http::HttpBuilder, model::application::Interaction};
+
+#[tokio::test]
+async fn ping_fixture_routes_and_sends_interaction_callback() {
+    let interaction: Interaction =
+        serde_json::from_str(include_str!("fixtures/interactions/ping.json"))
+            .expect("fixture should deserialize as a Serenity interaction");
+    let command = interaction
+        .into_command()
+        .expect("fixture should contain a command interaction");
+
+    let routed_command = BotCommand::from_name(&command.data.name);
+    assert_eq!(routed_command, Some(BotCommand::Ping));
+
+    let server = MockServer::start_async().await;
+    let callback = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(
+                    "/api/v10/interactions/100000000000000001/\
+                     synthetic-interaction-token/callback",
+                )
+                .json_body(json!({
+                    "type": 4,
+                    "data": {
+                        "content": "Hi <@100000000000000005>! I'm Annie Mei, awake and ready to help with anime, manga, recommendations, and theme songs.",
+                        "attachments": []
+                    }
+                }));
+            then.status(204);
+        })
+        .await;
+    let http = HttpBuilder::new("synthetic-bot-token")
+        .proxy(server.base_url())
+        .ratelimiter_disabled(true)
+        .build();
+
+    ping::run_with_http(&http, &command)
+        .await
+        .expect("ping adapter should send the callback");
+
+    callback.assert_async().await;
+}

--- a/tests/discord_plumbing.rs
+++ b/tests/discord_plumbing.rs
@@ -1,7 +1,10 @@
-use annie_mei::commands::{BotCommand, ping};
-use httpmock::{Method::POST, MockServer};
+use annie_mei::commands::{BotCommand, anime, ping};
+use httpmock::{Method::PATCH, Method::POST, MockServer};
 use serde_json::json;
-use serenity::{http::HttpBuilder, model::application::Interaction};
+use serenity::{
+    http::HttpBuilder,
+    model::{application::Interaction, id::ApplicationId},
+};
 
 #[tokio::test]
 async fn ping_fixture_routes_and_sends_interaction_callback() {
@@ -43,4 +46,57 @@ async fn ping_fixture_routes_and_sends_interaction_callback() {
         .expect("ping adapter should send the callback");
 
     callback.assert_async().await;
+}
+
+#[tokio::test]
+async fn invalid_anime_fixture_defers_then_edits_original_response() {
+    let interaction: Interaction =
+        serde_json::from_str(include_str!("fixtures/interactions/anime-invalid.json"))
+            .expect("fixture should deserialize as a Serenity interaction");
+    let command = interaction
+        .into_command()
+        .expect("fixture should contain a command interaction");
+
+    let routed_command = BotCommand::from_name(&command.data.name);
+    assert_eq!(routed_command, Some(BotCommand::Anime));
+
+    let server = MockServer::start_async().await;
+    let defer = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(
+                    "/api/v10/interactions/200000000000000001/\
+                     synthetic-anime-token/callback",
+                )
+                .json_body(json!({
+                    "type": 5,
+                    "data": { "attachments": [] }
+                }));
+            then.status(204);
+        })
+        .await;
+    let edit = server
+        .mock_async(|when, then| {
+            when.method(PATCH)
+                .path(
+                    "/api/v10/webhooks/200000000000000002/\
+                     synthetic-anime-token/messages/@original",
+                )
+                .json_body(json!({
+                    "content": "I couldn't use that search: Input must not be empty. Try an anime title or AniList ID."
+                }));
+            then.status(200).json_body(json!({}));
+        })
+        .await;
+    let http = HttpBuilder::new("synthetic-bot-token")
+        .application_id(ApplicationId::new(200000000000000002))
+        .proxy(server.base_url())
+        .ratelimiter_disabled(true)
+        .build();
+
+    let search_term = anime::command::defer_and_validate_search(&http, &command).await;
+
+    assert_eq!(search_term, None);
+    defer.assert_async().await;
+    edit.assert_async().await;
 }

--- a/tests/fixtures/interactions/anime-invalid.json
+++ b/tests/fixtures/interactions/anime-invalid.json
@@ -1,0 +1,44 @@
+{
+  "id": "200000000000000001",
+  "application_id": "200000000000000002",
+  "type": 2,
+  "data": {
+    "id": "200000000000000003",
+    "name": "anime",
+    "type": 1,
+    "options": [
+      {
+        "name": "search",
+        "type": 3,
+        "value": "   "
+      }
+    ]
+  },
+  "channel_id": "200000000000000004",
+  "user": {
+    "id": "200000000000000005",
+    "username": "fixture-user",
+    "global_name": "Fixture User",
+    "avatar": null,
+    "banner": null,
+    "accent_color": null,
+    "locale": null,
+    "verified": null,
+    "email": null,
+    "public_flags": 0,
+    "member": null,
+    "primary_guild": null,
+    "avatar_decoration_data": null,
+    "collectibles": null
+  },
+  "token": "synthetic-anime-token",
+  "version": 1,
+  "app_permissions": "2147483647",
+  "locale": "en-US",
+  "entitlements": [],
+  "authorizing_integration_owners": {
+    "1": "200000000000000005"
+  },
+  "context": 1,
+  "attachment_size_limit": 10485760
+}

--- a/tests/fixtures/interactions/ping.json
+++ b/tests/fixtures/interactions/ping.json
@@ -1,0 +1,37 @@
+{
+  "id": "100000000000000001",
+  "application_id": "100000000000000002",
+  "type": 2,
+  "data": {
+    "id": "100000000000000003",
+    "name": "ping",
+    "type": 1
+  },
+  "channel_id": "100000000000000004",
+  "user": {
+    "id": "100000000000000005",
+    "username": "fixture-user",
+    "global_name": "Fixture User",
+    "avatar": null,
+    "banner": null,
+    "accent_color": null,
+    "locale": null,
+    "verified": null,
+    "email": null,
+    "public_flags": 0,
+    "member": null,
+    "primary_guild": null,
+    "avatar_decoration_data": null,
+    "collectibles": null
+  },
+  "token": "synthetic-interaction-token",
+  "version": 1,
+  "app_permissions": "2147483647",
+  "locale": "en-US",
+  "entitlements": [],
+  "authorizing_integration_owners": {
+    "1": "100000000000000005"
+  },
+  "context": 1,
+  "attachment_size_limit": 10485760
+}


### PR DESCRIPTION
## Summary

Add deterministic Discord protocol/plumbing integration tests that deserialize synthetic Serenity interactions, route commands through the bot's command catalog, and assert real Serenity HTTP requests against a local mock server.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [x] Chore

## Changes
- dbc40c640f1d293993410155e58d0a2dda3ba348: centralize slash command registration and dispatch in one tested catalog
- 84f0ab40dd4d42e3898ea8e04673ebd827e9c64f: cover `/ping` routing and immediate Discord interaction callback serialization
- 583d2459fa6f199406e3b490dac158d22091bc5b: cover `/anime` deferred acknowledgement and validation response editing
- 695f40d3ad9e3da4b262c0bf8f3c5979020dc492: document automated plumbing tests and the dedicated-guild live smoke procedure
- e3371b787d7ee14df418149c2b5e71f28441113c: bump the release version to 3.10.13 and update the lockfile
- 6c80dc43a74592fac927ef29724047e13cc1b96a: update contributor and reviewer guidance for the shared command catalog

### Notes

The automated suite requires no Discord token or upstream service credentials. Fully automated live slash-command invocation is intentionally excluded because Discord provides no supported user command-invocation API and user-account automation is prohibited.

## Validation
- [x] `cargo test --all-features` (234 unit tests and 2 Discord plumbing tests passed; 5 doctests ignored)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [ ] Manual dedicated Discord test-guild smoke checklist (requires test credentials and human invocation)

## References

- [Serenity unit testing guidance](https://github.com/serenity-rs/serenity/issues/1895)

---

This PR description was written by GPT-5.3 Codex.